### PR TITLE
build(release): rename Python sdist assets to match other release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,10 @@ jobs:
           mv geniex-cli-setup.exe "geniex-cli-setup-windows-arm64-${RELEASE_TAG}.exe"
           mv geniex-android-aar.aar "geniex-android-aar-${RELEASE_TAG}.aar"
 
+          mv geniex-*.tar.gz "geniex-pysdist-${RELEASE_TAG}.tar.gz"
+          mv geniex_llama_cpp-*.tar.gz "geniex-pysdist-llama_cpp-${RELEASE_TAG}.tar.gz"
+          mv geniex_qairt-*.tar.gz "geniex-pysdist-qairt-${RELEASE_TAG}.tar.gz"
+
           staged="geniex-cli-linux-arm64-${RELEASE_TAG}"
           mkdir -p "${staged}"
           unzip -q cli-linux-arm64/artifact.zip -d "${staged}"

--- a/bindings/python/BUILD.md
+++ b/bindings/python/BUILD.md
@@ -51,9 +51,9 @@ pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/
 pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple geniex-qairt
 
 # From GitHub Release (canonical) — pick the distribution you need
-pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex-0.0.3a1.tar.gz
-pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex_llama_cpp-0.0.3a1.tar.gz
-pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex_qairt-0.0.3a1.tar.gz
+pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex-pysdist-v0.0.3-alpha.1.tar.gz
+pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex-pysdist-llama_cpp-v0.0.3-alpha.1.tar.gz
+pip install https://github.com/qualcomm/GenieX/releases/download/v0.0.3-alpha.1/geniex-pysdist-qairt-v0.0.3-alpha.1.tar.gz
 ```
 
 ### Supported platforms (automatic SDK download)

--- a/notes/release.md
+++ b/notes/release.md
@@ -8,7 +8,7 @@ git tag v1.2.3 && git push origin v1.2.3
 
 - Tags containing `-` are drafts (and push the sdist to TestPyPI).
 - Bare `vX.Y.Z` tags publish immediately (and push the sdist to production PyPI).
-- Assets: `geniex-sdk-{linux,windows}-arm64-<tag>.zip`, `geniex-cli-linux-arm64-<tag>.tar.gz`, `geniex-cli-setup-windows-arm64-<tag>.exe`, `*.whl`, `*.aar`, and per-file `.sha256` sidecars.
+- Assets: `geniex-sdk-{linux,windows}-arm64-<tag>.zip`, `geniex-cli-linux-arm64-<tag>.tar.gz`, `geniex-cli-setup-windows-arm64-<tag>.exe`, `geniex-android-aar-<tag>.aar`, `geniex-bench-{linux,windows,android}-arm64-<tag>.{tar.gz,zip}`, `geniex-pysdist{,-llama_cpp,-qairt}-<tag>.tar.gz`, and per-file `.sha256` sidecars.
 - Re-running the same tag via **Actions → Release → Run workflow** is safe **as long as you set "Use workflow from" to the tag** (Tags tab in the dropdown). Dispatching from `main` is rejected by `resolve-tag` so the workflow never builds a tag against the wrong commit.
 - S3 mirror at `s3://qaihub-public-assets/qai-hub-geniex/` — see [§ S3 mirror & manifest](#s3-mirror--manifest) below.
 


### PR DESCRIPTION
## Summary

On the GitHub Release page, the three Python source-distribution assets look inconsistent next to every other artifact from the same tag:

| Currently | Everything else |
|---|---|
| `geniex-0.3.19a3.tar.gz` | `geniex-cli-linux-arm64-v0.3.19-alpha.3.tar.gz` |
| `geniex_llama_cpp-0.3.19a3.tar.gz` | `geniex-android-aar-v0.3.19-alpha.3.aar` |
| `geniex_qairt-0.3.19a3.tar.gz` | `geniex-sdk-windows-arm64-v0.3.19-alpha.3.zip` |

Three problems: (1) bare `geniex-…` gives no hint that this is a Python sdist; (2) PEP-440 form `0.3.19a3` differs from the `v0.3.19-alpha.3` tag used elsewhere; (3) `geniex_llama_cpp` / `geniex_qairt` join name + backend with an underscore, but every other asset separates fields with hyphens.

Root cause: `python -m build --sdist` names its output `<pep625-normalized-name>-<pep440-version>.tar.gz` from the sdist's own `pyproject.toml`; unlike the CLI / SDK / bench / AAR artifacts, no downstream step renames it to the release-asset convention.

This PR renames only the **release asset**. It does not touch `[project].name` or the internal PEP-440 version, so PyPI publishing and `pip install geniex[…]` are unaffected — `publish-pypi` reads the un-renamed workflow artifact.

After this PR, the release page shows:

- `geniex-pysdist-v<tag>.tar.gz`
- `geniex-pysdist-llama_cpp-v<tag>.tar.gz`
- `geniex-pysdist-qairt-v<tag>.tar.gz`

`pysdist` is a single-token marker of "Python source distribution"; `llama_cpp` keeps its underscore because that is the canonical backend identifier (`sdk/plugins/llama_cpp/`, `--backend llama_cpp`).

Changes:
- `.github/workflows/release.yml` — three `mv` lines in `package-release`, before the `sha256sum` sidecar loop (sidecars follow automatically).
- `bindings/python/BUILD.md` — the three `pip install <URL>` examples.
- `notes/release.md` — asset-list line was stale (`*.whl` — no wheels are shipped) and missing the sdists / AAR / bench archives; refreshed.

## Test plan

- [x] `geniex-*.tar.gz` glob in the new rename block matches only the top-level sdist (not `geniex_llama_cpp-*.tar.gz` / `geniex_qairt-*.tar.gz`), and no other `.tar.gz` files are present at that point in the workflow — dry-run:
  ```
  $ touch geniex-0.3.19a3.tar.gz geniex_llama_cpp-0.3.19a3.tar.gz geniex_qairt-0.3.19a3.tar.gz
  $ RELEASE_TAG=v0.3.19-alpha.3
  $ mv geniex-*.tar.gz "geniex-pysdist-${RELEASE_TAG}.tar.gz"
  $ mv geniex_llama_cpp-*.tar.gz "geniex-pysdist-llama_cpp-${RELEASE_TAG}.tar.gz"
  $ mv geniex_qairt-*.tar.gz "geniex-pysdist-qairt-${RELEASE_TAG}.tar.gz"
  $ ls
  geniex-pysdist-llama_cpp-v0.3.19-alpha.3.tar.gz
  geniex-pysdist-qairt-v0.3.19-alpha.3.tar.gz
  geniex-pysdist-v0.3.19-alpha.3.tar.gz
  ```
- [x] End-to-end verified on the next real pre-release tag: release page shows exactly the three new asset names + matching `.sha256` sidecars, and `publish-pypi` still uploads `geniex` / `geniex-llama-cpp` / `geniex-qairt` with their internal versions unchanged — pending, cannot repro locally without cutting a tag.