### PR TITLE
fix(sdk): enable thinking mode on the llama.cpp VLM path

### DIFF
--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -154,10 +154,7 @@ int32_t LlamaVlm::apply_chat_template(
         tmpl_inputs.tools = common_chat_tools_parse_oaicompat(nlohmann::ordered_json::parse(std::string(input->tools)));
     }
 
-    if (input->enable_thinking) {
-        GENIEX_LOG_WARN("thinking mode not supported for llama.cpp VLM; ignoring enable_thinking=true");
-    }
-    tmpl_inputs.enable_thinking = false;
+    tmpl_inputs.enable_thinking = input->enable_thinking;
     GENIEX_LOG_DEBUG("applying chat template with add_generation_prompt=true, use_jinja={}", tmpl_inputs.use_jinja);
 
     // Apply chat template
@@ -399,7 +396,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             break;
         }
 
-        int n = llama_token_to_piece(vocab, token, token_buffer, sizeof(token_buffer) - 1, 0, false);
+        int n = llama_token_to_piece(vocab, token, token_buffer, sizeof(token_buffer) - 1, 0, true);
         if (n < 0) n = 0;
         token_buffer[n] = '\0';
 


### PR DESCRIPTION
## Summary

`geniex infer <gemma-4 gguf> --think` produced no thinking (`<think>`) content, even though the model supports reasoning and llama-cli renders it with the same GGUF.

Gemma-4 ships an mmproj file, so it loads as a **VLM** and runs through `sdk/plugins/llama_cpp/src/vlm.cpp` — not `llm.cpp`. That path suppressed thinking in two spots:

- `LlamaVlm::apply_chat_template` hardcoded `enable_thinking = false` (and logged a "not supported" warning), so the chat template never emitted the `<|think|>` system-turn token that primes Gemma-4 to reason.
- `LlamaVlm::generate` called `llama_token_to_piece(..., /*special=*/false)`, so the model's `<|channel>` / `<channel|>` reasoning delimiters rendered as empty strings and the CLI's `<think>` FSM never fired.

This PR passes `enable_thinking` through on the VLM path and renders special tokens during generation (matching llama.cpp's own `mtmd-cli`, which renders special tokens by default).

## Test plan

- [x] `geniex infer google/gemma-4-E2B-it-qat-q4_0-gguf --think` renders a `<think>…</think>` block
- [x] `--think=false` suppresses thinking (direct answer)
- [x] Qwen3 LLM path with `--think` still renders `<think>`
