### PR TITLE
feat(cli): add --log flag equivalent to GENIEX_LOG

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -8,16 +8,22 @@ Command-line interface for running AI models locally on **Qualcomm** chipsets. I
 
 | Value   | Emits                                    |
 |---------|------------------------------------------|
-| `none`  | nothing                                  |
+| `none`  | nothing (**CLI default**)                |
 | `error` | errors only                              |
 | `warn`  | warnings + errors                        |
-| `info`  | info + warnings + errors (**default**)   |
+| `info`  | info + warnings + errors                 |
 | `debug` | debug + info + warnings + errors         |
-| `trace` | everything (requires a debug build)      |
+| `trace` | everything                               |
 
 ```bash
 export GENIEX_LOG="debug"          # bash / zsh
 $env:GENIEX_LOG="debug"            # PowerShell
+```
+
+The `--log` flag is equivalent and takes precedence over `GENIEX_LOG` when both are set:
+
+```bash
+geniex --log debug list
 ```
 
 `NO_COLOR=1` disables ANSI colors.

--- a/cli/README_zh.md
+++ b/cli/README_zh.md
@@ -8,16 +8,22 @@
 
 | 取值    | 输出内容                                 |
 |---------|------------------------------------------|
-| `none`  | 无输出                                   |
+| `none`  | 无输出（**CLI 默认**）                   |
 | `error` | 仅错误                                   |
 | `warn`  | 警告 + 错误                              |
-| `info`  | 信息 + 警告 + 错误（**默认**）           |
+| `info`  | 信息 + 警告 + 错误                       |
 | `debug` | 调试 + 信息 + 警告 + 错误                |
-| `trace` | 全部输出（需要 debug 构建）              |
+| `trace` | 全部输出                                 |
 
 ```bash
 export GENIEX_LOG="debug"          # bash / zsh
 $env:GENIEX_LOG="debug"            # PowerShell
+```
+
+`--log` 参数与之等效，且当二者同时设置时优先于 `GENIEX_LOG`：
+
+```bash
+geniex --log debug list
 ```
 
 设置 `NO_COLOR=1` 可关闭 ANSI 颜色。

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -38,8 +38,6 @@ func RootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			cmd.SilenceErrors = true
-
 			subCmd := cmd.CalledAs()
 
 			// Skip ModelInit for commands that don't touch the model manager

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -38,6 +38,10 @@ func RootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Re-apply now that flags are parsed so --log takes effect; the
+			// call in main() runs before parsing and only sees GENIEX_LOG.
+			common.ApplyLogLevel()
+
 			subCmd := cmd.CalledAs()
 
 			// Skip ModelInit for commands that don't touch the model manager
@@ -80,6 +84,8 @@ func RootCmd() *cobra.Command {
 	}
 	rootCmd.PersistentFlags().StringVarP(&dataDir, "data-dir", "", "", "Custom data directory (env: GENIEX_DATADIR)")
 	viper.BindPFlag("datadir", rootCmd.PersistentFlags().Lookup("data-dir"))
+	rootCmd.PersistentFlags().String("log", "none", "Log level: none, error, warn, info, debug, trace (env: GENIEX_LOG)")
+	viper.BindPFlag("log", rootCmd.PersistentFlags().Lookup("log"))
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "Enable verbose output")
 	rootCmd.PersistentFlags().BoolVarP(&skipUpdate, "skip-update", "", false, "Skip checking for updates")
 	rootCmd.PersistentFlags().BoolVarP(&testMode, "test-mode", "", false, "Enable test mode")

--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -95,6 +95,23 @@ Describe this picture </full/path/to/image.png>
 geniex serve
 ```
 
+## **日志**
+
+`--log` 是全局标志，控制 CLI 的日志输出。它与 `GENIEX_LOG` 环境变量等效，且当二者同时设置时优先于 `GENIEX_LOG`。
+
+```bash
+geniex --log debug list
+```
+
+| 取值 | 输出内容 |
+|---|---|
+| `none` | 无输出（**CLI 默认**） |
+| `error` | 仅错误 |
+| `warn` | 警告 + 错误 |
+| `info` | 信息 + 警告 + 错误 |
+| `debug` | 调试 + 信息 + 警告 + 错误 |
+| `trace` | 全部输出 |
+
 ## **配置标志**
 
 以下标志可传给 `geniex infer`，用于控制模型加载与生成行为。

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -95,6 +95,23 @@ Start the OpenAI-compatible local server. See [Local server](/en/run/cli/local-s
 geniex serve
 ```
 
+## **Logging**
+
+`--log` is a global flag controlling the CLI's log output. It is equivalent to the `GENIEX_LOG` environment variable and takes precedence over it when both are set.
+
+```bash
+geniex --log debug list
+```
+
+| Value | Emits |
+|---|---|
+| `none` | nothing (**CLI default**) |
+| `error` | errors only |
+| `warn` | warnings + errors |
+| `info` | info + warnings + errors |
+| `debug` | debug + info + warnings + errors |
+| `trace` | everything |
+
 ## **Configuration flags**
 
 These flags can be passed to `geniex infer` to control model loading and generation.


### PR DESCRIPTION
## What

Adds a global `--log` flag to the CLI that sets the log level, mirroring the existing `GENIEX_LOG` environment variable. This brings log level in line with other CLI options that already expose a flag alongside their env var (`--compute`, `--nctx`, `--data-dir`, …).

```bash
geniex --log debug list
```

## How

- New persistent `--log` flag on the root command, bound to the existing viper `log` key. viper gives an explicitly-set flag precedence over the env var, while an unset flag still falls back to `GENIEX_LOG` then the default.
- `ApplyLogLevel()` is re-run in `PersistentPreRun`: the existing call in `main()` happens *before* flags are parsed, so it only ever sees `GENIEX_LOG`. Re-applying after parse lets `--log` take effect.

## Docs

- Documented `--log` in `cli/README.md` / `README_zh.md` and the CLI reference (en/cn).
- Corrected the log-level tables while there: the **CLI default is `none`** (was mislabeled `info`), and `trace` does **not** require a debug build.

## Drive-by

- Dropped a redundant `cmd.SilenceErrors = true` in `PersistentPreRun` (separate commit) — the root command already sets `SilenceErrors: true`, which cobra applies to all subcommands, so the re-set had no effect. Verified error output across all subcommands is unaffected (no swallowed or duplicated errors).

## Testing

- `bazelisk build //cli` passes.
- Verified `--log debug` emits debug logs, `GENIEX_LOG` still works, `--log` overrides the env var, and the default stays silent.

Implements qualcomm/GenieX#1362 (tracked at https://github.com/qcom-ai-hub/geniex/issues/1362).