### PR TITLE
fix(sdk): patch llama.cpp OpenCL cpy kernel for Adreno

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -139,27 +139,35 @@ enable_testing()
 #   the llama.cpp plugin to tear down HTP FastRPC channels on model unload so
 #   QAIRT's HTP re-init is not poisoned by stale sessions. See
 #   sdk/plugins/llama_cpp/src/llm.cpp for the caller.
+# * llama-opencl-adreno-cpy-constreg.patch works around an Adreno OpenCL
+#   compiler crash: kernel_cpy_f32_f32_pack's min(ne00, get_local_size(0))
+#   emits an IMINrr with two constant-class operands, which the driver's
+#   instruction validator rejects (NumConstRegsError). See GenieX #1250.
 if(GENIEX_PLUGIN_LLAMA_CPP)
     set(_LLAMA_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/../third-party/llama.cpp")
-    set(_LLAMA_PATCH "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-hexagon-release-sessions.patch")
-    if(EXISTS "${_LLAMA_PATCH}")
-        find_package(Git QUIET REQUIRED)
-        execute_process(
-            COMMAND ${GIT_EXECUTABLE} -C "${_LLAMA_DIR}" apply --reverse --check "${_LLAMA_PATCH}"
-            RESULT_VARIABLE _reverse_check_rc
-            OUTPUT_QUIET ERROR_QUIET)
-        if(NOT _reverse_check_rc EQUAL 0)
-            message(STATUS "Applying llama.cpp patch: ${_LLAMA_PATCH}")
+    set(_LLAMA_PATCHES
+        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-hexagon-release-sessions.patch"
+        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-cpy-constreg.patch")
+    find_package(Git QUIET REQUIRED)
+    foreach(_LLAMA_PATCH ${_LLAMA_PATCHES})
+        if(EXISTS "${_LLAMA_PATCH}")
             execute_process(
-                COMMAND ${GIT_EXECUTABLE} -C "${_LLAMA_DIR}" apply "${_LLAMA_PATCH}"
-                RESULT_VARIABLE _apply_rc)
-            if(NOT _apply_rc EQUAL 0)
-                message(FATAL_ERROR
-                    "Failed to apply ${_LLAMA_PATCH} to ${_LLAMA_DIR}. "
-                    "If the submodule was bumped, refresh the patch against the new tip.")
+                COMMAND ${GIT_EXECUTABLE} -C "${_LLAMA_DIR}" apply --reverse --check "${_LLAMA_PATCH}"
+                RESULT_VARIABLE _reverse_check_rc
+                OUTPUT_QUIET ERROR_QUIET)
+            if(NOT _reverse_check_rc EQUAL 0)
+                message(STATUS "Applying llama.cpp patch: ${_LLAMA_PATCH}")
+                execute_process(
+                    COMMAND ${GIT_EXECUTABLE} -C "${_LLAMA_DIR}" apply "${_LLAMA_PATCH}"
+                    RESULT_VARIABLE _apply_rc)
+                if(NOT _apply_rc EQUAL 0)
+                    message(FATAL_ERROR
+                        "Failed to apply ${_LLAMA_PATCH} to ${_LLAMA_DIR}. "
+                        "If the submodule was bumped, refresh the patch against the new tip.")
+                endif()
             endif()
         endif()
-    endif()
+    endforeach()
 endif()
 
 # headers

--- a/sdk/patches/llama-opencl-adreno-cpy-constreg.patch
+++ b/sdk/patches/llama-opencl-adreno-cpy-constreg.patch
@@ -1,0 +1,18 @@
+diff --git a/ggml/src/ggml-opencl/kernels/cpy.cl b/ggml/src/ggml-opencl/kernels/cpy.cl
+index adbd2e766..89aeb1cca 100644
+--- a/ggml/src/ggml-opencl/kernels/cpy.cl
++++ b/ggml/src/ggml-opencl/kernels/cpy.cl
+@@ -208,7 +208,12 @@ kernel void kernel_cpy_f32_f32_pack(
+     src0 = (global float*)((global char*)src0 + offset0);
+     dst = (global float*)((global char*)dst + offsetd);
+ 
+-    int lsz = get_local_size(0);
++    // Adreno's instruction validator rejects min(uniform, constant): the
++    // resulting IMINrr would carry two constant-class operands (ne00 is a
++    // uniform reg, get_local_size(0) a constant reg). Force lsz into a GPR
++    // via volatile to break the pairing.
++    volatile int lsz_v = get_local_size(0);
++    int lsz = lsz_v;
+     int tpr = min(ne00, lsz);          // threads per row
+     int rpw = lsz / tpr;               // rows per workgroup
+     int lid = get_local_id(0);


### PR DESCRIPTION
Work around an Adreno OpenCL compiler crash that makes `--compute gpu` and `--compute hybrid` unusable on QCS9075 (Adreno 663). Fixes https://github.com/qualcomm/GenieX/issues/1250.

## Root cause

`kernel_cpy_f32_f32_pack` (`ggml/src/ggml-opencl/kernels/cpy.cl`) computes `min(ne00, get_local_size(0))`. `ne00` is a uniform register and `get_local_size(0)` a constant register, so the resulting `IMINrr` carries two constant-class operands — which the driver's instruction validator rejects:

```
NumConstRegsError: # of constant registers must be < 2.
Assertion failed: "back-end instruction validation failed"
.../QGPUInstructionValidator.cpp:440
```

`clBuildProgram` returns -6 and the plugin `exit(1)`s at model load. Introduced upstream by ggml-org/llama.cpp#24160.

## Fix

Route `get_local_size(0)` through a `volatile` temp so it lands in a GPR, breaking the constant-register pairing. This is the only variant that survives the Adreno optimizer (per the on-device matrix in #1250).

Delivered as `sdk/patches/llama-opencl-adreno-cpy-constreg.patch`, applied at configure time via the existing patch mechanism — the llama.cpp submodule stays pinned to its upstream commit. `sdk/CMakeLists.txt` now iterates a list of patches instead of a single hardcoded file.

## Verification

Cross-compiled for Linux arm64 and run on qdc (Adreno):

```
./geniex infer unsloth/Qwen3.5-4B-GGUF --compute gpu
```

Model loads (all OpenCL kernels compile), generates normally, no `NumConstRegsError`. Same model/flag that reproduced the crash in #1250.

## Notes

- No FFI change (`geniex.h` untouched).
- `volatile` only forces a register-class change; the value is unchanged, so output is bit-identical and the perf cost (one register round-trip in a cold, bandwidth-bound copy kernel) is negligible.
- Worth submitting the one-liner upstream too — this is an unreported llama.cpp bug.