### PR TITLE
fix(sdk): fully clear VLM memory on reset

### DIFF
--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -115,13 +115,11 @@ int32_t LlamaVlm::get_capabilities(geniex_VlmCapabilities* output) {
 int32_t LlamaVlm::reset() {
     if (!this->ctx) return GENIEX_ERROR_COMMON_INVALID_INPUT;
 
-    // Clear memory keeping BOS token (like mtmd-cli.cpp does)
-    llama_memory_seq_rm(llama_get_memory(this->ctx), 0, 1, -1);
+    // Hybrid/recurrent models require a full KV cache clear; partial trimming can
+    // leave cache state inconsistent with n_past. Keep this aligned with LlamaLlm::reset().
+    llama_memory_clear(llama_get_memory(this->ctx), /*clear data=*/true);
 
-    // Reset conversation state, setting to n_past = 1 since we preserved the BOS token above.
-    // TODO: revisit and verify that setting to 1 is correct. mtmd-cli.cpp in llama-cpp sets it to 0 but setting to 0
-    // will cause all test cases to fail.
-    this->n_past              = 1;
+    this->n_past              = 0;
     this->global_n_past_chars = 0;
 
     return GENIEX_SUCCESS;


### PR DESCRIPTION
## Summary

- Fully clear VLM KV memory during reset instead of retaining BOS state.
- Reset `n_past` to zero so it remains aligned with the cleared cache.

## Root cause

For hybrid/recurrent architectures such as Qwen3.5's Gated Delta Net, `llama_memory_seq_rm(mem, 0, 1, -1)` may no-op when the recurrent-cache rollback exceeds `n_rs_seq` (which remains at its default of zero). This leaves the KV cache populated while GenieX resets `n_past` to one. The next decode then fails M-RoPE's position-monotonicity check.

A full `llama_memory_clear()` and `n_past = 0` restore the same state as a newly created VLM context.

## Test plan

- [x] `git diff --check`
- [x] Verified two consecutive HTTP requests with a Qwen3.5 VLM on IQ9