### PR TITLE
fix(cli): suggest --log debug in model-load failure hint

### DIFF
--- a/cli/cmd/geniex/common/error.go
+++ b/cli/cmd/geniex/common/error.go
@@ -33,6 +33,7 @@ const (
 - Redownload the model.
 - Verify your system meets the model's requirements.
 - Check your NPU / GPU driver version and update it if it's out of date.
+- Re-run with '--log debug' (or higher) to see the underlying load failure.
 - See help in our discord or slack.`
 
 	hintPluginLoad = `⚠️ Oops. Runtime failed to load.


### PR DESCRIPTION
## What

Add a line to the model-load failure hint (`hintModelLoad`) suggesting the user re-run with `--log debug` (or higher) to surface the underlying load failure.

## Why

When a model fails to load, the friendly hint previously offered no path to the actual error. Pointing users at `--log debug` lets them see the underlying cause without needing to ask for help.