### PR TITLE
fix(cli/server): address UX gaps from issue #1295

### DIFF
--- a/cli/cmd/geniex/BUILD.bazel
+++ b/cli/cmd/geniex/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
 go_cgo_test(
     name = "geniex_test",
     srcs = [
+        "infer_test.go",
         "model_test.go",
         "update_test.go",
     ],

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -237,6 +237,23 @@ func loadStopSequences() ([]string, error) {
 	return stopSequences, nil
 }
 
+// modelLoadedLine formats a one-line summary of what the inference session
+// actually got, printed after the model is loaded when --verbose is set. It's
+// a pure helper so tests can pin the output without touching the SDK.
+func modelLoadedLine(runtimeID, deviceID string, ngl, nctx int32) string {
+	parts := []string{
+		fmt.Sprintf("backend=%s", runtimeID),
+		fmt.Sprintf("device=%s", deviceID),
+	}
+	if runtimeID == geniex_sdk.RuntimeLlamaCpp {
+		parts = append(parts,
+			fmt.Sprintf("ngl=%d", ngl),
+			fmt.Sprintf("nctx=%d", nctx),
+		)
+	}
+	return "Model loaded: " + strings.Join(parts, " ")
+}
+
 // resolveModelParams resolves --compute / --ngl / --nctx into the
 // (device_id, ngl, nctx) triple the SDK expects. --ngl (-1 = all) and
 // --nctx are llama_cpp-only; qairt rejects any non-zero value, so both
@@ -332,6 +349,10 @@ func inferLLM(ctx context.Context, paths *geniex_sdk.ModelPaths) error {
 		return err
 	}
 	defer p.Destroy()
+
+	if verbose {
+		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, deviceID, nglResolved, nctxResolved)))
+	}
 
 	var history []geniex_sdk.LlmChatMessage
 	if systemPrompt != "" {
@@ -488,6 +509,10 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 		return err
 	}
 	defer p.Destroy()
+
+	if verbose {
+		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, deviceID, nglResolved, nctxResolved)))
+	}
 
 	caps, _ := p.Capabilities()
 	slog.Debug("VLM capabilities", "vision", caps.SupportsVision, "audio", caps.SupportsAudio)

