### PR TITLE
fix(ci): avoid rebuilding SDK inside QDC Test when called from test.yml

### DIFF
--- a/.github/workflows/_qdc-test.yml
+++ b/.github/workflows/_qdc-test.yml
@@ -7,6 +7,12 @@ name: QDC Test
 
 on:
   workflow_call:
+    inputs:
+      build_sdk:
+        description: "Build the SDK inline (set false when the caller already built it)."
+        required: false
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       platforms:
@@ -21,7 +27,9 @@ permissions:
 
 jobs:
   build-sdk:
-    if: github.event_name == 'workflow_dispatch'
+    # workflow_dispatch always builds; workflow_call opts in via inputs.build_sdk
+    # so callers that already produced the sdk-<platform> artifact don't rebuild.
+    if: github.event_name == 'workflow_dispatch' || inputs.build_sdk
     uses: ./.github/workflows/_build-sdk.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Follow-up fix to #1297. The reusable `_qdc-test.yml` gated its `build-sdk` job on `github.event_name == 'workflow_dispatch'`, but a reusable workflow inherits the caller's event name — so when `test.yml` (tag push or dispatch) fanned out to `_qdc-test.yml`, the child rebuilt the SDK for 3 platforms even though `test.yml` had already produced and uploaded the `sdk-<platform>` artifacts.

Replace the event check with an explicit `workflow_call` input `build_sdk` (default `false`). `test.yml`'s existing call passes no `build_sdk`, so the child's build-sdk skips; the QDC leg still picks up the parent's artifact via `download-artifact`. Direct `workflow_dispatch` on `_qdc-test.yml` still builds inline.

## Test plan

- [ ] `gh workflow run test.yml --ref main` after merge: `Test` run shows build-sdk running **once** (in the parent), and `test-sdk-qdc / QDC Test` sub-run shows the build-sdk job as `skipped` — matches the 2 real QDC legs kicking off without rebuild.
- [ ] `gh workflow run _qdc-test.yml --ref main` after merge: standalone dispatch still triggers build-sdk inline.