### PR TITLE
fix(cli): apply --log to the SDK log callback

### DIFF
--- a/cli/cmd/geniex/common/log.go
+++ b/cli/cmd/geniex/common/log.go
@@ -23,34 +23,37 @@ const (
 	LogLevelError string = "error"
 )
 
-func ApplyLogLevel() {
-	options := tint.Options{AddSource: true}
-
-	if os.Getenv("NO_COLOR") == "1" {
-		options.NoColor = true
-	}
-
+// ApplySlog configures slog from the resolved log level, without touching the
+// SDK callback. Safe to call before flags are parsed.
+func ApplySlog() {
 	level := config.Get().Log
-
-	switch level {
-	case LogLevelNone:
-		geniex_sdk.SetLog(false)
+	if level == LogLevelNone {
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 		return
-	case LogLevelTrace:
-		options.Level = slog.LevelDebug
-		slog.SetDefault(slog.New(tint.NewHandler(os.Stderr, &options)))
-		return
-	case LogLevelDebug:
-		options.Level = slog.LevelDebug
-	case LogLevelInfo:
-		options.Level = slog.LevelInfo
-	case LogLevelWarn:
-		options.Level = slog.LevelWarn
-	case LogLevelError:
-		options.Level = slog.LevelError
 	}
 
-	geniex_sdk.SetLog(true)
+	options := tint.Options{
+		AddSource: true,
+		Level:     slogLevels[level],
+		NoColor:   os.Getenv("NO_COLOR") == "1",
+	}
 	slog.SetDefault(slog.New(tint.NewHandler(os.Stderr, &options)))
+}
+
+// ApplyLogLevel runs after flags are parsed; the only place that sets the SDK
+// callback. trace keeps the SDK's native handler; other levels forward to slog.
+func ApplyLogLevel() {
+	ApplySlog()
+
+	if level := config.Get().Log; level != LogLevelTrace {
+		geniex_sdk.SetLog(level != LogLevelNone)
+	}
+}
+
+var slogLevels = map[string]slog.Level{
+	LogLevelTrace: slog.LevelDebug,
+	LogLevelDebug: slog.LevelDebug,
+	LogLevelInfo:  slog.LevelInfo,
+	LogLevelWarn:  slog.LevelWarn,
+	LogLevelError: slog.LevelError,
 }

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -38,8 +38,7 @@ func RootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			// Re-apply now that flags are parsed so --log takes effect; the
-			// call in main() runs before parsing and only sees GENIEX_LOG.
+			// Re-apply now that --log is parsed; the main() call only saw GENIEX_LOG.
 			common.ApplyLogLevel()
 
 			subCmd := cmd.CalledAs()
@@ -130,8 +129,9 @@ func checkAudioDependency() {
 
 // main is the entry point that executes the root command.
 func main() {
-	// log
-	common.ApplyLogLevel()
+	// Honor GENIEX_LOG for early logs; the SDK callback is set later once --log
+	// is parsed. Setting it here (default "none") would null its built-in handler.
+	common.ApplySlog()
 	common.EnableUTF8Console()
 
 	cmd := RootCmd()


### PR DESCRIPTION
## Problem

`--log trace` and `GENIEX_LOG=trace` behaved differently: with `--log trace` the llama.cpp model-load logs were **not** printed, while `GENIEX_LOG=trace` printed them.

## Root cause

`ApplyLogLevel()` was called twice — once in `main()` before flag parsing, once in `PersistentPreRun` after.

- **`--log trace` (broken):** the pre-parse call ran with the default level `none` → `SetLog(false)`, which sets the SDK callback (`geniex_log`) to `nullptr`. The SDK exposes no way to restore its built-in handler, so this is irreversible. The post-parse `trace` case then intentionally skipped `SetLog` (trace is meant to keep the SDK's native handler), leaving the callback null → all llama.cpp logs dropped.
- **`GENIEX_LOG=trace` (fine):** viper resolves the env var before the pre-parse call, so the level was already `trace` and `SetLog(false)` never ran — the built-in handler stayed installed.

## Fix

Split slog configuration from the SDK callback:

- `ApplySlog()` — configures slog only, safe to call before flags are parsed. `main()` now calls this early so `GENIEX_LOG` still governs startup logs.
- `ApplyLogLevel()` — runs in `PersistentPreRun` after flags are parsed and is the **only** place that touches the SDK callback (`trace` keeps the native handler, `none` silences, other levels forward to slog).

No FFI change (`geniex.h` untouched).

## Testing

Ran `infer` on Qwen3-4B and inspected load logs:

| Case | llama.cpp load logs | Path |
|------|--------------------|------|
| `GENIEX_LOG=trace` | ✅ printed | SDK native handler |
| `--log trace` | ✅ printed (**was missing before**) | SDK native handler |
| `--log debug` | ✅ printed (38 loader lines) | forwarded to slog via Go callback |
| `--log none` | none (0 lines) | SDK silenced |

`--log trace` now matches `GENIEX_LOG=trace`; no regression on other levels.