--- a/cli/cmd/geniex/infer_test.go
+++ b/cli/cmd/geniex/infer_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"testing"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+func TestModelLoadedLine(t *testing.T) {
+	tests := []struct {
+		name              string
+		runtimeID, device string
+		ngl, nctx         int32
+		want              string
+	}{
+		{
+			name:      "llama_cpp shows ngl/nctx",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, device: "HTP0", ngl: 32, nctx: 4096,
+			want: "Model loaded: backend=llama_cpp device=HTP0 ngl=32 nctx=4096",
+		},
+		{
+			name:      "llama_cpp with ngl=-1 (all layers) still prints",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, device: "CPU", ngl: -1, nctx: 2048,
+			want: "Model loaded: backend=llama_cpp device=CPU ngl=-1 nctx=2048",
+		},
+		{
+			name:      "qairt hides ngl/nctx (not applicable)",
+			runtimeID: geniex_sdk.RuntimeQairt, device: "HTP0", ngl: 0, nctx: 0,
+			want: "Model loaded: backend=qairt device=HTP0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := modelLoadedLine(tt.runtimeID, tt.device, tt.ngl, tt.nctx)
+			if got != tt.want {
+				t.Errorf("modelLoadedLine\n got: %q\nwant: %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -204,6 +205,8 @@ func list() *cobra.Command {
 		case "csv":
 			return printListCSV(models)
 		}
+		fmt.Println(render.GetTheme().Info.Sprintf("Models cached in %s", modelsRootDir()))
+		fmt.Println()
 		printListTable(models, verbose)
 		return nil
 	}
@@ -474,7 +477,39 @@ func pullModel(ctx context.Context, name string, quant string) error {
 	}
 
 	fmt.Println(render.GetTheme().Success.Sprint("✔  Download success"))
+
+	key := name
+	if quant != "" {
+		key = name + ":" + quant
+	}
+	var location string
+	if paths, err := geniex_sdk.ModelGetPaths(key); err == nil && paths.ModelPath != "" {
+		location = filepath.Dir(paths.ModelPath)
+	}
+	var sizeBytes int64
+	if models, err := geniex_sdk.ModelListDetailed(); err == nil {
+		for _, m := range models {
+			if m.Name == name {
+				sizeBytes = m.TotalSize
+				break
+			}
+		}
+	}
+	if sizeBytes > 0 {
+		fmt.Println(render.GetTheme().Info.Sprintf("   Size:      %s", humanize.IBytes(uint64(sizeBytes))))
+	}
+	if location != "" {
+		fmt.Println(render.GetTheme().Info.Sprintf("   Location:  %s", location))
+	}
+	if quant != "" {
+		fmt.Println(render.GetTheme().Info.Sprintf("   Precision: %s", quant))
+	}
 	return nil
+}
+
+// modelsRootDir returns the directory that holds all cached models.
+func modelsRootDir() string {
+	return filepath.Join(store.Get().DataPath(), "models")
 }
 
 // choosePrecision picks a precision from the remote candidates: the only one

--- a/cli/server/BUILD.bazel
+++ b/cli/server/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
 
 go_cgo_test(
     name = "server_test",
-    srcs = ["package_test.go"],
+    srcs = [
+        "server_test.go",
+    ],
     embed = [":server"],
 )

--- a/cli/server/package_test.go
+++ b/cli/server/package_test.go
@@ -1,8 +1,0 @@
-// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-// SPDX-License-Identifier: BSD-3-Clause
-
-package server
-
-import "testing"
-
-func TestPackageBuilds(t *testing.T) {}

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -5,7 +5,9 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -13,6 +15,30 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/render"
 	"github.com/qualcomm/GenieX/cli/server/service"
 )
+
+// hostBindingHint returns a one-line hint suggesting how to expose the server
+// on the LAN when the host binds to a loopback address. Returns "" for
+// non-loopback binds (0.0.0.0, [::], an explicit LAN IP, etc.) so the caller
+// prints nothing when the hint would be noise. Malformed hosts are treated as
+// non-loopback — better silent than misleading.
+func hostBindingHint(host string) string {
+	h, port, err := net.SplitHostPort(host)
+	if err != nil {
+		return ""
+	}
+	if !isLoopback(h) {
+		return ""
+	}
+	return fmt.Sprintf("Bound to loopback only. To expose on your network, restart with --host 0.0.0.0:%s", port)
+}
+
+func isLoopback(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
 
 // @Title		GenieX Server
 // @Version	0.0.0
@@ -48,9 +74,15 @@ func Serve() {
 
 		fmt.Println(render.GetTheme().Info.Sprintf("HTTPS enabled: cert=%s key=%s", certFile, keyFile))
 		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on https://%s/", cfg.Host))
+		if hint := hostBindingHint(cfg.Host); hint != "" {
+			fmt.Println(render.GetTheme().Info.Sprint(hint))
+		}
 		err = engine.RunTLS(cfg.Host, certFile, keyFile)
 	} else {
 		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on http://%s/", cfg.Host))
+		if hint := hostBindingHint(cfg.Host); hint != "" {
+			fmt.Println(render.GetTheme().Info.Sprint(hint))
+		}
 		err = engine.Run(cfg.Host)
 	}
 

--- a/cli/server/server_test.go
+++ b/cli/server/server_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHostBindingHint(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantHint bool
+		wantPort string // if wantHint, the port that should appear in the message
+	}{
+		{"ipv4 loopback", "127.0.0.1:18181", true, "18181"},
+		{"ipv4 loopback other subnet", "127.0.1.5:8080", true, "8080"},
+		{"localhost", "localhost:18181", true, "18181"},
+		{"localhost uppercase", "LOCALHOST:18181", true, "18181"},
+		{"ipv6 loopback", "[::1]:18181", true, "18181"},
+		{"any ipv4", "0.0.0.0:18181", false, ""},
+		{"any ipv6", "[::]:18181", false, ""},
+		{"lan ipv4", "192.168.1.10:18181", false, ""},
+		{"malformed no port", "127.0.0.1", false, ""},
+		{"empty", "", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hostBindingHint(tt.host)
+			if tt.wantHint && got == "" {
+				t.Errorf("hostBindingHint(%q) = %q, want non-empty hint", tt.host, got)
+			}
+			if !tt.wantHint && got != "" {
+				t.Errorf("hostBindingHint(%q) = %q, want empty", tt.host, got)
+			}
+			if tt.wantHint && !strings.Contains(got, "--host 0.0.0.0:"+tt.wantPort) {
+				t.Errorf("hostBindingHint(%q) = %q, want it to suggest --host 0.0.0.0:%s", tt.host, got, tt.wantPort)
+			}
+		})
+	}
+}

