### PR TITLE
fix(sdk): reacquire HTP sessions on all devices, not just NPU

### DIFF
--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -43,11 +43,12 @@ int32_t LlamaLlm::create(const geniex_LlmCreateInput* input) {
     // MoE override + null terminator; must outlive the load_from_file call below.
     llama_model_tensor_buft_override tensor_overrides[2];
 
-    // FIX: HTP backend patch — only reacquire HTP sessions when we're actually
-    // going to use them (npu / hybrid). CPU and GPU targets shouldn't be gated
-    // on the ADSP domain's health.
+    // FIX: HTP backend patch — reacquire whenever the HTP backend is present
+    // in the ggml registry, regardless of the current target device. Any load
+    // walks the registry's device list, and a stale session pointer left from
+    // a prior release_sessions crashes the load even on cpu / gpu targets.
     {
-        if (device == Device::NPU) {
+        if (htp::htp_backend_present()) {
             htp::reacquire_before_load();
         }
     }

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -38,10 +38,10 @@ int32_t LlamaVlm::create(const geniex_VlmCreateInput* input) {
     const Device              device = classify_device(input->device_id, input->config.n_gpu_layers);
     const geniex_ModelConfig& config = input->config;
 
-    // See llm.cpp for the rationale behind the HTP session release/reacquire
-    // dance. Only reacquire when we're actually going to use HTP — CPU/GPU
-    // targets shouldn't touch the ADSP domain.
-    if (device == Device::NPU) {
+    // See llm.cpp: reacquire whenever the HTP backend is registered, since
+    // any llama.cpp load walks the registry's device list and a stale session
+    // pointer left from a prior release will crash the load on cpu / gpu too.
+    if (htp::htp_backend_present()) {
         htp::reacquire_before_load();
     }
 


### PR DESCRIPTION
## Summary

- `test-sdk-qdc` has been failing on all three legs since v0.3.18-alpha.2 with `Windows fatal exception: access violation` in `geniex_llm_create` / `geniex_vlm_create`.
- Root cause: `SessionGuard::release_if_last` releases the shared HTP sessions on the last llama.cpp destructor unconditionally, but the reacquire hook in `LlamaLlm::create` / `LlamaVlm::create` was gated to `device == Device::NPU`. Any load walks the ggml registry's device list, so the next `llama_model_load_from_file` — even on cpu / gpu — dereferences the stale HTP session pointer at offset 0x18.
- Fix: gate the reacquire on `htp::htp_backend_present()` instead, matching how `mark_htp` decides whether to participate in the shared refcount.

## Test plan

- [x] Local repeat-load repro on Windows-on-Snapdragon (three back-to-back cpu creates + destroys succeed; prior build crashed on the second create).
- [x] `pytest tests/plugins/llama_cpp/test_llama_cpp_llm.py -k "generate_stream or quality_keywords or multi_turn_recalls or ngram_simple"` on the same host — 15 / 16 pass (only the pre-existing `Paris-npu` early-stop assertion remains, unrelated to the HTP session dance).
- [x] `test-sdk-qdc` on this PR — pending CI.