### PR TITLE
fix(cli): route --spec-type through the LLM path for VLM-classified models

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -138,7 +138,14 @@ func infer() *cobra.Command {
 			return err
 		}
 
-		switch paths.ModelType {
+		effectiveType := paths.ModelType
+		if effectiveType == geniex_sdk.ModelTypeVLM && specType != "" {
+			fmt.Println(render.GetTheme().Warning.Sprintf(
+				"Warning: --spec-type set on a VLM-classified model; running the LLM path, image / audio inputs will be ignored"))
+			effectiveType = geniex_sdk.ModelTypeLLM
+		}
+
+		switch effectiveType {
 		case geniex_sdk.ModelTypeLLM:
 			err = inferLLM(cmd.Context(), paths)
 		case geniex_sdk.ModelTypeVLM:

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -143,7 +143,14 @@ func ChatCompletions(c *gin.Context) {
 		modelParam.NCtx = int32(param.MaxCompletionTokens.Value)
 	}
 
-	switch modelType {
+	effectiveType := modelType
+	if effectiveType == geniex_sdk.ModelTypeVLM && param.SpecType != "" {
+		slog.Warn("spec_type set on VLM-classified model; running LLM path, image/audio content will be ignored",
+			"model", param.Model, "spec_type", param.SpecType)
+		effectiveType = geniex_sdk.ModelTypeLLM
+	}
+
+	switch effectiveType {
 	case geniex_sdk.ModelTypeLLM:
 		chatCompletionsLLM(c, param, modelParam)
 	case geniex_sdk.ModelTypeVLM:

--- a/docs/en/tutorials/compute/speculative-decoding-mtp.mdx
+++ b/docs/en/tutorials/compute/speculative-decoding-mtp.mdx
@@ -17,6 +17,8 @@ This tutorial enables MTP for **Gemma-4-26B-A4B** on the Hexagon NPU, in `geniex
 
 <Note>Speculative decoding is **`llama_cpp`-only**. On the `qairt` runtime these flags are ignored with a warning rather than an error — `qairt` "SSD" bundles carry their own NPU acceleration that GenieX applies automatically.</Note>
 
+<Note>MTP is **text-only** — upstream llama.cpp's speculative path doesn't currently combine with image / audio inputs. If `--spec-type` is set on a model that GenieX classified as multimodal (mmproj sibling in the repo), GenieX runs the LLM path and drops any image / audio content with a warning; the model itself is unchanged and remains usable for multimodal inference without `--spec-type`.</Note>
+
 ## **Prerequisites**
 
 - The CLI installed — see [Install](/en/run/cli/install).


### PR DESCRIPTION
## Summary

When a HuggingFace repo ships a co-located `-mmproj.gguf` (e.g.
`google/gemma-4-26B-A4B-it-qat-q4_0-gguf`), `geniex pull` classifies the model
as VLM. The CLI / server then dispatch to the VLM plugin path, which never
wires up `common_speculative` regardless of `--spec-type` / `spec_type`, so
speculative decoding silently no-ops and the mtmd path produces degenerate
output for text-only requests (`prompt_tokens=1`, `stop_reason=length`) or
crashes with `dspqueue_read` on X2 Elite HTP.

Preflight the two dispatch `switch`es (`cli/cmd/geniex/infer.go`,
`cli/server/handler/chat.go`): when `--spec-type` / `spec_type` is set on a
VLM-classified model, route through the LLM path and warn that image /
audio inputs in that same request are dropped. The plain VLM path is
unchanged for requests without a spec type set.

Tutorial (`docs/en/tutorials/compute/speculative-decoding-mtp.mdx`) gets a
one-line note that MTP is text-only — upstream llama.cpp's speculative
path doesn't currently combine with image / audio inputs (`--mmproj` +
`--spec-type` server crashes in `ggml-opencl.cpp` `GGML_ASSERT(dst->extra)`
on the first image request).

Related: #1090 fixed the same misclassification pattern in `geniex-bench`;
the CLI / server paths were not updated.

## Test plan

- [x] Snapdragon X2 Elite HTP + gemma-4-26B (VLM-classified) + `--compute npu --spec-type draft-mtp --draft-model RachidAR/... --draft-tokens 3 -p Hi` → coherent output, `stop` finish, non-zero draft accept rate; warning line about VLM→LLM re-route printed. Measured 30.4 tok/s decode / 72% draft acceptance
- [x] Server `/v1/chat/completions` with `spec_type: draft-mtp` on the same model → HTTP 200 with `finish_reason: stop`, `prompt_tokens: 17` (LLM path — VLM path would have been 1); `slog.Warn` line lands in the server log when `--log warn` or higher is set