### PR TITLE
feat(cli): add 'geniex model list' for AI Hub catalogue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Every commit MUST use one of these types. CI and `/release` derive the SemVer bu
 | `ci`       | CI config only.                              | PATCH              |
 | `revert`   | Revert a prior commit.                       | no bump by default |
 
-- **Scope** — one per commit, naming the area touched: `cli`, `sdk`, `python`, `android`, `go`, `server`, `build`, `release`, `ci`, `dx`, `docs`. Introduce a new scope in the same PR that introduces the area.
+- **Scope** — one per commit, naming the area touched: `cli`, `sdk`, `python`, `android`, `go`, `bindings`, `server`, `build`, `release`, `ci`, `dx`, `docs`. Use `bindings` only when a change spans more than one language binding at once; a single-language change uses `go` / `python` / `android`. Introduce a new scope in the same PR that introduces the area.
 - **Subject** — imperative mood (`add`, not `added`), ≤ 72 characters, no trailing period, describes *what* not *why*. Banned subjects (reviewers reject them — they make version derivation impossible): `update code`, `fix bug`, `misc`, `wip`, `tmp`, empty, placeholder, non-ASCII.
 - **Body** — omit by default; add only when the "why" is non-obvious. Don't restate the diff. No co-authors, no emojis.
 - **Breaking changes** — mark with `!` after the type/scope (`feat(cli)!: rename --model flag`) or a `BREAKING CHANGE:` footer. **Pre-1.0 rule:** the leading `X` in `vX.Y.Z` stays `0` until the first stable public release, so breaking changes bump **MINOR**, not MAJOR, while `X = 0`.

--- a/bindings/android/app/src/main/cpp/model_manager_jni.cpp
+++ b/bindings/android/app/src/main/cpp/model_manager_jni.cpp
@@ -565,3 +565,62 @@ extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_jni_ModelManager_detect
     geniex_free(out);
     return result;
 }
+
+jobject build_hub_model(JNIEnv* env, const geniex_HubModelInfo& m) {
+    jclass cls = env->FindClass("com/geniex/sdk/bean/HubModel");
+    if (!cls) return nullptr;
+    jmethodID ctor =
+        env->GetMethodID(cls, "<init>", "(Ljava/lang/String;Lcom/geniex/sdk/bean/ModelType;[Ljava/lang/String;)V");
+    if (!ctor) {
+        env->DeleteLocalRef(cls);
+        return nullptr;
+    }
+    jclass    modelTypeCls = env->FindClass("com/geniex/sdk/bean/ModelType");
+    jmethodID fromValueMid = env->GetStaticMethodID(modelTypeCls, "fromValue", "(I)Lcom/geniex/sdk/bean/ModelType;");
+    jobject   jModelType   = env->CallStaticObjectMethod(modelTypeCls, fromValueMid, static_cast<jint>(m.model_type));
+
+    jstring jName = env->NewStringUTF(m.name ? m.name : "");
+
+    jclass       stringCls = env->FindClass("java/lang/String");
+    jobjectArray jChipsets = env->NewObjectArray(m.chipset_count, stringCls, nullptr);
+    for (int32_t i = 0; i < m.chipset_count; ++i) {
+        jstring c = env->NewStringUTF(m.chipsets[i] ? m.chipsets[i] : "");
+        env->SetObjectArrayElement(jChipsets, i, c);
+        env->DeleteLocalRef(c);
+    }
+
+    jobject obj = env->NewObject(cls, ctor, jName, jModelType, jChipsets);
+
+    if (jModelType) env->DeleteLocalRef(jModelType);
+    env->DeleteLocalRef(jName);
+    env->DeleteLocalRef(jChipsets);
+    env->DeleteLocalRef(stringCls);
+    env->DeleteLocalRef(modelTypeCls);
+    env->DeleteLocalRef(cls);
+    return obj;
+}
+
+extern "C" JNIEXPORT jobjectArray JNICALL Java_com_geniex_sdk_jni_ModelManager_listHubModels(
+    JNIEnv* env, jobject /*thiz*/, jstring jChipset) {
+    jclass hubModelCls = env->FindClass("com/geniex/sdk/bean/HubModel");
+
+    std::string         chipset = jstring2str(env, jChipset);
+    geniex_HubModelList out{};
+    int32_t             rc = geniex_model_list_hub(chipset.empty() ? nullptr : chipset.c_str(), &out);
+    if (rc != GENIEX_SUCCESS) {
+        LOGe("[ModelManager JNI] listHubModels() failed rc=%d", rc);
+        jobjectArray empty = env->NewObjectArray(0, hubModelCls, nullptr);
+        env->DeleteLocalRef(hubModelCls);
+        return empty;
+    }
+
+    jobjectArray arr = env->NewObjectArray(out.count, hubModelCls, nullptr);
+    for (int32_t i = 0; i < out.count; ++i) {
+        jobject item = build_hub_model(env, out.models[i]);
+        env->SetObjectArrayElement(arr, i, item);
+        if (item) env->DeleteLocalRef(item);
+    }
+    env->DeleteLocalRef(hubModelCls);
+    geniex_model_list_hub_free(&out);
+    return arr;
+}

