### PR TITLE
chore(cli): drop stale SoX preflight warning

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -516,9 +516,6 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 
 	caps, _ := p.Capabilities()
 	slog.Debug("VLM capabilities", "vision", caps.SupportsVision, "audio", caps.SupportsAudio)
-	if caps.SupportsAudio {
-		checkAudioDependency()
-	}
 
 	var history []geniex_sdk.VlmChatMessage
 	if systemPrompt != "" {

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -4,11 +4,8 @@
 package main
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
-	"runtime"
 	"slices"
 
 	"github.com/spf13/cobra"
@@ -105,23 +102,6 @@ func RootCmd() *cobra.Command {
 	)
 
 	return rootCmd
-}
-
-func checkAudioDependency() {
-	if _, err := exec.LookPath("sox"); err != nil {
-		fmt.Println(render.GetTheme().Warning.Sprintf("SoX is not installed, some features may not work. Try:"))
-		switch runtime.GOOS {
-		case "linux":
-			fmt.Println(render.GetTheme().Warning.Sprintf("  sudo apt install sox       # Debian/Ubuntu"))
-			fmt.Println(render.GetTheme().Warning.Sprintf("  sudo yum install sox       # RHEL/CentOS/Fedora"))
-			fmt.Println(render.GetTheme().Warning.Sprintf("  sudo pacman -S sox         # Arch Linux"))
-		case "windows":
-			fmt.Println(render.GetTheme().Warning.Sprintf("  winget install --id=ChrisBagwell.SoX -e"))
-			fmt.Println(render.GetTheme().Warning.Sprintf("Then restart your terminal to make sure sox is in PATH"))
-		default:
-			fmt.Println(render.GetTheme().Warning.Sprintf("Please install it manually for your OS: %s\n", runtime.GOOS))
-		}
-	}
 }
 
 // main is the entry point that executes the root command.

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -51,7 +51,6 @@ func serve() *cobra.Command {
 	viper.BindPFlag("keyfile", serveCmd.Flags().Lookup("keyfile"))
 
 	serveCmd.Run = func(cmd *cobra.Command, args []string) {
-		checkAudioDependency()
 		if err := common.InitSDK(); err != nil {
 			common.PrintError(err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

- Drop the SoX preflight banner (`SoX is not installed, some features may not work...`) from `geniex serve` and `geniex infer` (VLM path)
- The current inference stack does not require SoX for anything the CLI actually does; the warning is stale noise for users on stock machines
- Underlying `cli/internal/record` package and the REPL `/mic` command are left in place — this change is only about the user-facing preflight text

## Test plan

- [ ] `geniex serve --help && geniex serve` — no `SoX is not installed` banner in stdout
- [ ] `geniex infer <audio-capable-vlm>` — no SoX banner even when `caps.SupportsAudio == true`