### PR TITLE
fix(cli): echo compute alias in model-loaded line

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -237,13 +237,17 @@ func loadStopSequences() ([]string, error) {
 	return stopSequences, nil
 }
 
-// modelLoadedLine formats a one-line summary of what the inference session
-// actually got, printed after the model is loaded when --verbose is set. It's
-// a pure helper so tests can pin the output without touching the SDK.
-func modelLoadedLine(runtimeID, deviceID string, ngl, nctx int32) string {
+// modelLoadedLine summarizes the loaded session for --verbose. device echoes
+// the user alias, not the SDK's device_id (cpu/hybrid resolve to an empty one).
+// Mirrors geniex_resolve_device: empty/"auto" and qairt → npu.
+func modelLoadedLine(runtimeID, computeUnit string, ngl, nctx int32) string {
+	device := strings.ToLower(strings.TrimSpace(computeUnit))
+	if runtimeID == geniex_sdk.RuntimeQairt || device == "" || device == "auto" {
+		device = geniex_sdk.ComputeUnitNPU
+	}
 	parts := []string{
 		fmt.Sprintf("backend=%s", runtimeID),
-		fmt.Sprintf("device=%s", deviceID),
+		fmt.Sprintf("device=%s", device),
 	}
 	if runtimeID == geniex_sdk.RuntimeLlamaCpp {
 		parts = append(parts,
@@ -351,7 +355,7 @@ func inferLLM(ctx context.Context, paths *geniex_sdk.ModelPaths) error {
 	defer p.Destroy()
 
 	if verbose {
-		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, deviceID, nglResolved, nctxResolved)))
+		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, computeUnit, nglResolved, nctxResolved)))
 	}
 
 	var history []geniex_sdk.LlmChatMessage
@@ -511,7 +515,7 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 	defer p.Destroy()
 
 	if verbose {
-		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, deviceID, nglResolved, nctxResolved)))
+		fmt.Println(render.GetTheme().Info.Sprint(modelLoadedLine(paths.RuntimeID, computeUnit, nglResolved, nctxResolved)))
 	}
 
 	caps, _ := p.Capabilities()

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -237,17 +237,17 @@ func loadStopSequences() ([]string, error) {
 	return stopSequences, nil
 }
 