--- a/cli/server/service/BUILD.bazel
+++ b/cli/server/service/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//bindings/go:geniex_sdk_go",
         "//cli/internal/config",
+        "//cli/internal/render",
         "//cli/internal/types",
     ],
 )

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"reflect"
@@ -13,8 +14,44 @@ import (
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/config"
+	"github.com/qualcomm/GenieX/cli/internal/render"
 	"github.com/qualcomm/GenieX/cli/internal/types"
 )
+
+var (
+	computeWarningMu   sync.Mutex
+	computeWarningSink io.Writer = os.Stdout
+	computeWarned      = map[string]struct{}{}
+)
+
+func SetComputeWarningSinkForTest(w io.Writer) func() {
+	computeWarningMu.Lock()
+	prevSink := computeWarningSink
+	computeWarningSink = w
+	prevWarned := computeWarned
+	computeWarned = map[string]struct{}{}
+	computeWarningMu.Unlock()
+
+	return func() {
+		computeWarningMu.Lock()
+		computeWarningSink = prevSink
+		computeWarned = prevWarned
+		computeWarningMu.Unlock()
+	}
+}
+
+func emitComputeCoercionWarning(runtimeID, requestedCompute, warning string) {
+	key := runtimeID + "\x00" + requestedCompute
+	computeWarningMu.Lock()
+	if _, seen := computeWarned[key]; seen {
+		computeWarningMu.Unlock()
+		return
+	}
+	computeWarned[key] = struct{}{}
+	sink := computeWarningSink
+	computeWarningMu.Unlock()
+	fmt.Fprintln(sink, render.GetTheme().Warning.Sprintf("Warning: %s", warning))
+}
 
 // ResolveModelParam turns the (nctx, ngl, compute) knobs into the ModelParam
 // the keep-alive cache keys on. The caller passes already-resolved values (the
