### PR TITLE
feat(cli): add geniex eval - compare models on eval packs

### DIFF
--- a/cli/cmd/geniex/BUILD.bazel
+++ b/cli/cmd/geniex/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "geniex_lib",
     srcs = [
         "config.go",
+        "eval.go",
         "help.go",
         "infer.go",
         "main.go",
@@ -21,6 +22,7 @@ go_library(
         "//cli/cmd/geniex/common",
         "//cli/internal/config",
         "//cli/internal/downloader",
+        "//cli/internal/eval",
         "//cli/internal/record",
         "//cli/internal/render",
         "//cli/internal/store",

--- a/cli/cmd/geniex/eval.go
+++ b/cli/cmd/geniex/eval.go
@@ -1,0 +1,173 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/cmd/geniex/common"
+	"github.com/qualcomm/GenieX/cli/internal/eval"
+	"github.com/qualcomm/GenieX/cli/internal/render"
+)
+
+var (
+	evalPackRef   string
+	evalJSONOut   string
+	evalCompute   string
+	evalNgl       int32
+	evalNctx      int32
+	evalMaxTokens int32
+)
+
+func evalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		GroupID: "inference",
+		Use:     "eval <model-name>[:<precision>] [<model-name>...]",
+		Short:   "Evaluate and compare models on an eval pack",
+		Long: "Run one or more models over an eval pack and compare their accuracy.\n" +
+			"--eval selects a built-in pack (" + strings.Join(eval.BuiltinNames(), ", ") + ") or a custom pack from a JSON file.\n" +
+			"Runs are greedy (top-k 1, fixed seed) with thinking disabled, so results are repeatable.",
+	}
+	cmd.Args = cobra.MinimumNArgs(1)
+
+	cmd.Flags().SortFlags = false
+	cmd.Flags().StringVarP(&evalPackRef, "eval", "e", "basic", "built-in eval pack name or path to a custom pack (.json)")
+	cmd.Flags().StringVarP(&evalJSONOut, "json", "j", "", "also write full per-task results to this JSON file")
+	cmd.Flags().StringVarP(&evalCompute, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: npu)")
+	cmd.Flags().Int32VarP(&evalNgl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
+	cmd.Flags().Int32VarP(&evalNctx, "nctx", "", 4096, "context window size (llama_cpp only)")
+	cmd.Flags().Int32VarP(&evalMaxTokens, "max-tokens", "", 256, "max tokens generated per task")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		pack, err := eval.Resolve(evalPackRef)
+		if err != nil {
+			return err
+		}
+
+		if err := common.InitSDK(); err != nil {
+			return err
+		}
+		defer geniex_sdk.DeInit()
+
+		var reports []*eval.ModelReport
+		for _, arg := range args {
+			report, err := evalOneModel(cmd, arg, pack)
+			if err != nil {
+				return err
+			}
+			reports = append(reports, report)
+		}
+
+		fmt.Println()
+		fmt.Print(eval.RenderTable(pack, reports))
+		if evalJSONOut != "" {
+			if err := eval.WriteJSON(evalJSONOut, pack, reports); err != nil {
+				return fmt.Errorf("write %s: %w", evalJSONOut, err)
+			}
+			fmt.Println(render.GetTheme().Info.Sprintf("\nFull results written to %s", evalJSONOut))
+		}
+		return nil
+	}
+	return cmd
+}
+
+func evalOneModel(cmd *cobra.Command, arg string, pack *eval.Pack) (*eval.ModelReport, error) {
+	name, precision := geniex_sdk.SplitNamePrecision(arg)
+	paths, err := ensureModelAvailable(cmd.Context(), name, precision)
+	if err != nil {
+		return nil, err
+	}
+	if paths.ModelType != geniex_sdk.ModelTypeLLM {
+		return nil, fmt.Errorf("model %s is a %s; eval currently supports LLM models only", name, paths.ModelType)
+	}
+
+	resolved, err := geniex_sdk.ResolveDevice(geniex_sdk.ResolveDeviceInput{
+		RuntimeID:   paths.RuntimeID,
+		ModelName:   paths.ModelName,
+		ComputeUnit: evalCompute,
+		NglDefault:  evalNgl,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resolved.Warning != "" {
+		fmt.Println(render.GetTheme().Warning.Sprintf("Warning: %s", resolved.Warning))
+	}
+	nctx := evalNctx
+	if paths.RuntimeID != geniex_sdk.RuntimeLlamaCpp {
+		nctx = 0
+	}
+
+	spin := render.NewSpinner(fmt.Sprintf("loading %s...", name))
+	spin.Start()
+	p, err := geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
+		ModelPath: paths.ModelPath,
+		RuntimeID: paths.RuntimeID,
+		DeviceID:  resolved.DeviceID,
+		Config: geniex_sdk.ModelConfig{
+			NCtx:       nctx,
+			NGpuLayers: resolved.Ngl,
+		},
+	})
+	spin.Stop()
+	if err != nil {
+		return nil, fmt.Errorf("load model %s: %w", name, err)
+	}
+	defer p.Destroy()
+
+	// Greedy decoding with a fixed seed keeps runs repeatable.
+	sampler := &geniex_sdk.SamplerConfig{TopK: 1, Seed: 42}
+
+	theme := render.GetTheme()
+	fmt.Println(theme.Info.Sprintf("Evaluating %s on %s (%d tasks)", name, pack.Name, len(pack.Tasks)))
+
+	report := &eval.ModelReport{Model: name}
+	for i, task := range pack.Tasks {
+		result := eval.Result{TaskID: task.ID, Category: task.Category}
+
+		// Fresh context per task so tasks cannot leak into each other.
+		if err := p.Reset(); err != nil {
+			return nil, fmt.Errorf("reset before task %s: %w", task.ID, err)
+		}
+
+		tmpl, err := p.ApplyChatTemplate(geniex_sdk.LlmApplyChatTemplateInput{
+			Messages: []geniex_sdk.LlmChatMessage{
+				{Role: geniex_sdk.LlmRoleUser, Content: eval.RenderPrompt(task)},
+			},
+			EnableThink:         false,
+			AddGenerationPrompt: true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("apply chat template for task %s: %w", task.ID, err)
+		}
+
+		res, err := p.Generate(geniex_sdk.LlmGenerateInput{
+			PromptUTF8: tmpl.FormattedText,
+			Config: &geniex_sdk.GenerationConfig{
+				MaxTokens:     evalMaxTokens,
+				SamplerConfig: sampler,
+			},
+		})
+		if err != nil {
+			result.Error = err.Error()
+		} else {
+			result.Output = res.FullText
+			result.Correct = eval.Score(task, res.FullText)
+			report.DecodeTokens += res.ProfileData.GeneratedTokens
+			report.DecodeTimeUs += res.ProfileData.DecodeTime
+		}
+		report.Results = append(report.Results, result)
+
+		mark := theme.Error.Sprint("✗")
+		if result.Correct {
+			mark = theme.Success.Sprint("✓")
+		}
+		fmt.Printf("  [%d/%d] %s %s\n", i+1, len(pack.Tasks), mark, task.ID)
+	}
+	return report, nil
+}

--- a/cli/cmd/geniex/eval.go
+++ b/cli/cmd/geniex/eval.go
@@ -1,0 +1,174 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/cmd/geniex/common"
+	"github.com/qualcomm/GenieX/cli/internal/eval"
+	"github.com/qualcomm/GenieX/cli/internal/render"
+)
+
+var (
+	evalPackRef   string
+	evalJSONOut   string
+	evalCompute   string
+	evalNgl       int32
+	evalNctx      int32
+	evalMaxTokens int32
+)
+
+func evalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		GroupID: "inference",
+		Use:     "eval <model-name>[:<precision>] [<model-name>...]",
+		Short:   "Evaluate and compare models on an eval pack",
+		Long: "Run one or more models over an eval pack and compare their accuracy.\n" +
+			"--eval selects a built-in pack (" + strings.Join(eval.BuiltinNames(), ", ") + ") or a custom pack from a JSON file.\n" +
+			"Runs are greedy (top-k 1, fixed seed) with thinking disabled, so results are repeatable.",
+	}
+	cmd.Args = cobra.MinimumNArgs(1)
+
+	cmd.Flags().SortFlags = false
+	cmd.Flags().StringVarP(&evalPackRef, "eval", "e", "basic", "built-in eval pack name or path to a custom pack (.json)")
+	cmd.Flags().StringVarP(&evalJSONOut, "json", "j", "", "also write full per-task results to this JSON file")
+	cmd.Flags().StringVarP(&evalCompute, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: npu)")
+	cmd.Flags().Int32VarP(&evalNgl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
+	cmd.Flags().Int32VarP(&evalNctx, "nctx", "", 4096, "context window size (llama_cpp only)")
+	cmd.Flags().Int32VarP(&evalMaxTokens, "max-tokens", "", 256, "max tokens generated per task")
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		pack, err := eval.Resolve(evalPackRef)
+		if err != nil {
+			return err
+		}
+
+		if err := common.InitSDK(); err != nil {
+			return err
+		}
+		defer geniex_sdk.DeInit()
+
+		var reports []*eval.ModelReport
+		for _, arg := range args {
+			report, err := evalOneModel(cmd, arg, pack)
+			if err != nil {
+				return err
+			}
+			reports = append(reports, report)
+		}
+
+		fmt.Println()
+		fmt.Print(eval.RenderTable(pack, reports))
+		if evalJSONOut != "" {
+			if err := eval.WriteJSON(evalJSONOut, pack, reports); err != nil {
+				return fmt.Errorf("write %s: %w", evalJSONOut, err)
+			}
+			fmt.Println(render.GetTheme().Info.Sprintf("\nFull results written to %s", evalJSONOut))
+		}
+		return nil
+	}
+	return cmd
+}
+
+func evalOneModel(cmd *cobra.Command, arg string, pack *eval.Pack) (*eval.ModelReport, error) {
+	name, precision := geniex_sdk.SplitNamePrecision(arg)
+	paths, err := ensureModelAvailable(cmd.Context(), name, precision)
+	if err != nil {
+		return nil, err
+	}
+	if paths.ModelType != geniex_sdk.ModelTypeLLM {
+		return nil, fmt.Errorf("model %s is a %s; eval currently supports LLM models only", name, paths.ModelType)
+	}
+
+	resolved, err := geniex_sdk.ResolveDevice(geniex_sdk.ResolveDeviceInput{
+		RuntimeID:   paths.RuntimeID,
+		ModelName:   paths.ModelName,
+		ComputeUnit: evalCompute,
+		NglDefault:  evalNgl,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resolved.Warning != "" {
+		fmt.Println(render.GetTheme().Warning.Sprintf("Warning: %s", resolved.Warning))
+	}
+	nctx := evalNctx
+	if paths.RuntimeID != geniex_sdk.RuntimeLlamaCpp {
+		nctx = 0
+	}
+
+	spin := render.NewSpinner(fmt.Sprintf("loading %s...", name))
+	spin.Start()
+	p, err := geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
+		ModelName: paths.ModelName,
+		ModelPath: paths.ModelPath,
+		RuntimeID: paths.RuntimeID,
+		DeviceID:  resolved.DeviceID,
+		Config: geniex_sdk.ModelConfig{
+			NCtx:       nctx,
+			NGpuLayers: resolved.Ngl,
+		},
+	})
+	spin.Stop()
+	if err != nil {
+		return nil, fmt.Errorf("load model %s: %w", name, err)
+	}
+	defer p.Destroy()
+
+	// Greedy decoding with a fixed seed keeps runs repeatable.
+	sampler := &geniex_sdk.SamplerConfig{TopK: 1, Seed: 42}
+
+	theme := render.GetTheme()
+	fmt.Println(theme.Info.Sprintf("Evaluating %s on %s (%d tasks)", name, pack.Name, len(pack.Tasks)))
+
+	report := &eval.ModelReport{Model: name}
+	for i, task := range pack.Tasks {
+		result := eval.Result{TaskID: task.ID, Category: task.Category}
+
+		// Fresh context per task so tasks cannot leak into each other.
+		if err := p.Reset(); err != nil {
+			return nil, fmt.Errorf("reset before task %s: %w", task.ID, err)
+		}
+
+		tmpl, err := p.ApplyChatTemplate(geniex_sdk.LlmApplyChatTemplateInput{
+			Messages: []geniex_sdk.LlmChatMessage{
+				{Role: geniex_sdk.LlmRoleUser, Content: eval.RenderPrompt(task)},
+			},
+			EnableThink:         false,
+			AddGenerationPrompt: true,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("apply chat template for task %s: %w", task.ID, err)
+		}
+
+		res, err := p.Generate(geniex_sdk.LlmGenerateInput{
+			PromptUTF8: tmpl.FormattedText,
+			Config: &geniex_sdk.GenerationConfig{
+				MaxTokens:     evalMaxTokens,
+				SamplerConfig: sampler,
+			},
+		})
+		if err != nil {
+			result.Error = err.Error()
+		} else {
+			result.Output = res.FullText
+			result.Correct = eval.Score(task, res.FullText)
+			report.DecodeTokens += res.ProfileData.GeneratedTokens
+			report.DecodeTimeUs += res.ProfileData.DecodeTime
+		}
+		report.Results = append(report.Results, result)
+
+		mark := theme.Error.Sprint("✗")
+		if result.Correct {
+			mark = theme.Success.Sprint("✓")
+		}
+		fmt.Printf("  [%d/%d] %s %s\n", i+1, len(pack.Tasks), mark, task.ID)
+	}
+	return report, nil
+}

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -117,7 +117,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(
 		pull(), remove(), clean(), list(),
 		modelCmd(),
-		infer(),
+		infer(), evalCmd(),
 		serve(), run(),
 		configCmd(),
 		version(), update(),

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -98,7 +98,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.AddCommand(
 		pull(), remove(), clean(), list(),
 		modelCmd(),
-		infer(),
+		infer(), evalCmd(),
 		serve(), run(),
 		configCmd(),
 		version(), update(),

--- a/cli/internal/eval/BUILD.bazel
+++ b/cli/internal/eval/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "eval",
+    srcs = [
+        "pack.go",
+        "report.go",
+        "score.go",
+    ],
+    embedsrcs = ["packs/basic.json"],
+    importpath = "github.com/qualcomm/GenieX/cli/internal/eval",
+    visibility = ["//cli:__subpackages__"],
+)
+
+go_test(
+    name = "eval_test",
+    srcs = ["eval_test.go"],
+    embed = [":eval"],
+)

--- a/cli/internal/eval/eval_test.go
+++ b/cli/internal/eval/eval_test.go
@@ -1,0 +1,178 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package eval
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePack(t *testing.T) {
+	pack, err := parsePack([]byte(`{
+		"name": "p",
+		"tasks": [
+			{"type": "multiple_choice", "prompt": "q?", "choices": ["x", "y"], "answer": "b"},
+			{"id": "t2", "type": "exact_match", "prompt": "q2?", "expected": "yes"},
+			{"id": "t3", "type": "contains", "prompt": "q3?", "expected": "part"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("parsePack: %v", err)
+	}
+	if pack.Tasks[0].ID != "task-1" {
+		t.Errorf("auto id = %q, want task-1", pack.Tasks[0].ID)
+	}
+	if pack.Tasks[0].Answer != "B" {
+		t.Errorf("answer not upcased: %q", pack.Tasks[0].Answer)
+	}
+
+	bad := map[string]string{
+		"not json":         `{`,
+		"no name":          `{"tasks": [{"type": "contains", "prompt": "p", "expected": "e"}]}`,
+		"no tasks":         `{"name": "p", "tasks": []}`,
+		"unknown type":     `{"name": "p", "tasks": [{"type": "essay", "prompt": "p"}]}`,
+		"missing prompt":   `{"name": "p", "tasks": [{"type": "contains", "expected": "e"}]}`,
+		"missing expected": `{"name": "p", "tasks": [{"type": "exact_match", "prompt": "p"}]}`,
+		"one choice":       `{"name": "p", "tasks": [{"type": "multiple_choice", "prompt": "p", "choices": ["x"], "answer": "A"}]}`,
+		"answer range":     `{"name": "p", "tasks": [{"type": "multiple_choice", "prompt": "p", "choices": ["x", "y"], "answer": "C"}]}`,
+		"duplicate ids":    `{"name": "p", "tasks": [{"id": "t", "type": "contains", "prompt": "p", "expected": "e"}, {"id": "t", "type": "contains", "prompt": "p", "expected": "e"}]}`,
+	}
+	for name, data := range bad {
+		if _, err := parsePack([]byte(data)); err == nil {
+			t.Errorf("%s: expected error, got none", name)
+		}
+	}
+}
+
+func TestResolve(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "custom.json")
+	data := `{"name": "custom", "tasks": [{"type": "contains", "prompt": "p", "expected": "e"}]}`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pack, err := Resolve(path)
+	if err != nil || pack.Name != "custom" {
+		t.Fatalf("Resolve(file) = %v, %v", pack, err)
+	}
+	for _, name := range BuiltinNames() {
+		if _, err := Resolve(name); err != nil {
+			t.Errorf("built-in %q does not parse: %v", name, err)
+		}
+	}
+	if _, err := Resolve("no-such-pack"); err == nil || !strings.Contains(err.Error(), "basic") {
+		t.Fatalf("Resolve(unknown) should list built-ins, got: %v", err)
+	}
+}
+
+func TestRenderPrompt(t *testing.T) {
+	mc := Task{Type: TaskMultipleChoice, Prompt: "Pick one.", Choices: []string{"first", "second"}}
+	got := RenderPrompt(mc)
+	for _, want := range []string{"Pick one.", "A. first", "B. second", "only the letter"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("RenderPrompt missing %q in:\n%s", want, got)
+		}
+	}
+	plain := Task{Type: TaskExactMatch, Prompt: "Just this."}
+	if RenderPrompt(plain) != "Just this." {
+		t.Errorf("non-MC prompt should pass through, got %q", RenderPrompt(plain))
+	}
+}
+
+func TestScore(t *testing.T) {
+	mc := Task{Type: TaskMultipleChoice, Prompt: "q", Choices: []string{"alpha", "beta", "gamma", "delta"}, Answer: "B"}
+	correct := []string{
+		"B", "b", "(B)", "B.", "**B**", "B) beta",
+		"Answer: B", "The answer is B.",
+		"<think>hmm A or B... let me think</think>B",
+		"beta", "It is beta.",
+	}
+	for _, out := range correct {
+		if !Score(mc, out) {
+			t.Errorf("Score(%q) = false, want true", out)
+		}
+	}
+	wrong := []string{
+		"A", "C", "alpha", "", "no idea", "E",
+		"The answer is a fruit.", // article "a" is not choice A
+		"alpha or beta",          // ambiguous
+		"<think>the answer is B", // unterminated think block
+	}
+	for _, out := range wrong {
+		if Score(mc, out) {
+			t.Errorf("Score(%q) = true, want false", out)
+		}
+	}
+
+	exact := Task{Type: TaskExactMatch, Prompt: "q", Expected: "Paris"}
+	for _, out := range []string{"Paris", "paris", " Paris. ", "PARIS!"} {
+		if !Score(exact, out) {
+			t.Errorf("Score(%q) = false, want true", out)
+		}
+	}
+	for _, out := range []string{"The capital is Paris", "Pariss", ""} {
+		if Score(exact, out) {
+			t.Errorf("Score(%q) = true, want false", out)
+		}
+	}
+
+	contains := Task{Type: TaskContains, Prompt: "q", Expected: "children"}
+	if !Score(contains, "The plural of child is CHILDREN.") {
+		t.Error("case-insensitive contains failed")
+	}
+	if Score(contains, "The plural is childs.") {
+		t.Error("contains matched wrong text")
+	}
+}
+
+func TestReports(t *testing.T) {
+	pack := &Pack{Name: "p", Tasks: []Task{{ID: "a"}, {ID: "b"}, {ID: "c"}, {ID: "d"}}}
+	report := &ModelReport{
+		Model: "model-x",
+		Results: []Result{
+			{TaskID: "a", Category: "math", Correct: true},
+			{TaskID: "b", Category: "math", Correct: false},
+			{TaskID: "c", Category: "lang", Correct: true},
+			{TaskID: "d", Category: "lang", Correct: true},
+		},
+		DecodeTokens: 100,
+		DecodeTimeUs: 2_000_000,
+	}
+	if report.Correct() != 3 || report.Accuracy() != 0.75 || report.TokPerSec() != 50 {
+		t.Errorf("got correct=%d accuracy=%f tok/s=%f", report.Correct(), report.Accuracy(), report.TokPerSec())
+	}
+	empty := &ModelReport{Model: "empty"}
+	if empty.Accuracy() != 0 || empty.TokPerSec() != 0 {
+		t.Error("empty report should report zeros, not NaN/Inf")
+	}
+
+	table := RenderTable(pack, []*ModelReport{report})
+	for _, want := range []string{"model-x", "75.0%", "3/4", "50.0", "MATH", "LANG", "2/2"} {
+		if !strings.Contains(table, want) {
+			t.Errorf("table missing %q:\n%s", want, table)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "out.json")
+	if err := WriteJSON(path, pack, []*ModelReport{report}); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Eval      string         `json:"eval"`
+		TaskCount int            `json:"task_count"`
+		Models    []*ModelReport `json:"models"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if doc.Eval != "p" || doc.TaskCount != 4 || len(doc.Models) != 1 {
+		t.Errorf("round-trip mismatch: %+v", doc)
+	}
+}

--- a/cli/internal/eval/pack.go
+++ b/cli/internal/eval/pack.go
@@ -1,0 +1,139 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package eval implements the harness behind `geniex eval`: loading eval
+// packs, scoring model output, and rendering comparison reports.
+package eval
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	TaskMultipleChoice = "multiple_choice"
+	TaskExactMatch     = "exact_match"
+	TaskContains       = "contains"
+)
+
+type Task struct {
+	ID       string   `json:"id"`
+	Type     string   `json:"type"`
+	Category string   `json:"category,omitempty"`
+	Prompt   string   `json:"prompt"`
+	Choices  []string `json:"choices,omitempty"`  // multiple_choice
+	Answer   string   `json:"answer,omitempty"`   // multiple_choice: correct letter
+	Expected string   `json:"expected,omitempty"` // exact_match / contains
+}
+
+type Pack struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Tasks       []Task `json:"tasks"`
+}
+
+//go:embed packs/*.json
+var builtinFS embed.FS
+
+// BuiltinNames lists the packs shipped with the CLI, sorted.
+func BuiltinNames() []string {
+	entries, err := builtinFS.ReadDir("packs")
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, strings.TrimSuffix(e.Name(), ".json"))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Resolve loads a pack from `ref`: an existing file path wins, otherwise the
+// name of a built-in pack.
+func Resolve(ref string) (*Pack, error) {
+	if info, err := os.Stat(ref); err == nil && !info.IsDir() {
+		data, err := os.ReadFile(ref)
+		if err != nil {
+			return nil, fmt.Errorf("read eval pack %s: %w", ref, err)
+		}
+		pack, err := parsePack(data)
+		if err != nil {
+			return nil, fmt.Errorf("eval pack %s: %w", filepath.Base(ref), err)
+		}
+		return pack, nil
+	}
+	data, err := builtinFS.ReadFile("packs/" + ref + ".json")
+	if err != nil {
+		return nil, fmt.Errorf("no eval pack %q: not a file, and not a built-in (available: %s)",
+			ref, strings.Join(BuiltinNames(), ", "))
+	}
+	return parsePack(data)
+}
+
+func parsePack(data []byte) (*Pack, error) {
+	var pack Pack
+	if err := json.Unmarshal(data, &pack); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if pack.Name == "" {
+		return nil, fmt.Errorf("missing \"name\"")
+	}
+	if len(pack.Tasks) == 0 {
+		return nil, fmt.Errorf("no tasks")
+	}
+	seen := make(map[string]bool, len(pack.Tasks))
+	for i := range pack.Tasks {
+		t := &pack.Tasks[i]
+		if t.ID == "" {
+			t.ID = fmt.Sprintf("task-%d", i+1)
+		}
+		if seen[t.ID] {
+			return nil, fmt.Errorf("duplicate task id %q", t.ID)
+		}
+		seen[t.ID] = true
+		if t.Prompt == "" {
+			return nil, fmt.Errorf("task %q: missing \"prompt\"", t.ID)
+		}
+		switch t.Type {
+		case TaskMultipleChoice:
+			if len(t.Choices) < 2 || len(t.Choices) > 26 {
+				return nil, fmt.Errorf("task %q: multiple_choice needs 2-26 choices, got %d", t.ID, len(t.Choices))
+			}
+			letter := strings.ToUpper(strings.TrimSpace(t.Answer))
+			if len(letter) != 1 || letter[0] < 'A' || int(letter[0]-'A') >= len(t.Choices) {
+				return nil, fmt.Errorf("task %q: \"answer\" must be a letter A-%c", t.ID, 'A'+len(t.Choices)-1)
+			}
+			t.Answer = letter
+		case TaskExactMatch, TaskContains:
+			if t.Expected == "" {
+				return nil, fmt.Errorf("task %q: missing \"expected\"", t.ID)
+			}
+		default:
+			return nil, fmt.Errorf("task %q: unknown type %q (supported: %s, %s, %s)",
+				t.ID, t.Type, TaskMultipleChoice, TaskExactMatch, TaskContains)
+		}
+	}
+	return &pack, nil
+}
+
+// RenderPrompt returns the prompt sent to the model; multiple-choice tasks
+// get lettered options and an answer-format instruction.
+func RenderPrompt(t Task) string {
+	if t.Type != TaskMultipleChoice {
+		return t.Prompt
+	}
+	var b strings.Builder
+	b.WriteString(t.Prompt)
+	b.WriteString("\n")
+	for i, choice := range t.Choices {
+		fmt.Fprintf(&b, "\n%c. %s", 'A'+i, choice)
+	}
+	b.WriteString("\n\nAnswer with only the letter of the correct choice.")
+	return b.String()
+}

--- a/cli/internal/eval/packs/basic.json
+++ b/cli/internal/eval/packs/basic.json
@@ -1,0 +1,30 @@
+{
+  "name": "basic",
+  "description": "Built-in smoke eval: 24 unambiguous tasks across arithmetic, knowledge, reasoning, and language. Meant for quick cross-model comparison, not leaderboard-grade benchmarking.",
+  "tasks": [
+    { "id": "math-1", "type": "exact_match", "category": "math", "prompt": "What is 17 + 25? Answer with only the number.", "expected": "42" },
+    { "id": "math-2", "type": "exact_match", "category": "math", "prompt": "What is 12 * 12? Answer with only the number.", "expected": "144" },
+    { "id": "math-3", "type": "exact_match", "category": "math", "prompt": "What is 1000 - 249? Answer with only the number.", "expected": "751" },
+    { "id": "math-4", "type": "multiple_choice", "category": "math", "prompt": "A shirt costs $20 and is discounted by 25%. What is the sale price?", "choices": ["$5", "$12", "$15", "$18"], "answer": "C" },
+    { "id": "math-5", "type": "multiple_choice", "category": "math", "prompt": "Which number is prime?", "choices": ["21", "27", "29", "33"], "answer": "C" },
+    { "id": "math-6", "type": "exact_match", "category": "math", "prompt": "What is the remainder when 17 is divided by 5? Answer with only the number.", "expected": "2" },
+    { "id": "know-1", "type": "exact_match", "category": "knowledge", "prompt": "What is the capital city of Japan? Answer with only the city name.", "expected": "Tokyo" },
+    { "id": "know-2", "type": "multiple_choice", "category": "knowledge", "prompt": "Which planet is known as the Red Planet?", "choices": ["Venus", "Mars", "Jupiter", "Mercury"], "answer": "B" },
+    { "id": "know-3", "type": "multiple_choice", "category": "knowledge", "prompt": "What gas do plants primarily absorb from the atmosphere for photosynthesis?", "choices": ["Oxygen", "Carbon dioxide", "Nitrogen", "Hydrogen"], "answer": "B" },
+    { "id": "know-4", "type": "multiple_choice", "category": "knowledge", "prompt": "Who wrote the play 'Romeo and Juliet'?", "choices": ["Charles Dickens", "William Shakespeare", "Jane Austen", "Mark Twain"], "answer": "B" },
+    { "id": "know-5", "type": "exact_match", "category": "knowledge", "prompt": "What is the chemical symbol for gold? Answer with only the symbol.", "expected": "Au" },
+    { "id": "know-6", "type": "multiple_choice", "category": "knowledge", "prompt": "Which ocean is the largest by surface area?", "choices": ["Atlantic", "Indian", "Arctic", "Pacific"], "answer": "D" },
+    { "id": "reason-1", "type": "multiple_choice", "category": "reasoning", "prompt": "All bloops are razzies. All razzies are lazzies. Are all bloops definitely lazzies?", "choices": ["Yes", "No", "Cannot be determined"], "answer": "A" },
+    { "id": "reason-2", "type": "exact_match", "category": "reasoning", "prompt": "Tom is taller than Sam. Sam is taller than Jim. Who is the shortest? Answer with only the name.", "expected": "Jim" },
+    { "id": "reason-3", "type": "multiple_choice", "category": "reasoning", "prompt": "A farmer has 17 sheep. All but 9 run away. How many sheep are left?", "choices": ["8", "9", "17", "0"], "answer": "B" },
+    { "id": "reason-4", "type": "exact_match", "category": "reasoning", "prompt": "What is the next number in the sequence 2, 4, 8, 16? Answer with only the number.", "expected": "32" },
+    { "id": "reason-5", "type": "multiple_choice", "category": "reasoning", "prompt": "If today is Wednesday, what day will it be in 100 days?", "choices": ["Monday", "Tuesday", "Friday", "Sunday"], "answer": "C" },
+    { "id": "reason-6", "type": "multiple_choice", "category": "reasoning", "prompt": "Which weighs more: a kilogram of feathers or a kilogram of iron?", "choices": ["The feathers", "The iron", "They weigh the same"], "answer": "C" },
+    { "id": "lang-1", "type": "exact_match", "category": "language", "prompt": "What is the past tense of the verb 'go'? Answer with only the word.", "expected": "went" },
+    { "id": "lang-2", "type": "multiple_choice", "category": "language", "prompt": "Which word is a synonym of 'happy'?", "choices": ["Angry", "Joyful", "Tired", "Hungry"], "answer": "B" },
+    { "id": "lang-3", "type": "exact_match", "category": "language", "prompt": "Unscramble the letters 'TCA' to form an English animal name. Answer with only the word.", "expected": "cat" },
+    { "id": "lang-4", "type": "multiple_choice", "category": "language", "prompt": "Which sentence is grammatically correct?", "choices": ["She don't like apples.", "She doesn't likes apples.", "She doesn't like apples.", "She not like apples."], "answer": "C" },
+    { "id": "lang-5", "type": "contains", "category": "language", "prompt": "What is the plural of the word 'child'?", "expected": "children" },
+    { "id": "lang-6", "type": "multiple_choice", "category": "language", "prompt": "What is the antonym of 'ancient'?", "choices": ["Old", "Modern", "Antique", "Historic"], "answer": "B" }
+  ]
+}

--- a/cli/internal/eval/report.go
+++ b/cli/internal/eval/report.go
@@ -1,0 +1,115 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+type Result struct {
+	TaskID   string `json:"task_id"`
+	Category string `json:"category,omitempty"`
+	Correct  bool   `json:"correct"`
+	Output   string `json:"output"`
+	Error    string `json:"error,omitempty"`
+}
+
+type ModelReport struct {
+	Model        string   `json:"model"`
+	Results      []Result `json:"results"`
+	DecodeTokens int64    `json:"decode_tokens"`
+	DecodeTimeUs int64    `json:"decode_time_us"`
+}
+
+func (r *ModelReport) Correct() int {
+	n := 0
+	for _, res := range r.Results {
+		if res.Correct {
+			n++
+		}
+	}
+	return n
+}
+
+func (r *ModelReport) Accuracy() float64 {
+	if len(r.Results) == 0 {
+		return 0
+	}
+	return float64(r.Correct()) / float64(len(r.Results))
+}
+
+func (r *ModelReport) TokPerSec() float64 {
+	if r.DecodeTimeUs <= 0 {
+		return 0
+	}
+	return float64(r.DecodeTokens) / (float64(r.DecodeTimeUs) / 1e6)
+}
+
+// RenderTable renders the cross-model comparison as an aligned text table.
+func RenderTable(pack *Pack, reports []*ModelReport) string {
+	seen := map[string]bool{}
+	var cats []string
+	for _, r := range reports {
+		for _, res := range r.Results {
+			if res.Category != "" && !seen[res.Category] {
+				seen[res.Category] = true
+				cats = append(cats, res.Category)
+			}
+		}
+	}
+	sort.Strings(cats)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Eval: %s (%d tasks)\n\n", pack.Name, len(pack.Tasks))
+	w := tabwriter.NewWriter(&b, 2, 0, 3, ' ', 0)
+	header := "MODEL\tACCURACY\tCORRECT\tTOK/S"
+	if len(cats) > 0 {
+		header += "\t" + strings.ToUpper(strings.Join(cats, "\t"))
+	}
+	fmt.Fprintln(w, header)
+
+	for _, r := range reports {
+		row := fmt.Sprintf("%s\t%.1f%%\t%d/%d", r.Model, r.Accuracy()*100, r.Correct(), len(r.Results))
+		if r.TokPerSec() > 0 {
+			row += fmt.Sprintf("\t%.1f", r.TokPerSec())
+		} else {
+			row += "\t-"
+		}
+		for _, c := range cats {
+			correct, total := 0, 0
+			for _, res := range r.Results {
+				if res.Category == c {
+					total++
+					if res.Correct {
+						correct++
+					}
+				}
+			}
+			row += fmt.Sprintf("\t%d/%d", correct, total)
+		}
+		fmt.Fprintln(w, row)
+	}
+	w.Flush()
+	return b.String()
+}
+
+// WriteJSON writes the full run to path for diffing or feeding other tools.
+func WriteJSON(path string, pack *Pack, reports []*ModelReport) error {
+	doc := struct {
+		Eval        string         `json:"eval"`
+		Description string         `json:"description,omitempty"`
+		TaskCount   int            `json:"task_count"`
+		Models      []*ModelReport `json:"models"`
+	}{pack.Name, pack.Description, len(pack.Tasks), reports}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}

--- a/cli/internal/eval/score.go
+++ b/cli/internal/eval/score.go
@@ -1,0 +1,66 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package eval
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	// A closed <think> block, or an unterminated one (model never answered).
+	thinkRe = regexp.MustCompile(`(?s)<think>(.*?</think>|.*$)`)
+	// Uppercase only: a standalone lowercase letter is usually the article "a".
+	letterRe     = regexp.MustCompile(`\b([A-Z])\b`)
+	loneLetterRe = regexp.MustCompile(`^[^A-Za-z0-9]*([A-Za-z])[^A-Za-z0-9]*$`)
+)
+
+// Score reports whether output answers t correctly. Unparseable output is
+// simply wrong, never an error.
+func Score(t Task, output string) bool {
+	answer := strings.TrimSpace(thinkRe.ReplaceAllString(output, ""))
+	switch t.Type {
+	case TaskMultipleChoice:
+		idx, ok := extractChoice(answer, t.Choices)
+		return ok && idx == int(t.Answer[0]-'A')
+	case TaskExactMatch:
+		return normalize(answer) == normalize(t.Expected)
+	case TaskContains:
+		return strings.Contains(normalize(answer), normalize(t.Expected))
+	default:
+		return false
+	}
+}
+
+func normalize(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	return strings.TrimSpace(strings.TrimRight(s, ".!?"))
+}
+
+// extractChoice maps output to a choice index: a bare letter ("b", "(B)."),
+// then the first standalone uppercase letter in range ("Answer: B"), then an
+// output matching exactly one choice's text.
+func extractChoice(answer string, choices []string) (int, bool) {
+	if m := loneLetterRe.FindStringSubmatch(answer); m != nil {
+		idx := int(strings.ToUpper(m[1])[0] - 'A')
+		return idx, idx < len(choices)
+	}
+	for _, m := range letterRe.FindAllStringSubmatch(answer, -1) {
+		if idx := int(m[1][0] - 'A'); idx < len(choices) {
+			return idx, true
+		}
+	}
+	normalized := normalize(answer)
+	if normalized == "" {
+		return 0, false
+	}
+	matched, count := -1, 0
+	for i, choice := range choices {
+		if strings.Contains(normalized, normalize(choice)) {
+			matched = i
+			count++
+		}
+	}
+	return matched, count == 1
+}

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -143,6 +143,33 @@ geniex model list
 geniex model list --all
 ```
 
+### **`geniex eval`**
+
+Evaluate one or more models on an eval pack and compare their accuracy side by side:
+
+```bash
+geniex eval Qwen/Qwen3-0.6B-GGUF unsloth/Llama-3.2-1B-Instruct-GGUF
+```
+
+`--eval` selects a built-in pack (`basic`) or a custom pack from a JSON file; `--json` additionally writes full per-task results to a file. Runs are greedy (top-k 1, fixed seed) with thinking disabled, so results are repeatable.
+
+```bash
+geniex eval Qwen/Qwen3-0.6B-GGUF --eval my-eval.json --json results.json
+```
+
+A custom pack is a JSON file with a `name` and a list of `tasks`. Each task is one of three types: `multiple_choice` (lettered `choices` plus the correct `answer` letter), `exact_match`, or `contains` (both match model output against `expected`, case-insensitively):
+
+```json
+{
+  "name": "my-eval",
+  "tasks": [
+    { "type": "multiple_choice", "prompt": "Which planet is the Red Planet?", "choices": ["Venus", "Mars", "Jupiter"], "answer": "B" },
+    { "type": "exact_match", "prompt": "What is 2+2? Answer with only the number.", "expected": "4" },
+    { "type": "contains", "prompt": "What is the plural of 'child'?", "expected": "children" }
+  ]
+}
+```
+
 ## **`geniex serve`**
 
 Start the OpenAI-compatible local server. See [Local server](/en/run/cli/local-server) for the API.

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -87,6 +87,33 @@ For text-only, just launch and chat. For image input, provide the **absolute pat
 Describe this picture </full/path/to/image.png>
 ```
 
+### **`geniex eval`**
+
+Evaluate one or more models on an eval pack and compare their accuracy side by side:
+
+```bash
+geniex eval Qwen/Qwen3-0.6B-GGUF unsloth/Llama-3.2-1B-Instruct-GGUF
+```
+
+`--eval` selects a built-in pack (`basic`) or a custom pack from a JSON file; `--json` additionally writes full per-task results to a file. Runs are greedy (top-k 1, fixed seed) with thinking disabled, so results are repeatable.
+
+```bash
+geniex eval Qwen/Qwen3-0.6B-GGUF --eval my-eval.json --json results.json
+```
+
+A custom pack is a JSON file with a `name` and a list of `tasks`. Each task is one of three types: `multiple_choice` (lettered `choices` plus the correct `answer` letter), `exact_match`, or `contains` (both match model output against `expected`, case-insensitively):
+
+```json
+{
+  "name": "my-eval",
+  "tasks": [
+    { "type": "multiple_choice", "prompt": "Which planet is the Red Planet?", "choices": ["Venus", "Mars", "Jupiter"], "answer": "B" },
+    { "type": "exact_match", "prompt": "What is 2+2? Answer with only the number.", "expected": "4" },
+    { "type": "contains", "prompt": "What is the plural of 'child'?", "expected": "children" }
+  ]
+}
+```
+
 ## **`geniex serve`**
 
 Start the OpenAI-compatible local server. See [Local server](/en/run/cli/local-server) for the API.


### PR DESCRIPTION
Closes #1070.

Adds `geniex eval`: run one or more models over an eval pack and compare accuracy.

```
geniex eval <model> [<model>...] [--eval basic|pack.json] [--json out.json]
```

Custom packs are JSON (task types: `multiple_choice`, `exact_match`, `contains`); one built-in smoke pack ships embedded. Runs are repeatable: greedy decoding, fixed seed, thinking off, context reset per task. LLM only for now; wiring reuses the infer plumbing.

@alanzhuly happy to rework schema/scoring/UX to fit your direction. Test report in the comment below.