--- a/bindings/android/app/src/main/java/com/geniex/sdk/ModelManagerWrapper.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/ModelManagerWrapper.kt
@@ -2,6 +2,7 @@ package com.geniex.sdk
 
 import com.geniex.sdk.bean.ChipsetInfo
 import com.geniex.sdk.bean.FileProgress
+import com.geniex.sdk.bean.HubModel
 import com.geniex.sdk.bean.ModelPaths
 import com.geniex.sdk.bean.ModelPullInput
 import com.geniex.sdk.bean.ModelType
@@ -118,6 +119,10 @@ object ModelManagerWrapper {
 
     suspend fun detectChipset(): String? = withContext(Dispatchers.IO) {
         native.detectChipset()
+    }
+
+    suspend fun listHubModels(chipset: String? = null): List<HubModel> = withContext(Dispatchers.IO) {
+        native.listHubModels(chipset).toList()
     }
 
     sealed class PullEvent {

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/HubModel.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/HubModel.kt
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package com.geniex.sdk.bean
+
+/** Mirrors `geniex_HubModelInfo`. One AI Hub model geniex can run (qairt). */
+data class HubModel(
+    val name: String,
+    val model_type: ModelType,
+    val chipsets: Array<String>,
+)

--- a/bindings/android/app/src/main/java/com/geniex/sdk/jni/ModelManager.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/jni/ModelManager.kt
@@ -1,6 +1,7 @@
 package com.geniex.sdk.jni
 
 import com.geniex.sdk.bean.ChipsetInfo
+import com.geniex.sdk.bean.HubModel
 import com.geniex.sdk.bean.ModelDetail
 import com.geniex.sdk.bean.ModelPaths
 import com.geniex.sdk.bean.ModelPullInput
@@ -75,4 +76,10 @@ internal class ModelManager {
 
     /** Detect the host chipset via a local probe. @return `null` if not probeable. */
     external fun detectChipset(): String?
+
+    /**
+     * AI Hub models with a qairt (NPU) build, sorted by name (from manifest.json).
+     * @param chipset canonical chipset id to filter by, or null to list every model.
+     */
+    external fun listHubModels(chipset: String?): Array<HubModel>
 }

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -294,6 +294,41 @@ func ModelDetectChipset() (string, error) {
 	return C.GoString(out), nil
 }
 
+// HubModel is one Qualcomm AI Hub model geniex can run (qairt / NPU).
+type HubModel struct {
+	Name      string // Pullable name, e.g. "qualcomm/Qwen3-4B".
+	ModelType ModelType
+	Chipsets  []string
+}
+
+// ModelListHub lists Qualcomm AI Hub models with a qairt asset, sorted by name.
+// chipset restricts results to a canonical chipset id; "" lists every model.
+// Detecting the host chipset is the caller's job (see ModelDetectChipset).
+func ModelListHub(chipset string) ([]HubModel, error) {
+	cChipset := cStringIfSet(chipset)
+	defer cFreeIfSet(unsafe.Pointer(cChipset))
+
+	var out C.geniex_HubModelList
+	if res := C.geniex_model_list_hub(cChipset, &out); res != C.GENIEX_SUCCESS {
+		return nil, modelError(res)
+	}
+	defer C.geniex_model_list_hub_free(&out)
+
+	if out.models == nil || out.count == 0 {
+		return nil, nil
+	}
+	models := unsafe.Slice(out.models, int(out.count))
+	result := make([]HubModel, out.count)
+	for i, m := range models {
+		result[i] = HubModel{
+			Name:      C.GoString(m.name),
+			ModelType: ModelType(m.model_type),
+			Chipsets:  cCharArrayToSlice(m.chipsets, m.chipset_count),
+		}
+	}
+	return result, nil
+}
+
 // ModelRemove deletes a cached model ("org/repo" or "org/repo:precision").
 func ModelRemove(name string) error {
 	cName := C.CString(name)

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -14,6 +14,7 @@ from ._types import (
     geniex_GetDeviceListInput,
     geniex_GetDeviceListOutput,
     geniex_GetPluginListOutput,
+    geniex_HubModelList,
     geniex_KvCacheLoadInput,
     geniex_KvCacheLoadOutput,
     geniex_KvCacheSaveInput,
@@ -297,6 +298,12 @@ def _bind_all() -> None:
 
     lib.geniex_model_detect_chipset.argtypes = [POINTER(c_char_p)]
     lib.geniex_model_detect_chipset.restype = c_int32
+
+    lib.geniex_model_list_hub.argtypes = [c_char_p, POINTER(geniex_HubModelList)]
+    lib.geniex_model_list_hub.restype = c_int32
+
+    lib.geniex_model_list_hub_free.argtypes = [POINTER(geniex_HubModelList)]
+    lib.geniex_model_list_hub_free.restype = None
 
 
 _bound = False

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -445,3 +445,19 @@ class geniex_ChipsetList(Structure):
         ('chipsets', POINTER(geniex_ChipsetInfo)),
         ('count', c_int32),
     ]
+
+
+class geniex_HubModelInfo(Structure):
+    _fields_ = [
+        ('name', c_char_p),
+        ('model_type', c_int32),
+        ('chipsets', POINTER(c_char_p)),
+        ('chipset_count', c_int32),
+    ]
+
+
+class geniex_HubModelList(Structure):
+    _fields_ = [
+        ('models', POINTER(geniex_HubModelInfo)),
+        ('count', c_int32),
+    ]

--- a/bindings/python/geniex/model_manager.py
+++ b/bindings/python/geniex/model_manager.py
@@ -21,6 +21,7 @@ from ._ffi._types import (
     GENIEX_MODEL_TYPE_VLM,
     geniex_ChipsetList,
     geniex_download_progress_cb,
+    geniex_HubModelList,
     geniex_ModelListDetailedOutput,
     geniex_ModelPaths,
     geniex_ModelPullInput,
@@ -51,6 +52,8 @@ __all__ = [
     'ChipsetInfo',
     'list_chipsets',
     'detect_chipset',
+    'HubModel',
+    'list_hub_models',
 ]
 
 
@@ -94,6 +97,15 @@ class ChipsetInfo:
 
     name: str
     aliases: list[str]
+
+
+@dataclass(frozen=True)
+class HubModel:
+    """One Qualcomm AI Hub model geniex can run (qairt / NPU)."""
+
+    name: str  # Pullable name, e.g. "qualcomm/Qwen3-4B".
+    model_type: str  # "llm" or "vlm"
+    chipsets: list[str]
 
 
 @dataclass(frozen=True)
@@ -501,6 +513,34 @@ def detect_chipset() -> str | None:
         return out.value.decode()
     finally:
         lib.geniex_free(out)
+
+
+def list_hub_models(chipset: str | None = None) -> list[HubModel]:
+    """List Qualcomm AI Hub models with a qairt (NPU) build, sorted by name.
+
+    ``chipset`` restricts results to a canonical chipset id; ``None`` lists
+    every model. Detecting the host chipset is the caller's job (see
+    :func:`detect_chipset`). Sourced from ``manifest.json`` (cached 24h); the
+    first call may hit the network.
+    """
+    _ensure_init()
+    lib = load_library()
+    out = geniex_HubModelList()
+    _check(lib.geniex_model_list_hub(chipset.encode() if chipset else None, byref(out)))
+    try:
+        models = []
+        for i in range(out.count):
+            m = out.models[i]
+            models.append(
+                HubModel(
+                    name=m.name.decode() if m.name else '',
+                    model_type=_type_str(m.model_type),
+                    chipsets=[m.chipsets[j].decode() for j in range(m.chipset_count)],
+                )
+            )
+        return models
+    finally:
+        lib.geniex_model_list_hub_free(byref(out))
 
 
 def ensure_cached(

--- a/cli/cmd/geniex/config.go
+++ b/cli/cmd/geniex/config.go
@@ -125,6 +125,19 @@ func resolveChipset() string {
 	return detected
 }
 
+// ensureChipset resolves a chipset: configured value, then host probe, then an
+// interactive picker (which persists the choice).
+func ensureChipset() (string, error) {
+	if c, _, _ := store.Get().ConfigGet(store.ConfigKeyChipset); c != "" {
+		return c, nil
+	}
+	if detected, _ := geniex_sdk.ModelDetectChipset(); detected != "" {
+		return detected, nil
+	}
+	fmt.Println(render.GetTheme().Info.Sprint("No chipset configured. Please select your chipset first."))
+	return pickChipset()
+}
+
 // pickChipset lists the chipsets Qualcomm AI Hub supports and lets the user
 // select one interactively, defaulting to the host's detected chipset when it
 // can be probed. The chosen chipset name is persisted under the "chipset" key

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -312,7 +312,68 @@ func modelCmd() *cobra.Command {
 		Short:   "Manage cached models",
 		Long:    "Commands to manage cached models, including reconfiguring model-specific settings.",
 	}
-	cmd.AddCommand(setTypeCmd())
+	cmd.AddCommand(setTypeCmd(), listHubCmd())
+	return cmd
+}
+
+func printHubTable(models []geniex_sdk.HubModel, showChipsets bool) {
+	tw := table.NewWriter()
+	tw.SetOutputMirror(os.Stdout)
+	tw.SetStyle(table.StyleLight)
+	if showChipsets {
+		tw.AppendHeader(table.Row{"NAME", "TYPE", "CHIPSETS"})
+	} else {
+		tw.AppendHeader(table.Row{"NAME", "TYPE"})
+	}
+	for _, m := range models {
+		if showChipsets {
+			chips := make([]string, len(m.Chipsets))
+			for i, c := range m.Chipsets {
+				chips[i] = strings.TrimPrefix(strings.TrimPrefix(c, "qualcomm-"), "snapdragon-")
+			}
+			tw.AppendRow(table.Row{m.Name, m.ModelType, strings.Join(chips, ", ")})
+		} else {
+			tw.AppendRow(table.Row{m.Name, m.ModelType})
+		}
+	}
+	tw.Render()
+}
+
+func listHubCmd() *cobra.Command {
+	var all bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Qualcomm AI Hub models geniex can run",
+		Long: "List Qualcomm AI Hub models with a qairt (NPU) build.\n\n" +
+			"By default only models compatible with the current device are shown; " +
+			"pass --all to list every model. Names are ready to pull, e.g. " +
+			"'geniex pull qualcomm/Qwen3-4B'.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// "" lists every model; --all skips filtering entirely.
+			var chipset string
+			if !all {
+				c, err := ensureChipset()
+				if err != nil {
+					return err
+				}
+				chipset = c
+			}
+			models, err := geniex_sdk.ModelListHub(chipset)
+			if err != nil {
+				return err
+			}
+			if all {
+				fmt.Println(render.GetTheme().Info.Sprint("Qualcomm AI Hub models geniex can run:"))
+			} else {
+				fmt.Println(render.GetTheme().Info.Sprintf("Qualcomm AI Hub models for %s (use --all to see every model):", chipset))
+			}
+			fmt.Println()
+			// CHIPSETS column only with --all; filtered rows all share one chipset.
+			printHubTable(models, all)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "list every model, not just ones compatible with this device")
 	return cmd
 }
 
@@ -390,18 +451,9 @@ func pullModel(ctx context.Context, name string, quant string) error {
 		DisplayName: "",
 	}
 
-	// Resolve a chipset before the spinner (the picker can't share the terminal
-	// with one): configured value wins, then a host probe, then an interactive
-	// picker. The SDK decides whether the chipset is actually used for this pull.
-	if chipset, _, _ := store.Get().ConfigGet(store.ConfigKeyChipset); chipset != "" {
-		in.Chipset = chipset
-	} else if detected, _ := geniex_sdk.ModelDetectChipset(); detected != "" {
-		in.Chipset = detected
-	} else {
-		fmt.Println(render.GetTheme().Info.Sprint("No chipset configured. Please select your chipset first."))
-		if in.Chipset, err = pickChipset(); err != nil {
-			return err
-		}
+	// Resolve before the spinner — the picker can't share the terminal with one.
+	if in.Chipset, err = ensureChipset(); err != nil {
+		return err
 	}
 
 	// Validate --model-type early so we fail before downloading anything, and

--- a/sdk/model-manager/crates/core/src/source/ai_hub/dto.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/dto.rs
@@ -38,6 +38,15 @@ pub struct ManifestModelEntry {
     pub domain: String,
     #[serde(default)]
     pub manifest_urls: ManifestUrls,
+    /// Runtimes the model publishes assets for, e.g. `RUNTIME_GENIEX_QAIRT`.
+    // Inlined into the manifest since v0.58.0; `default` for older caches.
+    #[serde(default)]
+    pub supported_runtimes: Vec<String>,
+    /// Canonical chipset ids, same domain as [`detect::detect_host_chipset`].
+    #[serde(default)]
+    pub supported_chipsets: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
@@ -162,6 +162,88 @@ pub async fn list_supported_chipsets(cfg: &AiHubConfig) -> Result<Vec<ChipsetInf
     Ok(chipsets)
 }
 
+/// Runtime string the public bucket uses for geniex's qairt (NPU) assets.
+const RUNTIME_GENIEX_QAIRT: &str = "RUNTIME_GENIEX_QAIRT";
+
+/// One AI Hub model geniex can run.
+#[derive(Debug, Clone)]
+pub struct HubModel {
+    pub display_name: String,
+    pub id: String,
+    pub model_type: ModelType,
+    pub supported_chipsets: Vec<String>,
+}
+
+/// List AI Hub models with a `RUNTIME_GENIEX_QAIRT` asset, sorted by name.
+/// `chipset` restricts to models compatible with it (any alias / display name
+/// from `platform.json`); `None` lists every one. Host detection is the
+/// caller's job — pass the chipset you want to match.
+pub async fn list_hub_models(cfg: &AiHubConfig, chipset: Option<&str>) -> Result<Vec<HubModel>> {
+    let transport: Arc<dyn HttpTransport> = Arc::new(ReqwestTransport::new()?);
+
+    // `supported_chipsets` holds canonical ids, so map the caller's chipset
+    // (which may be an alias or reference-device name) through platform.json.
+    let canonical = match chipset {
+        Some(chip) => {
+            let plat = fetch_platform_info(cfg, &transport).await?;
+            Some(selector::resolve_chipset(&plat, chip)?)
+        }
+        None => None,
+    };
+
+    let manifest_url = format!(
+        "{}/releases/{}/{MANIFEST_FILENAME}",
+        cfg.endpoint, cfg.version
+    );
+    let manifest_cache = cfg.cache_dir.join(MANIFEST_FILENAME);
+    let manifest_bytes = fetch_with_cache(
+        &manifest_url,
+        &manifest_cache,
+        &cfg.version,
+        cfg.skip_cache,
+        &transport,
+    )
+    .await?;
+    let manifest: ReleaseManifest = parse_manifest("manifest.json", &manifest_bytes)?;
+
+    Ok(select_hub_models(manifest, canonical.as_deref()))
+}
+
+/// Pure filter/sort behind [`list_hub_models`], split out for testing.
+fn select_hub_models(manifest: ReleaseManifest, device_chipset: Option<&str>) -> Vec<HubModel> {
+    let mut models: Vec<HubModel> = manifest
+        .models
+        .into_iter()
+        .filter(|m| {
+            m.supported_runtimes
+                .iter()
+                .any(|r| r == RUNTIME_GENIEX_QAIRT)
+        })
+        .filter(|m| match device_chipset {
+            Some(chip) => m.supported_chipsets.iter().any(|c| c == chip),
+            None => true,
+        })
+        .map(|m| HubModel {
+            // MODEL_TAG_VLM marks VLMs even when domain is generic GENERATIVE_AI.
+            model_type: if m.tags.iter().any(|t| t == "MODEL_TAG_VLM") {
+                ModelType::Vlm
+            } else {
+                ModelType::Llm
+            },
+            display_name: m.display_name,
+            id: m.id,
+            supported_chipsets: m.supported_chipsets,
+        })
+        .collect();
+
+    models.sort_by(|a, b| {
+        a.display_name
+            .to_ascii_lowercase()
+            .cmp(&b.display_name.to_ascii_lowercase())
+    });
+    models
+}
+
 /// Detect the host chipset and resolve it to the reference device name AI
 /// Hub displays (e.g. `"Snapdragon X Elite CRD"`), the same name surfaced by
 /// [`list_supported_chipsets`]. Best-effort: returns `None` when the host
@@ -574,6 +656,9 @@ mod tests {
             display_name: id.to_string(),
             domain: domain.to_string(),
             manifest_urls: ManifestUrls::default(),
+            supported_runtimes: Vec::new(),
+            supported_chipsets: Vec::new(),
+            tags: Vec::new(),
         }
     }
 
@@ -630,6 +715,107 @@ mod tests {
         // isn't a VLM signal) → LLM.
         let e = entry("mystery_model", "MODEL_DOMAIN_GENERATIVE_AI");
         assert_eq!(classify_ai_hub(None, &e), ModelType::Llm);
+    }
+
+    fn hub_entry(
+        id: &str,
+        runtimes: &[&str],
+        chipsets: &[&str],
+        tags: &[&str],
+    ) -> ManifestModelEntry {
+        ManifestModelEntry {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            domain: "MODEL_DOMAIN_GENERATIVE_AI".to_string(),
+            manifest_urls: ManifestUrls::default(),
+            supported_runtimes: runtimes.iter().map(|s| s.to_string()).collect(),
+            supported_chipsets: chipsets.iter().map(|s| s.to_string()).collect(),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn select_keeps_only_qairt_models() {
+        let manifest = ReleaseManifest {
+            platform_url: String::new(),
+            models: vec![
+                hub_entry("qairt_model", &["RUNTIME_GENIEX_QAIRT"], &["chipA"], &[]),
+                hub_entry(
+                    "llamacpp_only",
+                    &["RUNTIME_GENIEX_LLAMACPP"],
+                    &["chipA"],
+                    &[],
+                ),
+                hub_entry(
+                    "cv_model",
+                    &["RUNTIME_TFLITE", "RUNTIME_ONNX"],
+                    &["chipA"],
+                    &[],
+                ),
+            ],
+        };
+        let out = select_hub_models(manifest, None);
+        let ids: Vec<&str> = out.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["qairt_model"]);
+    }
+
+    #[test]
+    fn select_filters_by_device_chipset() {
+        let manifest = ReleaseManifest {
+            platform_url: String::new(),
+            models: vec![
+                hub_entry(
+                    "on_device",
+                    &["RUNTIME_GENIEX_QAIRT"],
+                    &["chipA", "chipB"],
+                    &[],
+                ),
+                hub_entry("off_device", &["RUNTIME_GENIEX_QAIRT"], &["chipB"], &[]),
+            ],
+        };
+        let out = select_hub_models(manifest, Some("chipA"));
+        let ids: Vec<&str> = out.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["on_device"]);
+    }
+
+    #[test]
+    fn select_unfiltered_when_no_device() {
+        let manifest = ReleaseManifest {
+            platform_url: String::new(),
+            models: vec![
+                hub_entry("b_model", &["RUNTIME_GENIEX_QAIRT"], &["chipA"], &[]),
+                hub_entry("a_model", &["RUNTIME_GENIEX_QAIRT"], &["chipB"], &[]),
+            ],
+        };
+        // None → no device filter; also asserts case-insensitive name sort.
+        let out = select_hub_models(manifest, None);
+        let ids: Vec<&str> = out.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["a_model", "b_model"]);
+    }
+
+    #[test]
+    fn select_classifies_vlm_from_tag() {
+        let manifest = ReleaseManifest {
+            platform_url: String::new(),
+            models: vec![
+                hub_entry(
+                    "vl_model",
+                    &["RUNTIME_GENIEX_QAIRT"],
+                    &["chipA"],
+                    &["MODEL_TAG_VLM"],
+                ),
+                hub_entry(
+                    "text_model",
+                    &["RUNTIME_GENIEX_QAIRT"],
+                    &["chipA"],
+                    &["MODEL_TAG_LLM"],
+                ),
+            ],
+        };
+        let out = select_hub_models(manifest, None);
+        assert_eq!(out[0].id, "text_model"); // sorted: text_ before vl_
+        assert_eq!(out[0].model_type, ModelType::Llm);
+        assert_eq!(out[1].model_type, ModelType::Vlm);
     }
 
     #[test]

--- a/sdk/model-manager/crates/ffi/src/hub_models.rs
+++ b/sdk/model-manager/crates/ffi/src/hub_models.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::os::raw::c_char;
+
+use model_manager_core::config::StoreConfig;
+use model_manager_core::source::ai_hub::{list_hub_models, AiHubConfig};
+
+use crate::init::{get_store, runtime_handle};
+use crate::store::{to_ffi_type, GenieXModelType};
+use crate::types::*;
+
+/* ---- geniex_model_list_hub ---- */
+
+#[repr(C)]
+pub struct GenieXHubModelInfo {
+    /// Pullable model name, e.g. `qualcomm/Qwen3-4B`.
+    pub name: *mut c_char,
+    pub model_type: GenieXModelType,
+    pub chipsets: *mut *mut c_char,
+    pub chipset_count: i32,
+}
+
+#[repr(C)]
+pub struct GenieXHubModelList {
+    pub models: *mut GenieXHubModelInfo,
+    pub count: i32,
+}
+
+/// List AI Hub models geniex can run. `chipset` is a NUL-terminated canonical
+/// chipset id to filter by, or NULL to list every model. Detecting the host
+/// chipset is the caller's job (see `geniex_model_detect_chipset`).
+#[no_mangle]
+pub extern "C" fn geniex_model_list_hub(
+    chipset: *const c_char,
+    out: *mut GenieXHubModelList,
+) -> i32 {
+    ffi_guard(|| {
+        if out.is_null() {
+            return Err(GENIEX_ERROR_COMMON_INVALID_INPUT);
+        }
+        let chipset = if chipset.is_null() {
+            None
+        } else {
+            Some(unsafe { cstr_to_str(chipset)? })
+        };
+        let store = get_store()?;
+        let cfg = AiHubConfig::new(
+            StoreConfig::ai_hub_base_url(),
+            StoreConfig::ai_hub_version(),
+            String::new(),
+            store.config().ai_hub_cache_dir(),
+            false,
+        );
+        let models = runtime_handle()
+            .block_on(list_hub_models(&cfg, chipset))
+            .map_err(|e| report(&e))?;
+
+        let infos: Vec<GenieXHubModelInfo> = models
+            .into_iter()
+            .map(|m| {
+                let chipsets_vec: Vec<*mut c_char> = m
+                    .supported_chipsets
+                    .iter()
+                    .map(|c| str_to_cptr(c))
+                    .collect();
+                let (chipsets, chipset_count) = into_c_array(chipsets_vec);
+                GenieXHubModelInfo {
+                    name: str_to_cptr(&format!("qualcomm/{}", m.display_name)),
+                    model_type: to_ffi_type(m.model_type),
+                    chipsets,
+                    chipset_count,
+                }
+            })
+            .collect();
+        let (models_ptr, count) = into_c_array(infos);
+        unsafe {
+            (*out).models = models_ptr;
+            (*out).count = count;
+        }
+        Ok(GENIEX_SUCCESS)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn geniex_model_list_hub_free(out: *mut GenieXHubModelList) {
+    if out.is_null() {
+        return;
+    }
+    let o = &mut *out;
+    if let Some(mut infos) = from_c_array(o.models, o.count) {
+        for info in infos.iter_mut() {
+            free_cptr(info.name);
+            if let Some(chipsets) = from_c_array(info.chipsets, info.chipset_count) {
+                for c in chipsets {
+                    free_cptr(c);
+                }
+            }
+        }
+    }
+    o.models = std::ptr::null_mut();
+    o.count = 0;
+}

--- a/sdk/model-manager/crates/ffi/src/lib.rs
+++ b/sdk/model-manager/crates/ffi/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 mod chipset;
+mod hub_models;
 mod init;
 mod logging;
 mod mapping;

--- a/sdk/model-manager/include/geniex_model.h
+++ b/sdk/model-manager/include/geniex_model.h
@@ -456,6 +456,44 @@ GENIEX_API void geniex_model_list_chipsets_free(geniex_ChipsetList* out);
  */
 GENIEX_API int32_t geniex_model_detect_chipset(char** out_chipset);
 
+/* ============================================================
+ *  Hub model catalogue
+ * ============================================================ */
+
+/**
+ * @brief One Qualcomm AI Hub model geniex can run (qairt / NPU).
+ *
+ * `name` and the `chipsets` array are heap-allocated; free the enclosing
+ * list with geniex_model_list_hub_free().
+ */
+typedef struct {
+    char*            name;          /**< Pullable name, e.g. "qualcomm/Qwen3-4B". */
+    geniex_ModelType model_type;    /**< LLM or VLM.                              */
+    char**           chipsets;      /**< Canonical chipset ids the model runs on. */
+    int32_t          chipset_count; /**< Length of `chipsets`.                    */
+} geniex_HubModelInfo;
+
+typedef struct {
+    geniex_HubModelInfo* models;
+    int32_t              count;
+} geniex_HubModelList;
+
+/**
+ * @brief List Qualcomm AI Hub models with a qairt (NPU) asset, sorted by name.
+ *
+ * Sourced from the remote `manifest.json` (cached 24h); may hit the network.
+ *
+ * @param chipset  Canonical chipset id to filter by, or NULL to list every
+ *                 model. Detecting the host chipset is the caller's job — see
+ *                 geniex_model_detect_chipset().
+ * @param out  Populated on success. Call geniex_model_list_hub_free() when done.
+ * @return GENIEX_SUCCESS, or a negative geniex_ErrorCode.
+ */
+GENIEX_API int32_t geniex_model_list_hub(const char* chipset, geniex_HubModelList* out);
+
+/** Free every model's name + chipsets array, then zero the struct. */
+GENIEX_API void geniex_model_list_hub_free(geniex_HubModelList* out);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -42,7 +42,9 @@ if(WIN32)
         geniex_model_resolve_hub
         geniex_model_list_chipsets
         geniex_model_list_chipsets_free
-        geniex_model_detect_chipset)
+        geniex_model_detect_chipset
+        geniex_model_list_hub
+        geniex_model_list_hub_free)
     target_link_libraries(geniex PRIVATE "${RUST_MODEL_LIB}")
     foreach(_sym ${GENIEX_MODEL_FFI_SYMBOLS})
         target_link_options(geniex PRIVATE


### PR DESCRIPTION
## Summary

Implements `geniex model list`, listing Qualcomm AI Hub models geniex can run
(those with a qairt / NPU build). By default results are filtered to the
current device's chipset; `--all` lists every model. Names are ready to pull,
e.g. `geniex pull qualcomm/Qwen3-4B`.

The "model not found" error hint already suggested `geniex model list`, but the
subcommand did not exist — now it does.

Landed as three scoped commits:

- **feat(sdk)** — `geniex_model_list_hub` in the model-manager FFI. Reads the
  inlined `supported_runtimes` / `supported_chipsets` from `manifest.json`
  (one fetch, 24h cache); the chipset filter is resolved through
  `platform.json` aliases, so a display name / alias / canonical id all match.
- **feat(bindings)** — Go / Python / Android wrappers per the FFI-update rule.
  Adds the `bindings` scope for changes spanning more than one language binding.
- **feat(cli)** — the `model list` subcommand. Chipset resolution (configured →
  host probe → interactive picker) is shared with the `pull` path.

## Test plan

- [x] `cargo test -p model-manager-core` — 56 pass
- [x] CLI builds (`bazelisk build //cli`) and `bazelisk test //cli/cmd/geniex/...` pass
- [x] `geniex model list --all` lists all 16 QAIRT models with a CHIPSETS column
- [x] `geniex model list` with a configured chipset filters correctly
      (display name, alias, and canonical id all resolve)
- [x] Python smoke: `list_hub_models()` = 16, `list_hub_models('qualcomm-snapdragon-x-elite')` = 15
- [x] SDK bridge rebuilt + installed; header shows `const char* chipset`

Closes #1389