### PR TITLE
feat(server): match tool-call JSON by braces instead of tags

### DIFF
--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//cli/server/service",
         "//cli/server/utils",
         "@com_github_bytedance_sonic//:sonic",
-        "@com_github_bytedance_sonic//ast",
         "@com_github_gin_gonic_gin//:gin",
         "@com_github_openai_openai_go_v3//:openai-go",
         "@com_github_openai_openai_go_v3//packages/param",

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -11,12 +11,10 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/bytedance/sonic"
-	"github.com/bytedance/sonic/ast"
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
@@ -637,7 +635,7 @@ func writeContextLengthExceeded(c *gin.Context, fullText string, profile geniex_
 // when parseTool matches, content response otherwise (or on parse failure).
 func writeBlockingResponse(c *gin.Context, fullText string, profile geniex_sdk.ProfileData, parseTool bool) {
 	if parseTool {
-		toolCall, err := parseToolCalls(fullText)
+		toolCall, err := utils.ParseToolCalls(fullText)
 		if err == nil {
 			choice := openai.ChatCompletionChoice{}
 			choice.FinishReason = "tool_calls"
@@ -761,7 +759,7 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			return false
 		}
 		finishReason := "tool_calls"
-		toolCall, err := parseToolCalls(buffer.String())
+		toolCall, err := utils.ParseToolCalls(buffer.String())
 		if err != nil {
 			slog.Warn("Tool call parse error, fallback to text", "error", err)
 			finishReason = finish()
@@ -815,48 +813,4 @@ func mapFinishReason(stopReason string) string {
 	default:
 		return "stop"
 	}
-}
-
-// =============== tool-call parsing ===============
-
-var toolCallRegex = regexp.MustCompile(`<tool_call>([\s\S]+)<\/tool_call>` + "|" + "```json([\\s\\S]+)```")
-
-func parseToolCalls(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
-	match := toolCallRegex.FindStringSubmatch(resp)
-	if len(match) <= 1 {
-		return openai.ChatCompletionMessageFunctionToolCallFunction{}, errors.New("tool call not match")
-	}
-	matched := match[1]
-	if matched == "" && len(match) > 2 {
-		matched = match[2]
-	}
-
-	slog.Debug("Tool call matched", "matched", matched)
-
-	name, err := sonic.GetFromString(matched, "name")
-	toolCall := openai.ChatCompletionMessageFunctionToolCallFunction{}
-	if err != nil {
-		return openai.ChatCompletionMessageFunctionToolCallFunction{}, err
-	}
-	toolCall.Name, err = name.String()
-	if err != nil {
-		return openai.ChatCompletionMessageFunctionToolCallFunction{}, err
-	}
-
-	arguments, err := sonic.GetFromString(matched, "arguments")
-	if err != nil {
-		return openai.ChatCompletionMessageFunctionToolCallFunction{}, err
-	}
-	switch arguments.TypeSafe() {
-	case ast.V_OBJECT:
-		toolCall.Arguments, _ = arguments.Raw()
-	case ast.V_STRING:
-		toolCall.Arguments, _ = arguments.String()
-	default:
-		return openai.ChatCompletionMessageFunctionToolCallFunction{}, errors.New("unknown arguments type")
-	}
-
-	slog.Debug("Parsed tool call", "tool_call", toolCall)
-
-	return toolCall, nil
 }

--- a/cli/server/utils/BUILD.bazel
+++ b/cli/server/utils/BUILD.bazel
@@ -2,14 +2,25 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "utils",
-    srcs = ["common.go"],
+    srcs = [
+        "common.go",
+        "toolcall.go",
+    ],
     importpath = "github.com/qualcomm/GenieX/cli/server/utils",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_image//webp"],
+    deps = [
+        "@com_github_bytedance_sonic//:sonic",
+        "@com_github_bytedance_sonic//ast",
+        "@com_github_openai_openai_go_v3//:openai-go",
+        "@org_golang_x_image//webp",
+    ],
 )
 
 go_test(
     name = "utils_test",
-    srcs = ["common_test.go"],
+    srcs = [
+        "common_test.go",
+        "toolcall_test.go",
+    ],
     embed = [":utils"],
 )

--- a/cli/server/utils/toolcall.go
+++ b/cli/server/utils/toolcall.go
@@ -1,0 +1,110 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
+	"github.com/openai/openai-go/v3"
+)
+
+// balancedObjectEnd returns the index just past the '}' matching the '{' at
+// start, skipping braces inside string literals. -1 if never closed.
+func balancedObjectEnd(s string, start int) int {
+	depth := 0
+	inStr, escaped := false, false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+// extractJSONObjects returns every balanced {...} substring in s, skipping
+// stray or unterminated '{' so later objects are still found.
+func extractJSONObjects(s string) []string {
+	var objs []string
+	for i := 0; i < len(s); i++ {
+		if s[i] != '{' {
+			continue
+		}
+		end := balancedObjectEnd(s, i)
+		if end < 0 {
+			continue
+		}
+		objs = append(objs, s[i:end])
+		i = end - 1
+	}
+	return objs
+}
+
+// parseToolCallObject decodes one JSON object into a tool call, succeeding only
+// when "name" is a string and "arguments" is an object or string.
+func parseToolCallObject(obj string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	toolCall := openai.ChatCompletionMessageFunctionToolCallFunction{}
+
+	name, err := sonic.GetFromString(obj, "name")
+	if err != nil {
+		return toolCall, err
+	}
+	if name.TypeSafe() != ast.V_STRING {
+		return toolCall, errors.New("name is not a string")
+	}
+	toolCall.Name, err = name.String()
+	if err != nil {
+		return toolCall, err
+	}
+
+	arguments, err := sonic.GetFromString(obj, "arguments")
+	if err != nil {
+		return toolCall, err
+	}
+	switch arguments.TypeSafe() {
+	case ast.V_OBJECT:
+		toolCall.Arguments, _ = arguments.Raw()
+	case ast.V_STRING:
+		toolCall.Arguments, _ = arguments.String()
+	default:
+		return toolCall, errors.New("unknown arguments type")
+	}
+
+	return toolCall, nil
+}
+
+// ParseToolCalls returns the first balanced {...} object in resp that decodes
+// into a valid tool call, skipping any malformed or non-tool-call objects.
+func ParseToolCalls(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	for _, obj := range extractJSONObjects(resp) {
+		if toolCall, err := parseToolCallObject(obj); err == nil {
+			slog.Debug("Parsed tool call", "tool_call", toolCall)
+			return toolCall, nil
+		}
+	}
+
+	return openai.ChatCompletionMessageFunctionToolCallFunction{}, errors.New("tool call not match")
+}

--- a/cli/server/utils/toolcall_test.go
+++ b/cli/server/utils/toolcall_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import "testing"
+
+func TestParseToolCalls(t *testing.T) {
+	tests := []struct {
+		name      string
+		resp      string
+		wantName  string
+		wantArgs  string
+		wantError bool
+	}{
+		{
+			name:     "bare json object",
+			resp:     `{"name": "get_weather", "arguments": {"city": "Beijing"}}`,
+			wantName: "get_weather",
+			wantArgs: `{"city": "Beijing"}`,
+		},
+		{
+			name:     "json with surrounding prose",
+			resp:     `Sure, let me call it. {"name": "get_weather", "arguments": {"city": "Beijing"}} Done.`,
+			wantName: "get_weather",
+			wantArgs: `{"city": "Beijing"}`,
+		},
+		{
+			name:     "string arguments",
+			resp:     `{"name": "echo", "arguments": "hello"}`,
+			wantName: "echo",
+			wantArgs: "hello",
+		},
+		{
+			name:     "nested braces in arguments",
+			resp:     `{"name": "f", "arguments": {"a": {"b": {"c": 1}}}}`,
+			wantName: "f",
+			wantArgs: `{"a": {"b": {"c": 1}}}`,
+		},
+		{
+			name:     "deeply nested arguments",
+			resp:     `prose {"name": "deep", "arguments": {"l1": {"l2": {"l3": {"l4": {"l5": {"v": [1, {"x": 2}]}}}}}}} tail`,
+			wantName: "deep",
+			wantArgs: `{"l1": {"l2": {"l3": {"l4": {"l5": {"v": [1, {"x": 2}]}}}}}}`,
+		},
+		{
+			name:     "nested objects with braces inside strings",
+			resp:     `{"name": "g", "arguments": {"outer": {"inner": {"note": "close } here { and {} there"}}}}`,
+			wantName: "g",
+			wantArgs: `{"outer": {"inner": {"note": "close } here { and {} there"}}}`,
+		},
+		{
+			name:     "array of nested objects as arguments",
+			resp:     `{"name": "batch", "arguments": {"items": [{"a": {"b": 1}}, {"c": {"d": 2}}]}}`,
+			wantName: "batch",
+			wantArgs: `{"items": [{"a": {"b": 1}}, {"c": {"d": 2}}]}`,
+		},
+		{
+			name:     "braces inside string literal ignored",
+			resp:     `{"name": "say", "arguments": {"text": "a } b { c"}}`,
+			wantName: "say",
+			wantArgs: `{"text": "a } b { c"}`,
+		},
+		{
+			name:     "escaped quote inside string",
+			resp:     `{"name": "say", "arguments": {"text": "quote \" and } brace"}}`,
+			wantName: "say",
+			wantArgs: `{"text": "quote \" and } brace"}`,
+		},
+		{
+			name:     "skips leading object without name",
+			resp:     `{"thinking": "hmm"} then {"name": "go", "arguments": {}}`,
+			wantName: "go",
+			wantArgs: `{}`,
+		},
+		{
+			name:     "skips object with name but no arguments",
+			resp:     `{"name": "no_args"} {"name": "real", "arguments": {"x": 1}}`,
+			wantName: "real",
+			wantArgs: `{"x": 1}`,
+		},
+		{
+			name:     "picks first of multiple tool calls",
+			resp:     `{"name": "first", "arguments": {"a": 1}}{"name": "second", "arguments": {"b": 2}}`,
+			wantName: "first",
+			wantArgs: `{"a": 1}`,
+		},
+		{
+			name:     "skips candidate with array arguments",
+			resp:     `{"name": "bad", "arguments": [1, 2, 3]} {"name": "good", "arguments": {"ok": 1}}`,
+			wantName: "good",
+			wantArgs: `{"ok": 1}`,
+		},
+		{
+			name:     "skips candidate with numeric arguments",
+			resp:     `{"name": "bad", "arguments": 42} {"name": "good", "arguments": "text"}`,
+			wantName: "good",
+			wantArgs: "text",
+		},
+		{
+			name:     "skips candidate with non-string name",
+			resp:     `{"name": 7, "arguments": {}} {"name": "good", "arguments": {}}`,
+			wantName: "good",
+			wantArgs: `{}`,
+		},
+		{
+			name:      "all candidates invalid falls through to error",
+			resp:      `{"name": "a", "arguments": [1]} {"name": 2, "arguments": {}} {"name": "c"}`,
+			wantError: true,
+		},
+		{
+			name:     "multiple tool calls separated by prose",
+			resp:     `Call one: {"name": "first", "arguments": {}}. Then: {"name": "second", "arguments": {}}`,
+			wantName: "first",
+			wantArgs: `{}`,
+		},
+		{
+			name:     "leading unterminated brace does not swallow later call",
+			resp:     `reasoning { partial and never closed ... {"name": "go", "arguments": {"ok": true}}`,
+			wantName: "go",
+			wantArgs: `{"ok": true}`,
+		},
+		{
+			name:     "stray closing braces before real call",
+			resp:     `garbage } } more } {"name": "go", "arguments": {}}`,
+			wantName: "go",
+			wantArgs: `{}`,
+		},
+		{
+			name:     "name with escaped chars",
+			resp:     `{"name": "ns\\tool", "arguments": {"path": "C:\\tmp"}}`,
+			wantName: `ns\tool`,
+			wantArgs: `{"path": "C:\\tmp"}`,
+		},
+		{
+			name:     "empty object skipped then real call",
+			resp:     `{} {"name": "go", "arguments": {}}`,
+			wantName: "go",
+			wantArgs: `{}`,
+		},
+		{
+			// tag/fence wrappers are transparent: the inner object is extracted
+			name:     "json inside tool_call tag",
+			resp:     "<tool_call>\n{\"name\": \"tagged\", \"arguments\": {\"k\": 1}}\n</tool_call>",
+			wantName: "tagged",
+			wantArgs: `{"k": 1}`,
+		},
+		{
+			name:     "json inside code fence",
+			resp:     "here you go:\n```json\n{\"name\": \"fenced\", \"arguments\": {\"q\": \"x\"}}\n```",
+			wantName: "fenced",
+			wantArgs: `{"q": "x"}`,
+		},
+		{
+			name:      "no json object",
+			resp:      "just some plain text without any call",
+			wantError: true,
+		},
+		{
+			name:      "unterminated object",
+			resp:      `{"name": "go", "arguments":`,
+			wantError: true,
+		},
+		{
+			name:      "only non-tool-call objects",
+			resp:      `{"foo": 1} {"bar": 2} {"name": 42}`,
+			wantError: true,
+		},
+		{
+			name:      "empty string",
+			resp:      "",
+			wantError: true,
+		},
+		{
+			name:      "braces only inside a string literal",
+			resp:      `the model said "{ not json }" and stopped`,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseToolCalls(tt.resp)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got tool call %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Arguments != tt.wantArgs {
+				t.Errorf("arguments = %q, want %q", got.Arguments, tt.wantArgs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The serve chat handler previously extracted tool-call JSON by matching wrapper tags (`<tool_call>...</tool_call>` or ```` ```json ```` fences) with a greedy regex. This makes it parse tool calls by scanning for balanced `{...}` objects directly, so responses without any wrapper tag are handled.

The scanner:
- supports arbitrary nesting depth;
- ignores braces that appear inside string literals (honoring `\"` escapes);
- skips stray or unterminated `{` instead of swallowing the rest of the response;
- iterates every balanced object and returns the first that decodes into a valid tool call — a string `name` plus object/string `arguments` — so leading malformed or non-tool-call objects (e.g. reasoning blobs) are skipped.

Wrapper tags are now transparent: well-formed JSON inside them is still extracted, so no separate tag handling is needed.

The parser is moved out of the handler into `cli/server/utils/toolcall.go` (exported `ParseToolCalls`) with dedicated unit tests.

## Test plan

- [x] `bazelisk test //cli/server/utils:utils_test` — covers bare JSON, surrounding prose, string/object arguments, deep nesting, arrays, braces inside strings, multiple candidates, invalid-candidate skipping, and malformed/empty input
- [x] `bazelisk test //cli/server/handler:handler_test`
- [x] `bazelisk build //cli/server/...`
- [x] `gofmt` clean, `go mod tidy` no diff