-// modelLoadedLine summarizes the loaded session for --verbose. device echoes
+// modelLoadedLine summarizes the loaded session for --verbose. compute echoes
 // the user alias, not the SDK's device_id (cpu/hybrid resolve to an empty one).
 // Mirrors geniex_resolve_device: empty/"auto" and qairt → npu.
 func modelLoadedLine(runtimeID, computeUnit string, ngl, nctx int32) string {
-	device := strings.ToLower(strings.TrimSpace(computeUnit))
-	if runtimeID == geniex_sdk.RuntimeQairt || device == "" || device == "auto" {
-		device = geniex_sdk.ComputeUnitNPU
+	computeUnit = strings.ToLower(strings.TrimSpace(computeUnit))
+	if runtimeID == geniex_sdk.RuntimeQairt || computeUnit == "" || computeUnit == "auto" {
+		computeUnit = geniex_sdk.ComputeUnitNPU
 	}
 	parts := []string{
-		fmt.Sprintf("backend=%s", runtimeID),
-		fmt.Sprintf("device=%s", device),
+		fmt.Sprintf("runtime=%s", runtimeID),
+		fmt.Sprintf("compute=%s", computeUnit),
 	}
 	if runtimeID == geniex_sdk.RuntimeLlamaCpp {
 		parts = append(parts,

--- a/cli/cmd/geniex/infer_test.go
+++ b/cli/cmd/geniex/infer_test.go
@@ -19,27 +19,27 @@ func TestModelLoadedLine(t *testing.T) {
 		{
 			name:      "llama_cpp npu shows alias, ngl/nctx",
 			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "npu", ngl: 32, nctx: 4096,
-			want: "Model loaded: backend=llama_cpp device=npu ngl=32 nctx=4096",
+			want: "Model loaded: runtime=llama_cpp compute=npu ngl=32 nctx=4096",
 		},
 		{
 			name:      "llama_cpp cpu echoes alias (device_id is empty)",
 			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "cpu", ngl: 0, nctx: 2048,
-			want: "Model loaded: backend=llama_cpp device=cpu ngl=0 nctx=2048",
+			want: "Model loaded: runtime=llama_cpp compute=cpu ngl=0 nctx=2048",
 		},
 		{
 			name:      "llama_cpp hybrid echoes alias (device_id is empty)",
 			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "hybrid", ngl: -1, nctx: 4096,
-			want: "Model loaded: backend=llama_cpp device=hybrid ngl=-1 nctx=4096",
+			want: "Model loaded: runtime=llama_cpp compute=hybrid ngl=-1 nctx=4096",
 		},
 		{
 			name:      "llama_cpp empty compute defaults to npu",
 			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "", ngl: -1, nctx: 4096,
-			want: "Model loaded: backend=llama_cpp device=npu ngl=-1 nctx=4096",
+			want: "Model loaded: runtime=llama_cpp compute=npu ngl=-1 nctx=4096",
 		},
 		{
 			name:      "qairt fixed to npu, hides ngl/nctx",
 			runtimeID: geniex_sdk.RuntimeQairt, computeUnit: "cpu", ngl: 0, nctx: 0,
-			want: "Model loaded: backend=qairt device=npu",
+			want: "Model loaded: runtime=qairt compute=npu",
 		},
 	}
 	for _, tt := range tests {

--- a/cli/cmd/geniex/infer_test.go
+++ b/cli/cmd/geniex/infer_test.go
@@ -11,30 +11,40 @@ import (
 
 func TestModelLoadedLine(t *testing.T) {
 	tests := []struct {
-		name              string
-		runtimeID, device string
-		ngl, nctx         int32
-		want              string
+		name                   string
+		runtimeID, computeUnit string
+		ngl, nctx              int32
+		want                   string
 	}{
 		{
-			name:      "llama_cpp shows ngl/nctx",
-			runtimeID: geniex_sdk.RuntimeLlamaCpp, device: "HTP0", ngl: 32, nctx: 4096,
-			want: "Model loaded: backend=llama_cpp device=HTP0 ngl=32 nctx=4096",
+			name:      "llama_cpp npu shows alias, ngl/nctx",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "npu", ngl: 32, nctx: 4096,
+			want: "Model loaded: backend=llama_cpp device=npu ngl=32 nctx=4096",
 		},
 		{
-			name:      "llama_cpp with ngl=-1 (all layers) still prints",
-			runtimeID: geniex_sdk.RuntimeLlamaCpp, device: "CPU", ngl: -1, nctx: 2048,
-			want: "Model loaded: backend=llama_cpp device=CPU ngl=-1 nctx=2048",
+			name:      "llama_cpp cpu echoes alias (device_id is empty)",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "cpu", ngl: 0, nctx: 2048,
+			want: "Model loaded: backend=llama_cpp device=cpu ngl=0 nctx=2048",
 		},
 		{
-			name:      "qairt hides ngl/nctx (not applicable)",
-			runtimeID: geniex_sdk.RuntimeQairt, device: "HTP0", ngl: 0, nctx: 0,
-			want: "Model loaded: backend=qairt device=HTP0",
+			name:      "llama_cpp hybrid echoes alias (device_id is empty)",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "hybrid", ngl: -1, nctx: 4096,
+			want: "Model loaded: backend=llama_cpp device=hybrid ngl=-1 nctx=4096",
+		},
+		{
+			name:      "llama_cpp empty compute defaults to npu",
+			runtimeID: geniex_sdk.RuntimeLlamaCpp, computeUnit: "", ngl: -1, nctx: 4096,
+			want: "Model loaded: backend=llama_cpp device=npu ngl=-1 nctx=4096",
+		},
+		{
+			name:      "qairt fixed to npu, hides ngl/nctx",
+			runtimeID: geniex_sdk.RuntimeQairt, computeUnit: "cpu", ngl: 0, nctx: 0,
+			want: "Model loaded: backend=qairt device=npu",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := modelLoadedLine(tt.runtimeID, tt.device, tt.ngl, tt.nctx)
+			got := modelLoadedLine(tt.runtimeID, tt.computeUnit, tt.ngl, tt.nctx)
 			if got != tt.want {
 				t.Errorf("modelLoadedLine\n got: %q\nwant: %q", got, tt.want)
 			}


### PR DESCRIPTION
## Problem

The `--verbose` "Model loaded" line printed the SDK's concrete `device_id`. For `cpu`/`hybrid`, `geniex_resolve_device` resolves to an *empty* `device_id` (llama.cpp's per-tensor HTP+CPU scheduler sets none), so the line showed a blank `device=`.

## Fix

Echo the user-facing compute alias instead of the internal `device_id`. Normalization mirrors `geniex_resolve_device`'s defaults — empty/`auto` and `qairt` map to `npu`. `qairt` stays fixed at `device=npu` and keeps hiding `ngl`/`nctx` (its plugin has no `n_ctx` concept).

```
Model loaded: backend=llama_cpp device=npu ngl=-1 nctx=4096
Model loaded: backend=llama_cpp device=cpu ngl=0 nctx=4096
Model loaded: backend=llama_cpp device=hybrid ngl=-1 nctx=4096
Model loaded: backend=qairt device=npu
```

## Scope

CLI-only, no FFI change (the SDK alias table in `sdk/src/device.cpp` is untouched). Tests updated to cover cpu/hybrid/empty/qairt.