### PR TITLE
fix(sdk): restore mtmd_input_text.text_len in VLM tokenize

### DIFF
--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -276,6 +276,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             // prompt_utf8 already has chat template and media markers applied
             mtmd_input_text text;
             text.text          = new_text_portion.c_str();
+            text.text_len      = new_text_portion.length();
             text.add_special   = this->n_past == 0;  // add BOS only on first message
             text.parse_special = true;
 


### PR DESCRIPTION
## Background

`google/gemma-4-E4B-it-qat-q4_0-gguf` on the OpenAI-compatible `/v1/chat/completions` route, given an image and a prompt like "Whose headquarters is this?":

- `--compute npu` (default for llama_cpp on this model family) → "I do not have enough information..." across retries.
- `--compute cpu` → correctly identifies the subject of the image.
- Ollama on the same weights → correct answer.

Weights and CLIP output were fine; the image chunk simply wasn't reaching the LLM decode on some paths.

## Root cause

`mtmd_input_text` gained a `text_len` field in llama.cpp `b10019`, and `mtmd_tokenize` switched to `input_text.assign(text->text, text->text_len)` at [third-party/llama.cpp/tools/mtmd/mtmd.cpp:865](third-party/llama.cpp/tools/mtmd/mtmd.cpp#L865). Commit `0aa90fd3` set the field in the VLM path. Commit `2df324a8` (which reordered the HTP-session reacquire) rebased over `0aa90fd3` and dropped that one line — so `text_len` reverted to an uninitialized stack value.

Depending on the leftover stack value at that frame, `mtmd_tokenize` consumes the wrong number of bytes: the `<__media__>` marker produced by `apply_chat_template` gets truncated out and the image chunk is silently discarded, or the length lands too large and the allocator throws `std::bad_alloc`. The reporter's `--compute cpu` run happened to land on a value that kept the marker inside the consumed slice; `--compute npu` didn't. Both presentations (silent "not enough information" answer and a hard `Multimodal generation failed` — the shape I got on my local Snapdragon X Elite host) come from the same uninitialized read.

## Fix

Restore the single dropped assignment at [sdk/plugins/llama_cpp/src/vlm.cpp:278](sdk/plugins/llama_cpp/src/vlm.cpp#L278):

```cpp
text.text_len = new_text_portion.length();
```

## Test plan

- [x] Local: `geniex infer google/gemma-4-E4B-it-qat-q4_0-gguf -c cpu -p "./tests/assets/quality_dog.jpg Describe this image."` — without the fix errors with `mtmd_tokenize: number of media markers in text (0) does not match number of bitmaps (1)`; with the fix produces a coherent description. Details in the test-results comment below.
- [x] Local: same command with `-c npu` — same before/after. Details in the test-results comment below.
