### PR TITLE
docs(docs): add tutorials section with MTP guide and explicit chipset list

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -93,6 +93,20 @@
             ]
           },
           {
+            "group": "Tutorials",
+            "icon": "graduation-cap",
+            "pages": [
+              "en/tutorials/overview",
+              {
+                "group": "Compute (Windows ARM64)",
+                "icon": "laptop",
+                "pages": [
+                  "en/tutorials/compute/speculative-decoding-mtp"
+                ]
+              }
+            ]
+          },
+          {
             "group": "Resources",
             "icon": "circle-question",
             "pages": [

--- a/docs/en/get-started/platforms.mdx
+++ b/docs/en/get-started/platforms.mdx
@@ -11,15 +11,45 @@ GenieX runs exclusively on Qualcomm Snapdragon — no x86 or non-Snapdragon ARM 
 
 GenieX is supported across three Snapdragon families — compute, mobile, and IoT — covering Windows ARM64, Android, and Linux ARM64.
 
+### Supported chipsets
+
+These are the chipsets GenieX is validated on. Each row lists the **SoC identifier** you'd see from auto-detection, and the **AI Hub chipset id** used when pulling Qualcomm AI Hub Models.
+
+| Family | Chipset | SoC id | AI Hub chipset id |
+|---|---|---|---|
+| **Compute** *(Windows ARM64 / Copilot+ PC)* | **Snapdragon® X Elite** | `X1E*` | `qualcomm-snapdragon-x-elite` |
+| | **Snapdragon® X2 Elite** | `X2E*` | `qualcomm-snapdragon-x2-elite` |
+| **Mobile** *(Android)* | **Snapdragon® 8 Elite** | `SM8750` | `qualcomm-snapdragon-8-elite` |
+| | **Snapdragon® 8 Elite Gen 5** | `SM8850` | resolved from `SM8850` *(see note)* |
+| **IoT** *(Linux ARM64 — cameras, robotics, industrial)* | **Qualcomm® Dragonwing™ IQ-9075** | `QCS9075` | `qualcomm-qcs9075` |
+| | **Qualcomm® Dragonwing™ IQ-8275** | `QCS8275` | `qualcomm-qcs8275` |
+
+<Note>
+**Chipset vs. SoC id.** Snapdragon X-series parts are identified by their Oryon CPU SKU (`X1E80100`, `X2E80100`, …); every part within a generation shares one NPU architecture, so **all X Elite SKUs map to the same AI Hub asset** — including the X Plus and X2 Plus parts. Android reports its SoC through `ro.soc.model`, and Dragonwing boards through the device tree.
+
+On Android, GenieX passes the SoC id (e.g. `SM8850`) straight to Qualcomm AI Hub, which resolves it through its own alias table — GenieX deliberately keeps no second mapping. Pass the **SoC id**, not an AI Hub chipset name, and the right asset is selected. Variant suffixes are not exposed by `ro.soc.model`: a Galaxy S25 reports `SM8750`, not `SM8750-AC` (the alias for `qualcomm-snapdragon-8-elite-for-galaxy`), so pass the chipset explicitly if you need the variant asset.
+</Note>
+
+GenieX **auto-detects the chipset** on Windows on Snapdragon, Dragonwing Linux, and Android. Check what it found, or set it explicitly:
+
+```bash
+geniex config get chipset          # show the detected (or configured) chipset
+geniex config set chipset          # launch an interactive picker
+```
+
+<Warning>**Android requires an explicit chipset** for Qualcomm AI Hub pulls — auto-detect via `ro.soc.model` covers the CLI/SDK path, but the Android SDK needs `ModelPullInput.chipset` set to `"SM8750"` or `"SM8850"`. See [Android API reference](/en/run/android/api-reference#modelpullinput).</Warning>
+
+### Interfaces per OS
+
 | OS | Interfaces |
 |---|---|
 | **Windows ARM64** *(Compute / Copilot+ PC)* | <ul><li>[CLI](/en/run/cli/quickstart)</li><li>[Python SDK](/en/run/python/quickstart)</li><li>[Local server](/en/run/cli/local-server)</li></ul> |
 | **Android** *(Mobile)* | <ul><li>[Android SDK](/en/run/android/quickstart) (Kotlin, Maven Central)</li></ul> |
-| **Linux ARM64** *(Dragonwing IoT — cameras, robotics, industrial)* | <ul><li>[Native install](/en/run/cli/install)</li><li>[Docker](/en/run/linux/install)</li></ul> |
+| **Linux ARM64** *(Dragonwing IoT)* | <ul><li>[Native install](/en/run/cli/install)</li><li>[Docker](/en/run/linux/install)</li></ul> |
 
-For the full list of supported chipsets, see the [Qualcomm AI Hub device list](https://workbench.aihub.qualcomm.com/docs/hub/devices.html).
+The chipsets above are the validated set. GenieX may run on other Snapdragon parts within the same families — for everything Qualcomm AI Hub can compile for, see the [Qualcomm AI Hub device list](https://workbench.aihub.qualcomm.com/docs/hub/devices.html).
 
-<Tip>**No device on hand?** Sign in to [Qualcomm Developer Cloud (QDC)](https://qdc.qualcomm.com/) for remote sessions on Snapdragon X, 8 Elite, and Dragonwing QCS9075. See the [QDC walkthrough in the FAQ](/en/resources/faq#qdc-qualcomm-device-cloud).</Tip>
+<Tip>**No device on hand?** Sign in to [Qualcomm Developer Cloud (QDC)](https://qdc.qualcomm.com/) for remote sessions on Snapdragon X Elite / X2 Elite, Snapdragon 8 Elite / 8 Elite Gen 5, and Dragonwing IQ-9075. See the [QDC walkthrough in the FAQ](/en/resources/faq#qdc-qualcomm-device-cloud).</Tip>
 
 ## **GenieX runtimes**
 

--- a/docs/en/tutorials/compute/speculative-decoding-mtp.mdx
+++ b/docs/en/tutorials/compute/speculative-decoding-mtp.mdx
@@ -1,0 +1,178 @@
+---
+title: "Speculative decoding with MTP"
+description: "Accelerate Gemma-4-26B decoding on Snapdragon with a Multi-Token Prediction draft model, in geniex infer and the local server."
+---
+
+import Feedback from "/snippets/page-feedback.mdx";
+
+Speculative decoding speeds up a large model without changing what it produces. A cheap **draft** proposes several tokens ahead, the large **target** verifies them all in one forward pass, and the accepted prefix is committed at once. Because verification costs one pass no matter how many tokens it checks, accepted tokens after the first are nearly free — and the output is identical to what the target would have generated alone.
+
+**MTP (Multi-Token Prediction)** is the strongest variant of this. Rather than a separately-trained small model whose guesses drift from the target's, MTP uses prediction heads trained *alongside* the target that read its own hidden states — so proposals come from the same distribution the target samples from.
+
+This tutorial enables MTP for **Gemma-4-26B-A4B** on the Hexagon NPU, in `geniex infer` and then behind the local server.
+
+<Info>
+**Verified on:** Snapdragon X2 Elite, `llama_cpp` runtime, `--compute npu`, target + draft both `Q4_0`.
+</Info>
+
+<Note>Speculative decoding is **`llama_cpp`-only**. On the `qairt` runtime these flags are ignored with a warning rather than an error — `qairt` "SSD" bundles carry their own NPU acceleration that GenieX applies automatically.</Note>
+
+## **Prerequisites**
+
+- The CLI installed — see [Install](/en/run/cli/install).
+- A Snapdragon X-series device.
+- **~20 GB free disk**, and enough free RAM to hold both models at once — the target alone is ~15 GB at `Q4_0`.
+
+## **Step 1: Pull the model pair**
+
+MTP requires a draft trained against **the exact target** you're running. GenieX builds the draft context wired into the live target context (`LLAMA_CONTEXT_TYPE_MTP`), so an arbitrary small GGUF cannot be substituted — a mismatched pair fails the graph shape check at load time rather than silently degrading.
+
+| Role | Model | Precision |
+|---|---|---|
+| **Target** | `google/gemma-4-26B-A4B-it-qat-q4_0-gguf` | `Q4_0` |
+| **Draft** | `RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf` | `Q4_0` |
+
+```powershell
+geniex pull google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0
+geniex pull RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0
+```
+
+Why this pair: Gemma-4 is the only publicly published family shipping MTP heads in a llama.cpp-compatible GGUF today, and `A4B` is the smallest target with a matching published draft — the `RachidAR/*-assistant` draft is trained against `A4B`, so pairing it with the smaller `E2B` target fails. `Q4_0` on both sides has the best [Hexagon NPU support](/en/models/supported#precisions-quantizations-supported).
+
+<Tip>`geniex infer` auto-pulls a missing draft, but pulling explicitly gives you a progress bar instead of a silent stall — and the server path (Step 3) **requires** it.</Tip>
+
+## **Step 2: Run it in `geniex infer`**
+
+Take a baseline first, so you have a number to compare against:
+
+```powershell
+geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu
+```
+
+Then enable MTP:
+
+```powershell
+geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu ^
+    --spec-type draft-mtp ^
+    --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0 ^
+    --draft-tokens 3
+```
+
+Add `-p "your prompt"` for a one-shot run instead of an interactive session.
+
+### **Reading the acceptance rate**
+
+With speculation active, the profiling block gains a `draft accept` line — accepted draft tokens over total proposed:
+
+```
+decode speed:   56.4 tok/s
+stop reason:    eos
+draft accept:   14/75 (18.7%)
+```
+
+This is the number that tells you whether speculation is paying off, and **you have to compare decode speed against your baseline to know.** Acceptance varies sharply by workload: predictable, structured output (code, JSON, formulaic prose) accepts far more than open-ended prose. Benchmark on prompts resembling your real traffic.
+
+<Warning>
+Acceptance for this published Gemma-4 pair measured **low (single-digit to ~20%)** during validation. MTP's ceiling is high in principle, but a publicly available assistant draft is not the same as one tuned for your target — if speculation doesn't beat your baseline decode speed, that's a real result, not a misconfiguration. Verify against the baseline before adopting it.
+</Warning>
+
+### **Tuning**
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--draft-tokens` | `3` | Max draft tokens per verification step. |
+| `--draft-min` | `0` | Min draft tokens per step. `0` = llama.cpp default. |
+| `--draft-p-min` | `0` | Draft stops proposing below this confidence. `0` = llama.cpp default. |
+
+Start at `3`. Raise it only if acceptance is high — with mediocre acceptance a longer window makes things *worse*, since every rejected token was wasted target work. Lower it to `2` if acceptance is marginal.
+
+<Note>Raising `--draft-tokens` costs less memory than you'd expect: GenieX caps the draft context's batch at `max(64, draft-tokens)` instead of inheriting the target's, which otherwise allocates ~2.3 GiB of HTP scratch and OOMs.</Note>
+
+## **Step 3: Serve it over HTTP**
+
+<Warning>
+**The server never auto-downloads a draft model** — unlike `geniex infer`, it only consumes what's cached, so a missing draft errors mid-request. Complete [Step 1](#step-1-pull-the-model-pair) first.
+</Warning>
+
+`geniex serve` has no `--spec-type` flag; speculation is per-request. Either let `geniex run` forward the same flags you used above:
+
+```powershell
+geniex serve                      # terminal 1
+
+geniex run google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu ^
+    --spec-type draft-mtp ^
+    --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0 ^
+    --draft-tokens 3
+```
+
+…or send the fields directly on `POST /v1/chat/completions`:
+
+```bash
+curl http://127.0.0.1:18181/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0",
+    "messages": [{"role": "user", "content": "Explain speculative decoding briefly."}],
+    "compute": "npu",
+    "spec_type": "draft-mtp",
+    "spec_draft_model": "RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0",
+    "spec_n_max": 3
+  }'
+```
+
+| Field | Notes |
+|---|---|
+| `spec_type` | `draft-mtp`. Omit or leave empty to disable. |
+| `spec_draft_model` | Catalogue name `org/repo[:precision]` (**must be pulled**) or absolute GGUF path. |
+| `spec_n_max` | Max draft tokens per step. Default `3`. |
+| `spec_n_min` / `spec_p_min` | Match `--draft-min` / `--draft-p-min`. `0` = llama.cpp default. |
+
+<Note>**These fields are part of the model cache key.** Changing any of them rebuilds the model on the next request, so keep them stable across a benchmark run or you'll be measuring reload time. Full schema in the Swagger UI at `http://127.0.0.1:18181` — see [Local server](/en/run/cli/local-server).</Note>
+
+## **Troubleshooting**
+
+<AccordionGroup>
+  <Accordion title="No draft accept line in the output">
+    Speculation never ran. Setup failure is **non-fatal by design** — an unrecognized type or a draft context that won't build logs `speculative decoding setup failed; falling back to plain decoding` and continues at normal speed. Check the log for that line, and confirm the flag reached the process.
+  </Accordion>
+
+  <Accordion title="Load fails with a graph shape / tensor mismatch">
+    The draft doesn't match the target. The `RachidAR/*-assistant` draft is built for `gemma-4-26B-A4B` — not `E2B` or other sizes. Re-check both names and precisions against Step 1.
+  </Accordion>
+
+  <Accordion title="Server: resolve draft model ... error">
+    The server does not auto-pull. Run `geniex pull` for the draft repo with the same `:precision` suffix you're sending, then confirm with `geniex list`.
+  </Accordion>
+
+  <Accordion title="Out of memory on load">
+    Target + draft need substantial free RAM together. Close other models (the server's `--keepalive` may be holding one resident), lower `--nctx`, or switch to `ngram-mod`, which loads no second model.
+  </Accordion>
+
+  <Accordion title="Warning: speculative decoding is only supported by llama_cpp">
+    Your model resolved to the `qairt` runtime, which doesn't implement it — the flags are dropped and inference continues normally. Use a GGUF model for the `llama_cpp` runtime.
+  </Accordion>
+</AccordionGroup>
+
+## **Other speculative types**
+
+`--spec-type` forwards to llama.cpp's type parser, so it accepts more names than GenieX validates. One other is exercised on Snapdragon:
+
+- **`ngram-mod`** — self-speculative, no draft model, works with **any** GGUF. Verified on X Elite across CPU, GPU, and NPU. Weaker than a matched MTP pair on open-ended text, but useful on repetitive output, and free to try.
+
+```powershell
+geniex infer unsloth/Qwen3-0.6B-GGUF --compute gpu --spec-type ngram-mod -p "..."
+```
+
+<Warning>
+Treat anything outside `draft-mtp` and `ngram-mod` as **unsupported on Snapdragon**. `draft-eagle3` and `draft-simple` parse and load, but GenieX builds an MTP draft context for *every* draft-model type — they aren't wired to their own upstream paths. The remaining `ngram-*` variants have no Snapdragon validation.
+</Warning>
+
+## **Next steps**
+
+- [CLI reference](/en/run/cli/reference) — every `geniex infer` flag.
+- [Local server](/en/run/cli/local-server) — the full OpenAI-compatible API.
+- [Platforms & runtimes](/en/get-started/platforms) — compute units, and how `npu` differs from `hybrid`.
+
+<br />
+
+<Feedback />

--- a/docs/en/tutorials/overview.mdx
+++ b/docs/en/tutorials/overview.mdx
@@ -1,0 +1,34 @@
+---
+title: "Tutorials"
+description: "End-to-end walkthroughs for getting more out of GenieX on real Snapdragon hardware."
+---
+
+import Feedback from "/snippets/page-feedback.mdx";
+
+The [Run](/en/run/cli/quickstart) guides cover each interface on its own. Tutorials go the other way: one goal, start to finish, on a specific class of Snapdragon hardware — the model pull, the flags, the numbers you should see, and what to do when they don't show up.
+
+Each tutorial states the platform it was verified on at the top. Most techniques carry across families, but the model sizes and compute units that make sense do not — a 26B target that fits comfortably on a Copilot+ PC will not fit an IoT board.
+
+## **Compute — Windows ARM64 / Copilot+ PC**
+
+Snapdragon X-series laptops and desktops, where memory headroom allows large targets and multi-model setups.
+
+<CardGroup cols={2}>
+  <Card title="Speculative decoding with MTP" href="/en/tutorials/compute/speculative-decoding-mtp" icon="gauge-high">
+    Accelerate Gemma-4-26B decoding with a Multi-Token Prediction draft model, in both `geniex infer` and the local server.
+  </Card>
+</CardGroup>
+
+## **Before you start**
+
+Every tutorial assumes you have:
+
+- The CLI installed and on your `PATH` — see [Install](/en/run/cli/install).
+- A supported Snapdragon device, or a remote session on [Qualcomm Developer Cloud](https://qdc.qualcomm.com/) — see [Platforms & runtimes](/en/get-started/platforms).
+- Enough free disk for the models involved. Tutorials list sizes up front; `geniex list` shows what you already have cached.
+
+<Tip>New to GenieX entirely? Start with the [Quickstart](/en/get-started/quickstart) and come back here once you have a model answering prompts.</Tip>
+
+<br />
+
+<Feedback />


### PR DESCRIPTION
## Summary

Adds a **Tutorials** section to the docs site and makes the supported-chipset
list explicit on the platforms page.

### Tutorials section

New nav group structured as overview + platform subgroups, so the planned IoT
article drops in as a sibling without reorganizing anything:

    Tutorials
    ├── Overview                    en/tutorials/overview.mdx
    └── Compute (Windows ARM64)     (subgroup)
        └── Speculative decoding with MTP

- `en/tutorials/overview.mdx` — landing page with a card grid per platform
  family plus shared prerequisites.
- `en/tutorials/compute/speculative-decoding-mtp.mdx` — step-by-step guide to
  enabling MTP speculative decoding for Gemma-4-26B-A4B on the Hexagon NPU,
  covering `geniex infer`, `geniex run`, and raw `POST /v1/chat/completions`.

Content is sourced from #1195 and the code rather than inferred:
