### PR TITLE
feat(python): show progress bar during pip install SDK fetch

### DIFF
--- a/bindings/python/_sdk_fetch.py
+++ b/bindings/python/_sdk_fetch.py
@@ -120,7 +120,7 @@ def _download_with_progress(url: str, label: str) -> bytes | None:
                     unit='B',
                     unit_scale=True,
                     desc=f'[geniex] {label}',
-                    file=sys.stderr,
+                    file=_tty(),
                 ) as bar:
                     for chunk in iter(lambda: resp.read(65536), b''):
                         data.extend(chunk)
@@ -136,21 +136,35 @@ def _download_with_progress(url: str, label: str) -> bytes | None:
                             f'\r[geniex] {label}: {downloaded / 1048576:.1f}/{total / 1048576:.1f} MB ({pct}%)',
                             end='',
                             flush=True,
-                            file=sys.stderr,
+                            file=_tty(),
                         )
                     else:
                         print(
                             f'\r[geniex] {label}: {downloaded / 1048576:.1f} MB',
                             end='',
                             flush=True,
-                            file=sys.stderr,
+                            file=_tty(),
                         )
                 if downloaded:
-                    print(file=sys.stderr)
+                    print(file=_tty())
             return bytes(data)
     except (urllib.error.URLError, TimeoutError) as exc:
         print(f'[geniex] source unavailable: {url} ({exc})', file=sys.stderr)
         return None
+
+
+_tty_out = None
+
+
+def _tty():
+    global _tty_out
+    if _tty_out is None:
+        try:
+            name = 'CONOUT$' if sys.platform == 'win32' else '/dev/tty'
+            _tty_out = open(name, 'w', encoding='utf-8', errors='replace', buffering=1)
+        except OSError:
+            _tty_out = sys.stderr
+    return _tty_out
 
 
 def _file_url_to_path(url: str) -> Path:
@@ -347,7 +361,7 @@ def _range_fetch(zip_url: str, lib_dir: Path, backends: frozenset[Backend]) -> i
     n = len(to_extract)
     found_core = False
     for i, (entry, rel) in enumerate(to_extract, 1):
-        print(f'[geniex] ({i}/{n}) {rel}')
+        print(f'[geniex] ({i}/{n}) {rel}', file=_tty())
         if rel in _CORE_LIB_NAMES:
             found_core = True
         _extract_entry(zip_url, entry, lib_dir / rel)
@@ -397,10 +411,10 @@ def fetch(
     """
     lib_dir = pkg_dir / 'lib'
     if lib_dir.exists() and any(lib_dir.iterdir()):
-        print(f'[geniex] {lib_dir} already populated, skipping SDK download.')
+        print(f'[geniex] {lib_dir} already populated, skipping SDK download.', file=_tty())
         return
     if os.environ.get('GENIEX_SKIP_SDK_DOWNLOAD'):
-        print('[geniex] GENIEX_SKIP_SDK_DOWNLOAD set, skipping SDK download.')
+        print('[geniex] GENIEX_SKIP_SDK_DOWNLOAD set, skipping SDK download.', file=_tty())
         return
 
     backend_set = frozenset(backends)
@@ -446,7 +460,7 @@ def _try_one_source(
     successfully populating ``lib_dir``.
     """
     sha_url = f'{zip_url}.sha256'
-    print(f'[geniex] Trying {name}: {zip_url}')
+    print(f'[geniex] Trying {name}: {zip_url}', file=_tty())
 
     sha_bytes = _try_download(sha_url)
     # GENIEX_SDK_DOWNLOAD_URL is an explicit user opt-in to a specific source
@@ -471,7 +485,7 @@ def _try_one_source(
     try:
         count = _range_fetch(zip_url, lib_dir, backends)
     except (_RangeNotSupported, _ZIP64NotSupported) as exc:
-        print(f'[geniex] Range fetch unavailable on {name} ({exc}); falling back to full download.')
+        print(f'[geniex] Range fetch unavailable on {name} ({exc}); falling back to full download.', file=_tty())
         shutil.rmtree(lib_dir, ignore_errors=True)
         lib_dir.mkdir(parents=True, exist_ok=True)
     except (urllib.error.URLError, TimeoutError, RuntimeError) as exc:
@@ -479,8 +493,8 @@ def _try_one_source(
         shutil.rmtree(lib_dir, ignore_errors=True)
         return False
     else:
-        print(f'[geniex] Range-fetched {count} entries from {name}: {zip_url}')
-        print(f'[geniex] SDK libs installed at {lib_dir}')
+        print(f'[geniex] Range-fetched {count} entries from {name}: {zip_url}', file=_tty())
+        print(f'[geniex] SDK libs installed at {lib_dir}', file=_tty())
         return True
 
     label = zip_url.rsplit('/', 1)[-1]
@@ -499,6 +513,6 @@ def _try_one_source(
         errors.append(f'{zip_url} (full): {exc}')
         shutil.rmtree(lib_dir, ignore_errors=True)
         return False
-    print(f'[geniex] Full-zip extracted {count} entries from {name}: {zip_url}')
-    print(f'[geniex] SDK libs installed at {lib_dir}')
+    print(f'[geniex] Full-zip extracted {count} entries from {name}: {zip_url}', file=_tty())
+    print(f'[geniex] SDK libs installed at {lib_dir}', file=_tty())
     return True

--- a/bindings/python/_sdk_fetch.py
+++ b/bindings/python/_sdk_fetch.py
@@ -106,6 +106,53 @@ def _try_download(url: str) -> bytes | None:
         return None
 
 
+def _download_with_progress(url: str, label: str) -> bytes | None:
+    """Stream ``url`` with a progress display; returns bytes or None on failure."""
+    try:
+        with urllib.request.urlopen(url) as resp:
+            total = int(resp.headers.get('Content-Length') or 0)
+            data = bytearray()
+            try:
+                from tqdm import tqdm
+
+                with tqdm(
+                    total=total or None,
+                    unit='B',
+                    unit_scale=True,
+                    desc=f'[geniex] {label}',
+                    file=sys.stderr,
+                ) as bar:
+                    for chunk in iter(lambda: resp.read(65536), b''):
+                        data.extend(chunk)
+                        bar.update(len(chunk))
+            except ImportError:
+                downloaded = 0
+                for chunk in iter(lambda: resp.read(65536), b''):
+                    data.extend(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        pct = downloaded * 100 // total
+                        print(
+                            f'\r[geniex] {label}: {downloaded / 1048576:.1f}/{total / 1048576:.1f} MB ({pct}%)',
+                            end='',
+                            flush=True,
+                            file=sys.stderr,
+                        )
+                    else:
+                        print(
+                            f'\r[geniex] {label}: {downloaded / 1048576:.1f} MB',
+                            end='',
+                            flush=True,
+                            file=sys.stderr,
+                        )
+                if downloaded:
+                    print(file=sys.stderr)
+            return bytes(data)
+    except (urllib.error.URLError, TimeoutError) as exc:
+        print(f'[geniex] source unavailable: {url} ({exc})', file=sys.stderr)
+        return None
+
+
 def _file_url_to_path(url: str) -> Path:
     parsed = urllib.parse.urlparse(url)
     return Path(urllib.request.url2pathname(parsed.path))
@@ -292,19 +339,21 @@ def _range_fetch(zip_url: str, lib_dir: Path, backends: frozenset[Backend]) -> i
     cd_bytes = _fetch_range(zip_url, cd_offset, cd_offset + cd_size - 1)
     entries = _parse_central_directory(cd_bytes)
 
-    extracted = 0
-    found_core = False
+    to_extract = []
     for entry in entries:
         rel = _classify_entry(entry.filename, backends)
-        if rel is None:
-            continue
+        if rel is not None:
+            to_extract.append((entry, rel))
+    n = len(to_extract)
+    found_core = False
+    for i, (entry, rel) in enumerate(to_extract, 1):
+        print(f'[geniex] ({i}/{n}) {rel}')
         if rel in _CORE_LIB_NAMES:
             found_core = True
         _extract_entry(zip_url, entry, lib_dir / rel)
-        extracted += 1
     if not found_core:
         raise RuntimeError(f'{zip_url}: no core libgeniex/geniex.dll entry in central directory')
-    return extracted
+    return n
 
 
 def _full_extract(zip_bytes: bytes, lib_dir: Path, backends: frozenset[Backend]) -> int:
@@ -434,7 +483,8 @@ def _try_one_source(
         print(f'[geniex] SDK libs installed at {lib_dir}')
         return True
 
-    zip_bytes = _try_download(zip_url)
+    label = zip_url.rsplit('/', 1)[-1]
+    zip_bytes = _download_with_progress(zip_url, label)
     if zip_bytes is None:
         errors.append(f'{zip_url}: download failed')
         return False


### PR DESCRIPTION
## Summary
- Add `_download_with_progress` to stream the full-zip download with a tqdm bar (already a declared dep) when available, falling back to a `\r` byte-count display using only stdlib
- Update `_range_fetch` to pre-collect matching entries and print a `(i/n) rel` counter per entry
- Route all progress output through `_tty()`, which opens `CONOUT$` (Windows) / `/dev/tty` (Unix) so output bypasses pip's build-subprocess stdout/stderr capture and appears directly on the user's terminal; falls back to `sys.stderr` when no TTY is available (CI, headless)

## Test plan
- [x] tqdm progress bar: directly invoked `_download_with_progress` against the 83.8 MB S3 zip — bar rendered with %, speed, ETA
- [x] stdlib fallback: mocked `tqdm` ImportError, confirmed `\r` byte-count line + trailing newline
- [x] range-fetch counter: `fetch(..., backends=['llama-cpp'])` on windows-arm64 printed `(1/17)` through `(17/17)` and returned correct count
- [x] pip capture bypass: `open('CONOUT$', 'w')` write confirmed to appear on terminal while absent from `2>&1` capture; `pip install --no-binary :all: geniex==0.3.19a1` built an 83 MB wheel successfully with SDK fetched