### PR TITLE
docs: document --nctx and improve context-exceeded UX

### DIFF
--- a/cli/cmd/geniex/common/error.go
+++ b/cli/cmd/geniex/common/error.go
@@ -47,7 +47,12 @@ const (
 - This model may not be compatible with your system. Try another model.
 - See help in our discord or slack.`
 
-	hintContextLength = `Context length exceeded, please start a new conversation.`
+	hintContextLength = `⚠️ Context length exceeded — the conversation outgrew the context window.
+
+👉 Try these:
+- llama_cpp: raise the window with '--nctx <N>' (default 4096), up to the model's trained max. Larger windows use more memory.
+- qairt: the window is fixed at compile time and can't be raised at runtime. Add '--sliding-window' to keep chatting by evicting the oldest context, or pull a bundle built for a longer context.
+- Or start a new conversation to clear the history.`
 
 	hintHubUnreachable = `⚠️ Unable to reach the model hub while resolving metadata.
 

--- a/cli/cmd/geniex/common/process.go
+++ b/cli/cmd/geniex/common/process.go
@@ -128,7 +128,8 @@ func (p *Processor) Process() error {
 					return resetErr
 				}
 			}
-			fmt.Println(render.GetTheme().Error.Sprintf("Model context length exceeded; conversation is reset"))
+			fmt.Println(render.GetTheme().Error.Sprintf("Model context length exceeded; conversation is reset."))
+			fmt.Println(render.GetTheme().Error.Sprintf("Raise it with --nctx <N> (llama_cpp; larger uses more memory), or add --sliding-window (qairt)."))
 			fmt.Println()
 		default:
 			return err

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -82,7 +82,7 @@ var (
 		llmFlags.SortFlags = false
 		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: npu)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
-		llmFlags.Int32VarP(&nctx, "nctx", "", 4096, "context window size (llama_cpp only)")
+		llmFlags.Int32VarP(&nctx, "nctx", "", 4096, "context window size; raise to extend context (llama_cpp only)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")
 		llmFlags.StringArrayVarP(&stop, "stop", "", nil, "stop sequences (llama_cpp only)")
 		llmFlags.StringVarP(&stopFile, "stop-file", "", "", "file containing stop sequences (llama_cpp only)")

