### PR TITLE
ci(release): make release SDK builds hermetic (skip cross-run caches)

### DIFF
--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -18,6 +18,17 @@ on:
         required: false
         type: string
         default: ""
+      hermetic:
+        description: >-
+          Build from clean state: skip every cross-run cache restore (ccache,
+          cargo target, CMake build tree). Release builds set this so shipped
+          binaries can never be assembled from stale cached outputs — the same
+          uniform-mtime hazard documented on the cargo cache below applies to
+          the ninja build tree, whose cache key hashes only configure inputs,
+          not the C/C++ sources.
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -79,6 +90,7 @@ jobs:
           version_tag: ${{ inputs.version_tag }}
 
       - name: Restore ccache
+        if: ${{ !inputs.hermetic }}
         uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/.ccache
@@ -95,6 +107,7 @@ jobs:
       # No restore-keys — a source change forces a clean rebuild instead of a
       # fuzzy restore that would re-trigger the staleness.
       - name: Restore cargo target
+        if: ${{ !inputs.hermetic }}
         uses: actions/cache@v6
         with:
           path: |
@@ -127,6 +140,7 @@ jobs:
       # configure-time inputs; a change there mints a new entry, while
       # restore-keys lets unchanged-config runs reuse the previous tree.
       - name: Restore CMake build dir
+        if: ${{ !inputs.hermetic }}
         uses: actions/cache@v6
         with:
           path: sdk/build-${{ matrix.preset }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,12 @@ jobs:
     with:
       version_tag: ${{ needs.resolve-tag.outputs.tag }}
       upload_artifact: true
+      # Release artifacts must be built from clean state, never assembled from
+      # restored ccache / cargo / ninja-tree caches: actions/cache restores
+      # uniform mtimes, so a restored build tree can defeat ninja's staleness
+      # detection and `cmake --install` then ships outputs compiled from an
+      # older commit under the new tag (see qualcomm/GenieX#1266).
+      hermetic: true
 
   build-android-aar:
     name: build-android-aar


### PR DESCRIPTION
Adds a `hermetic` input to `_build-sdk.yml` that skips the three cross-run cache restores (ccache, cargo target, CMake build tree), and sets it for the `build-sdk` call in `release.yml`. Defaults to `false`, so PR/branch builds and every other caller keep their caches; only release artifacts pay the clean-build cost (one ~30–60 min build per release, inside the job's 120-minute timeout).

Rationale: shipped artifacts shouldn't depend on cross-run mutable state. The cargo-target cache comment in this file already records one stale-artifact incident in this pipeline; a hermetic release build removes that entire class for the binaries users install, whatever the mechanism of any individual incident.

Scope note, to be upfront: I verified that `actions/cache` extracts with archived mtimes (no `-m`), so ninja's staleness detection should normally be sound — this is defense-in-depth for releases, not a fix for a demonstrated bug, and it is independent of #1266 (which it came out of investigating). If you consider the current caches sufficient, closing this is a reasonable call.