@@ -79,6 +116,7 @@ func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCo
 	}
 	if resolved.Warning != "" {
 		slog.Warn("compute unit coerced", "warning", resolved.Warning)
+		emitComputeCoercionWarning(runtimeID, reqCompute, resolved.Warning)
 	}
 
 	mp := types.ModelParam{

--- a/cli/server/service/keepalive_test.go
+++ b/cli/server/service/keepalive_test.go
@@ -4,6 +4,8 @@
 package service
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
@@ -68,5 +70,55 @@ func TestResolveModelParam_NonLlamaCppZeroesNCtx(t *testing.T) {
 	}
 	if got.NGpuLayers != 0 {
 		t.Errorf("NGpuLayers = %d, want 0 (SDK zeroes ngl for qairt)", got.NGpuLayers)
+	}
+}
+
+// TestResolveModelParam_QairtGpuEmitsCoercionWarning verifies that when the
+// qairt plugin coerces a non-NPU compute unit to NPU, the SDK warning is
+// printed to the configured sink so serve users can see the redirection.
+func TestResolveModelParam_QairtGpuEmitsCoercionWarning(t *testing.T) {
+	var buf bytes.Buffer
+	restore := SetComputeWarningSinkForTest(&buf)
+	defer restore()
+
+	if _, err := ResolveModelParam(geniex_sdk.RuntimeQairt, "some-model", 0, 0, "gpu", SpecParam{}); err != nil {
+		t.Fatalf("ResolveModelParam: %v", err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "qairt plugin only supports NPU") {
+		t.Errorf("sink missing coercion warning; got %q", got)
+	}
+}
+
+// TestResolveModelParam_QairtWarningDedupPerRuntimeCompute verifies that repeat
+// requests with the same (runtime, compute) print the warning only once so
+// long-running serve processes are not spammed.
+func TestResolveModelParam_QairtWarningDedupPerRuntimeCompute(t *testing.T) {
+	var buf bytes.Buffer
+	restore := SetComputeWarningSinkForTest(&buf)
+	defer restore()
+
+	for i := 0; i < 3; i++ {
+		if _, err := ResolveModelParam(geniex_sdk.RuntimeQairt, "some-model", 0, 0, "gpu", SpecParam{}); err != nil {
+			t.Fatalf("ResolveModelParam[%d]: %v", i, err)
+		}
+	}
+	if n := strings.Count(buf.String(), "qairt plugin only supports NPU"); n != 1 {
+		t.Errorf("warning printed %d times, want 1 (dedup); output=%q", n, buf.String())
+	}
+}
+
+// TestResolveModelParam_LlamaCppNoCoercionWarning verifies llama_cpp with a
+// resolvable compute unit does not print a coercion warning.
+func TestResolveModelParam_LlamaCppNoCoercionWarning(t *testing.T) {
+	var buf bytes.Buffer
+	restore := SetComputeWarningSinkForTest(&buf)
+	defer restore()
+
+	if _, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 2048, 10, "cpu", SpecParam{}); err != nil {
+		t.Fatalf("ResolveModelParam: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on non-coerced path; got %q", buf.String())
 	}
 }


### PR DESCRIPTION
## Pull Request

**Description**

Addresses the four UX items from the customer feedback report in #1295 that we control at the CLI/server layer. All four are output-side changes; no SDK changes.

- **Issue 3** — `serve` now prints the SDK's qairt compute-coercion warning to stdout (colored), deduped per `(runtime, compute)` so a long-running server prints each mis-config once. The `slog.Warn` path is preserved for structured logs.
- **Issue 4** — `infer --verbose` prints a one-line summary of the resolved backend / device after model load (`ngl`/`nctx` shown for llama_cpp, hidden for qairt).
- **Issue 5** — `serve` adds a hint line when bound to loopback (127.0.0.0/8, `localhost`, `::1`), pointing users at `--host 0.0.0.0:<port>` to expose the server on the LAN. Non-loopback binds print nothing extra.
- **Issue 10** — `list --format=table` shows the models cache root as a header; `pull` success prints size / on-disk location / precision. `--format json|csv` are unchanged.

Items 1/2/7 are unfixable (upstream Adreno / hardware limits); item 6 is SDK-side (Rust detect) and out of scope for this PR; item 8 is a design question; item 9 is already fixed on main.

**Related Issue**

Refs qualcomm/GenieX#1295 (items 3, 4, 5, 10).

**Type of Change**

- Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

**Additional Context**

All four fixes were verified manually on Windows ARM64 (Snapdragon X Elite):

- Issue 3: qairt+gpu request emitted the yellow warning line once; a second identical request did not re-print (dedup ok).
- Issue 4: `--verbose` printed `Model loaded: backend=qairt device=NPU`; running without `--verbose` printed nothing extra.
- Issue 5: default bind printed the hint; `--host 0.0.0.0:18181` printed no hint; `[::1]:18181` printed the hint.
- Issue 10: `list` showed `Models cached in <path>` header for `table`, no header for `json` / `csv`; `pull` success showed size/location/precision.

Unit tests: 20 new cases across `keepalive_test.go`, `server_test.go`, `infer_test.go`, `model_test.go`; all pass locally.