--- a/docs/cn/resources/troubleshooting.mdx
+++ b/docs/cn/resources/troubleshooting.mdx
@@ -31,6 +31,15 @@ import Feedback from "/snippets/page-feedback.mdx";
   <Accordion title="`--compute cpu` 或 `--compute gpu` 在 Qualcomm AI Hub 模型上报错">
     Qualcomm AI Engine Direct 仅支持 NPU。请使用 `--compute npu`（或省略该标志——`npu` 是 `qairt` 的默认值）。如需在 CPU/GPU 上运行，改用 [llama.cpp 运行环境](/cn/get-started/platforms#llamacpp)的 GGUF 模型。
   </Accordion>
+
+  <Accordion title="长对话中出现 `Context length exceeded`">
+    对话增长超过了上下文窗口（`--nctx`，默认 4096）。
+
+    - **llama.cpp (GGUF)：** 可在运行时抬升，例如 `geniex infer <model> --nctx 8192`，上限为模型训练时的最大值。窗口越大占用内存越多。
+    - **Qualcomm AI Engine Direct (NPU)：** 窗口固化在编译好的模型包中，`--nctx` 不生效。加 `--sliding-window` 以继续对话（驱逐最旧的上下文），或获取按更长上下文编译的模型包。
+
+    参见[增大上下文长度](/cn/run/cli/reference#增大上下文长度)。
+  </Accordion>
 </AccordionGroup>
 
 ## **服务器**

--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -132,6 +132,20 @@ geniex serve
 | `-s`, `--system-prompt` | string | — | 设置模型行为的系统提示。 |
 | `--sliding-window` | — | `false` | （仅 `qairt`）当上下文长度超限时，驱逐锚定前缀之外最旧的上下文，而不是报错，从而让对话继续。 |
 
+### 增大上下文长度
+
+上下文窗口（`--nctx`）是模型一次能容纳的内容上限。当对话增长超过该上限时会报 *context length exceeded* 错误。如何增大取决于运行时：
+
+- **llama.cpp (GGUF)：** `--nctx <N>` 可在运行时抬升窗口，上限为模型训练时的最大值。窗口越大，占用的 KV 缓存内存越多。
+
+  ```bash
+  geniex infer unsloth/Qwen3-8B-GGUF --nctx 8192
+  ```
+
+- **Qualcomm AI Engine Direct (NPU)：** 上下文长度**固化在编译好的模型包中**，运行时无法抬升——`--nctx` 不生效。可改用：
+  - 加 `--sliding-window` 以在超限后继续对话：驱逐锚定前缀之外最旧的上下文，而不是报错。
+  - 如需真正更大的窗口，请从 [Qualcomm AI Hub](https://aihub.qualcomm.com/models/) 获取按更长上下文编译的模型包。参见 [Qualcomm AI Engine Direct 运行环境限制](/cn/get-started/platforms#运行环境限制)。
+
 ## **实用命令**
 
 | 命令 | 说明 | 示例 |

--- a/docs/en/resources/troubleshooting.mdx
+++ b/docs/en/resources/troubleshooting.mdx
@@ -31,6 +31,15 @@ import Feedback from "/snippets/page-feedback.mdx";
   <Accordion title="`--compute cpu` or `--compute gpu` errors with a Qualcomm AI Hub Model">
     Qualcomm AI Engine Direct is NPU-only. Use `--compute npu` (or omit the flag — `npu` is the default for `qairt`). To run on CPU/GPU, switch to a GGUF model on the [llama.cpp runtime](/en/get-started/platforms#llamacpp).
   </Accordion>
+
+  <Accordion title="`Context length exceeded` during a long chat">
+    The conversation outgrew the context window (`--nctx`, default 4096).
+
+    - **llama.cpp (GGUF):** raise it at runtime, e.g. `geniex infer <model> --nctx 8192`, up to the model's trained maximum. A larger window uses more memory.
+    - **Qualcomm AI Engine Direct (NPU):** the window is fixed in the compiled bundle and `--nctx` has no effect. Add `--sliding-window` to keep chatting (evicts the oldest context), or pull a bundle built for a longer context.
+
+    See [Increasing the context length](/en/run/cli/reference#increasing-the-context-length).
+  </Accordion>
 </AccordionGroup>
 
 ## **Server**

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -132,6 +132,20 @@ Control model loading, context, and generation limits.
 | `-s`, `--system-prompt` | string | — | System prompt to set model behavior. |
 | `--sliding-window` | — | `false` | (`qairt` only) Evict the oldest context above a small anchored prefix instead of erroring when the context length is exceeded, letting the conversation continue. |
 
+### Increasing the context length
+
+The context window (`--nctx`) is how much the model can hold at once. When a conversation grows past it you get a *context length exceeded* error. How to raise it depends on the runtime:
+
+- **llama.cpp (GGUF):** `--nctx <N>` raises the window at runtime, up to the model's trained maximum. A larger window uses more KV-cache memory.
+
+  ```bash
+  geniex infer unsloth/Qwen3-8B-GGUF --nctx 8192
+  ```
+
+- **Qualcomm AI Engine Direct (NPU):** the context length is **baked into the compiled bundle** and cannot be raised at runtime — `--nctx` has no effect. Instead:
+  - Add `--sliding-window` to keep chatting past the limit: the oldest context above a small anchored prefix is evicted instead of erroring.
+  - For a genuinely larger window, pull a bundle compiled for a longer context from [Qualcomm AI Hub](https://aihub.qualcomm.com/models/). See [Qualcomm AI Engine Direct runtime constraints](/en/get-started/platforms#runtime-constraints).
+
 ## **Utility commands**
 
 | Command | Description | Example |


### PR DESCRIPTION
## Summary

Address the docs + UX half of qcom-ai-hub/geniex#1357: users hit `context length exceeded` at the default 4096 window without realizing a flag controls it.

- **UX** (`fix(cli)`): the context-exceeded hint and the interactive auto-reset notice now name `--nctx` (llama_cpp, raises the window at runtime) and `--sliding-window` (qairt, fixed at compile time), instead of only saying "start a new conversation". Also clarify the `--nctx` flag help.
- **Docs** (`docs`): add an *Increasing the context length* section to the CLI reference and a *Context length exceeded* troubleshooting entry (en + cn), explaining the llama.cpp (runtime-raisable) vs Qualcomm AI Engine Direct (compile-time fixed, use `--sliding-window` or a longer-context bundle) distinction.

Scope is docs + UX only — truly extending the NPU context window is tracked separately (qcom-ai-hub/geniex#71).

## Test plan
- [x] `bazelisk test //cli/cmd/geniex/...` passes.
- [ ] Docs render check (Mintlify): reference + troubleshooting sections and cross-links resolve on en + cn.

Closes qcom-ai-hub/geniex#1357