### PR TITLE
fix(server): route reasoning_format to split thinking into reasoning_content

### DIFF
--- a/cli/cmd/geniex/common/BUILD.bazel
+++ b/cli/cmd/geniex/common/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//cli/internal/readline",
         "//cli/internal/render",
         "//cli/internal/store",
+        "//cli/internal/thinkfsm",
         "@com_github_bytedance_sonic//:sonic",
         "@com_github_lmittmann_tint//:tint",
     ] + select({

--- a/cli/cmd/geniex/common/process.go
+++ b/cli/cmd/geniex/common/process.go
@@ -18,6 +18,7 @@ import (
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/render"
+	"github.com/qualcomm/GenieX/cli/internal/thinkfsm"
 )
 
 var (
@@ -35,8 +36,7 @@ type Processor struct {
 	Run       func(prompt string, images, audios []string, onToken func(string) bool) (string, geniex_sdk.ProfileData, error)
 	Reset     func() error
 
-	fsm      map[[2]any][2]any
-	fsmState int
+	splitter *thinkfsm.Splitter
 }
 
 func (p *Processor) Process() error {
@@ -80,7 +80,7 @@ func (p *Processor) Process() error {
 		spin := render.NewSpinner("encoding...") // merge into fsm
 		spin.Start()
 
-		p.fsmInit()
+		p.splitter = thinkfsm.New()
 		stopGen = false
 		output, profileData, err := p.Run(prompt, images, audios, func(token string) bool {
 			if firstToken {
@@ -190,78 +190,29 @@ func (p *Processor) parseFiles(prompt string) (string, []string, []string, error
 
 // output parse
 
-const (
-	STATE_ASSISTANT = iota // init state
-	STATE_THINK
-	STATE_NORMAL
-
-	STATE_START
-	STATE_CHANNEL
-	STATE_ANALYSIS
-	STATE_FINAL
-	STATE_END
-
-	STATE_GEMMA_CHANNEL
-	STATE_GEMMA_CHANNEL_THOUGHT
-)
-
-func (p *Processor) fsmInit() {
-	thinkStart := func(extraLine bool) func() {
-		return func() {
-			render.GetTheme().Set(render.GetTheme().ThinkOutput)
-			if extraLine {
-				fmt.Print("<think>\n")
-			} else {
-				fmt.Print("<think>")
-			}
-		}
-	}
-	thinkEnd := func(extraLine bool) func() {
-		return func() {
-			if extraLine {
-				fmt.Print("\n</think>\n\n")
-			} else {
-				fmt.Print("</think>")
-			}
-			render.GetTheme().Set(render.GetTheme().ModelOutput)
-		}
-	}
-	p.fsm = map[[2]any][2]any{
-		// normal
-		{STATE_ASSISTANT, "<think>"}: {STATE_THINK, thinkStart(false)},
-		{STATE_THINK, "</think>"}:    {STATE_NORMAL, thinkEnd(false)},
-
-		// gpt-oss
-		{STATE_ASSISTANT, "<|channel|>"}: {STATE_CHANNEL, nil},
-		{STATE_CHANNEL, "analysis"}:      {STATE_ANALYSIS, nil},
-		{STATE_CHANNEL, "final"}:         {STATE_FINAL, nil},
-		{STATE_ANALYSIS, "<|message|>"}:  {STATE_THINK, thinkStart(true)},
-		{STATE_FINAL, "<|message|>"}:     {STATE_NORMAL, nil},
-		{STATE_THINK, "<|end|>"}:         {STATE_END, thinkEnd(true)},
-		{STATE_NORMAL, "<|end|>"}:        {STATE_END, nil},
-		{STATE_END, "<|start|>"}:         {STATE_START, nil},
-		{STATE_START, "assistant"}:       {STATE_ASSISTANT, nil},
-
-		// gemma4
-		{STATE_ASSISTANT, "<|channel>"}:     {STATE_GEMMA_CHANNEL, nil},
-		{STATE_GEMMA_CHANNEL, "thought"}:    {STATE_GEMMA_CHANNEL_THOUGHT, nil},
-		{STATE_GEMMA_CHANNEL_THOUGHT, "\n"}: {STATE_THINK, thinkStart(true)},
-		{STATE_THINK, "<channel|>"}:         {STATE_NORMAL, thinkEnd(true)},
-	}
-	p.fsmState = STATE_ASSISTANT
-}
-
+// fsmEvent routes one generated token through the shared think splitter,
+// decorating reasoning spans with colored <think> tags for the terminal. The
+// server drives the same splitter to fill reasoning_content instead.
 func (p *Processor) fsmEvent(token string) {
-	next, ok := p.fsm[[2]any{p.fsmState, token}]
-	if ok {
-		p.fsmState = next[0].(int)
-		if next[1] != nil {
-			next[1].(func())()
+	ev := p.splitter.Feed(token)
+	switch {
+	case ev.Boundary == thinkfsm.EnterReasoning:
+		render.GetTheme().Set(render.GetTheme().ThinkOutput)
+		if ev.Block {
+			fmt.Print("<think>\n")
+		} else {
+			fmt.Print("<think>")
 		}
-		return
+	case ev.Boundary == thinkfsm.ExitReasoning:
+		if ev.Block {
+			fmt.Print("\n</think>\n\n")
+		} else {
+			fmt.Print("</think>")
+		}
+		render.GetTheme().Set(render.GetTheme().ModelOutput)
+	case !ev.Consumed:
+		fmt.Print(ev.Text)
 	}
-
-	fmt.Print(token)
 }
 
 // print profile data

--- a/cli/internal/thinkfsm/BUILD.bazel
+++ b/cli/internal/thinkfsm/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "thinkfsm",
+    srcs = ["thinkfsm.go"],
+    importpath = "github.com/qualcomm/GenieX/cli/internal/thinkfsm",
+    visibility = ["//cli:__subpackages__"],
+)
+
+go_test(
+    name = "thinkfsm_test",
+    srcs = ["thinkfsm_test.go"],
+    embed = [":thinkfsm"],
+)

--- a/cli/internal/thinkfsm/thinkfsm.go
+++ b/cli/internal/thinkfsm/thinkfsm.go
@@ -1,0 +1,107 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package thinkfsm splits a model's token stream into reasoning ("thinking")
+// and normal content. Markers (`<think>`, gpt-oss `<|channel|>`, gemma
+// `<|channel>`) arrive as single tokens, so it must be fed one token at a time
+// — the same tags concatenated into a text blob would not match. Both terminal
+// rendering (geniex infer/run) and reasoning_content separation (geniex serve)
+// drive this one table.
+package thinkfsm
+
+type state int
+
+const (
+	stateAssistant state = iota // init state
+	stateThink                  // reasoning
+	stateNormal
+
+	// gpt-oss channels
+	stateStart
+	stateChannel
+	stateAnalysis
+	stateFinal
+	stateEnd
+
+	// gemma channels
+	stateGemmaChannel
+	stateGemmaChannelThought
+)
+
+var reasoningStates = map[state]bool{
+	stateThink: true,
+}
+
+type Boundary int
+
+const (
+	NoBoundary Boundary = iota
+	EnterReasoning
+	ExitReasoning
+)
+
+type transition struct {
+	next     state
+	boundary Boundary
+	// block spans its own lines (channel-style), vs the inline <think>...</think>
+	// pair. Terminal rendering uses it to pick decoration; the server ignores it.
+	block bool
+}
+
+type key struct {
+	s     state
+	token string
+}
+
+// transitions is the single source of truth for think-token handling. Any
+// (state, token) absent here is an ordinary token, classified by reasoningStates.
+var transitions = map[key]transition{
+	// normal <think>...</think>
+	{stateAssistant, "<think>"}: {next: stateThink, boundary: EnterReasoning},
+	{stateThink, "</think>"}:    {next: stateNormal, boundary: ExitReasoning},
+
+	// gpt-oss
+	{stateAssistant, "<|channel|>"}: {next: stateChannel},
+	{stateChannel, "analysis"}:      {next: stateAnalysis},
+	{stateChannel, "final"}:         {next: stateFinal},
+	{stateAnalysis, "<|message|>"}:  {next: stateThink, boundary: EnterReasoning, block: true},
+	{stateFinal, "<|message|>"}:     {next: stateNormal},
+	{stateThink, "<|end|>"}:         {next: stateEnd, boundary: ExitReasoning, block: true},
+	{stateNormal, "<|end|>"}:        {next: stateEnd},
+	{stateEnd, "<|start|>"}:         {next: stateStart},
+	{stateStart, "assistant"}:       {next: stateAssistant},
+
+	// gemma4
+	{stateAssistant, "<|channel>"}:   {next: stateGemmaChannel},
+	{stateGemmaChannel, "thought"}:   {next: stateGemmaChannelThought},
+	{stateGemmaChannelThought, "\n"}: {next: stateThink, boundary: EnterReasoning, block: true},
+	{stateThink, "<channel|>"}:       {next: stateNormal, boundary: ExitReasoning, block: true},
+}
+
+// Event routes one token. A consumed marker (e.g. the <think> tag) belongs to
+// no output stream; otherwise Text goes to the reasoning or content stream.
+type Event struct {
+	Consumed  bool
+	Boundary  Boundary // only when Consumed
+	Block     bool     // only when Consumed
+	Text      string   // only when !Consumed
+	Reasoning bool     // only when !Consumed
+}
+
+// Splitter tracks one generation's think state. Create one per generation with
+// New; not safe for concurrent use.
+type Splitter struct {
+	state state
+}
+
+func New() *Splitter {
+	return &Splitter{state: stateAssistant}
+}
+
+func (s *Splitter) Feed(token string) Event {
+	if t, ok := transitions[key{s.state, token}]; ok {
+		s.state = t.next
+		return Event{Consumed: true, Boundary: t.boundary, Block: t.block}
+	}
+	return Event{Text: token, Reasoning: reasoningStates[s.state]}
+}

--- a/cli/internal/thinkfsm/thinkfsm_test.go
+++ b/cli/internal/thinkfsm/thinkfsm_test.go
@@ -1,0 +1,97 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package thinkfsm
+
+import "testing"
+
+// split feeds tokens through a fresh splitter and returns the concatenated
+// content and reasoning streams (markers dropped).
+func split(tokens []string) (content, reasoning string) {
+	s := New()
+	for _, tok := range tokens {
+		ev := s.Feed(tok)
+		if ev.Consumed {
+			continue
+		}
+		if ev.Reasoning {
+			reasoning += ev.Text
+		} else {
+			content += ev.Text
+		}
+	}
+	return content, reasoning
+}
+
+func TestSplit(t *testing.T) {
+	cases := []struct {
+		name          string
+		tokens        []string
+		wantContent   string
+		wantReasoning string
+	}{
+		{
+			name:        "plain content, no thinking",
+			tokens:      []string{"2", "+", "2", " is ", "4"},
+			wantContent: "2+2 is 4",
+		},
+		{
+			name:          "inline think block",
+			tokens:        []string{"<think>", "hmm", " 2+2", "</think>", "4"},
+			wantContent:   "4",
+			wantReasoning: "hmm 2+2",
+		},
+		{
+			name:          "gpt-oss channels",
+			tokens:        []string{"<|channel|>", "analysis", "<|message|>", "reason", "<|end|>", "<|start|>", "assistant", "<|channel|>", "final", "<|message|>", "answer"},
+			wantContent:   "answer",
+			wantReasoning: "reason",
+		},
+		{
+			name:          "gemma channel thought",
+			tokens:        []string{"<|channel>", "thought", "\n", "think", "<channel|>", "reply"},
+			wantContent:   "reply",
+			wantReasoning: "think",
+		},
+		{
+			name:        "unterminated think stays reasoning",
+			tokens:      []string{"<think>", "still", " going"},
+			wantContent: "",
+			// everything after <think> is reasoning until a close marker
+			wantReasoning: "still going",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content, reasoning := split(tc.tokens)
+			if content != tc.wantContent {
+				t.Errorf("content = %q, want %q", content, tc.wantContent)
+			}
+			if reasoning != tc.wantReasoning {
+				t.Errorf("reasoning = %q, want %q", reasoning, tc.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestFeedBoundaries(t *testing.T) {
+	s := New()
+
+	ev := s.Feed("<think>")
+	if !ev.Consumed || ev.Boundary != EnterReasoning {
+		t.Fatalf("<think>: got %+v, want consumed EnterReasoning", ev)
+	}
+	ev = s.Feed("x")
+	if ev.Consumed || ev.Reasoning != true || ev.Text != "x" {
+		t.Fatalf("x: got %+v, want reasoning text", ev)
+	}
+	ev = s.Feed("</think>")
+	if !ev.Consumed || ev.Boundary != ExitReasoning {
+		t.Fatalf("</think>: got %+v, want consumed ExitReasoning", ev)
+	}
+	ev = s.Feed("y")
+	if ev.Consumed || ev.Reasoning || ev.Text != "y" {
+		t.Fatalf("y: got %+v, want content text", ev)
+	}
+}

--- a/cli/server/docs/swagger.yaml
+++ b/cli/server/docs/swagger.yaml
@@ -233,6 +233,11 @@ components:
           type: boolean
           description: Whether to enable thinking mode for the model
           default: true
+        reasoning_format:
+          type: string
+          enum: [none, deepseek, deepseek-legacy, auto]
+          description: Where to put the model's chain-of-thought. `none` keeps it inline in `message.content` (default); `deepseek` / `deepseek-legacy` / `auto` move it to `message.reasoning_content`. Ignored for tool-call requests.
+          default: none
         top_k:
           type: integer
           minimum: 0
@@ -304,6 +309,9 @@ components:
               items:
                 $ref: "#/components/schemas/ChatMessageContent"
           description: The contents of the message
+        reasoning_content:
+          type: string
+          description: The model's chain-of-thought, present on assistant responses only when the request set `reasoning_format` to a separating value (e.g. `deepseek`).
         name:
           type: string
           description: The name of the author of this message

--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//bindings/go:geniex_sdk_go",
         "//cli/internal/config",
         "//cli/internal/store",
+        "//cli/internal/thinkfsm",
         "//cli/internal/types",
         "//cli/server/service",
         "//cli/server/utils",
@@ -27,6 +28,8 @@ go_library(
 
 go_cgo_test(
     name = "handler_test",
-    srcs = ["package_test.go"],
+    srcs = [
+        "chat_test.go",
+    ],
     embed = [":handler"],
 )

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -23,6 +23,7 @@ import (
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/config"
 	"github.com/qualcomm/GenieX/cli/internal/store"
+	"github.com/qualcomm/GenieX/cli/internal/thinkfsm"
 	"github.com/qualcomm/GenieX/cli/internal/types"
 	"github.com/qualcomm/GenieX/cli/server/service"
 	"github.com/qualcomm/GenieX/cli/server/utils"
@@ -40,6 +41,9 @@ type ChatCompletionRequest struct {
 	NCtx        int32  `json:"nctx"`
 	Ngl         int32  `json:"ngl"` // 0 = pure CPU, -1 = all layers, N = N layers; defaults to the server --ngl when omitted
 	Compute     string `json:"compute"`
+	// ReasoningFormat: "" / "none" keeps thinking inline in content (default);
+	// "deepseek" / "deepseek-legacy" / "auto" move it to reasoning_content.
+	ReasoningFormat string `json:"reasoning_format"`
 
 	ImageMaxLength int32 `json:"image_max_length"`
 
@@ -267,6 +271,8 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		return
 	}
 
+	reasoner := newReasoner(param, parseTool)
+
 	if param.Stream {
 		stopGen := false
 		dataCh := make(chan string)
@@ -302,7 +308,7 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		finish := func() string { return mapFinishReason(res.ProfileData.StopReason) }
 		includeUsage := param.StreamOptions.IncludeUsage.Value
 		if !parseTool {
-			streamPlainText(c, dataCh, wait, includeUsage, usage, finish)
+			streamPlainText(c, dataCh, wait, includeUsage, usage, finish, reasoner)
 		} else {
 			streamToolCall(c, dataCh, wait, includeUsage, usage, finish)
 		}
@@ -312,8 +318,10 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		}
 
 	} else {
+		var content, reasoning strings.Builder
 		genOut, err := p.Generate(geniex_sdk.LlmGenerateInput{
 			PromptUTF8: formatted.FormattedText,
+			OnToken:    reasoningSink(reasoner, &content, &reasoning),
 			Config: &geniex_sdk.GenerationConfig{
 				MaxTokens:     int32(param.MaxCompletionTokens.Value),
 				SamplerConfig: samplerConfig,
@@ -327,7 +335,7 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return
 		}
-		writeBlockingResponse(c, genOut.FullText, genOut.ProfileData, parseTool)
+		writeBlockingResponse(c, content.String(), reasoning.String(), genOut.ProfileData, parseTool)
 	}
 }
 
@@ -499,6 +507,8 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		}
 	}
 
+	reasoner := newReasoner(param, parseTool)
+
 	if param.Stream {
 		stopGen := false
 		dataCh := make(chan string)
@@ -538,7 +548,7 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		finish := func() string { return mapFinishReason(res.ProfileData.StopReason) }
 		includeUsage := param.StreamOptions.IncludeUsage.Value
 		if !parseTool {
-			streamPlainText(c, dataCh, wait, includeUsage, usage, finish)
+			streamPlainText(c, dataCh, wait, includeUsage, usage, finish, reasoner)
 		} else {
 			streamToolCall(c, dataCh, wait, includeUsage, usage, finish)
 		}
@@ -548,8 +558,10 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		}
 
 	} else {
+		var content, reasoning strings.Builder
 		genOut, err := p.Generate(geniex_sdk.VlmGenerateInput{
 			PromptUTF8: formatted.FormattedText,
+			OnToken:    reasoningSink(reasoner, &content, &reasoning),
 			Config: &geniex_sdk.GenerationConfig{
 				MaxTokens:      int32(param.MaxCompletionTokens.Value),
 				SamplerConfig:  samplerConfig,
@@ -566,7 +578,62 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return
 		}
-		writeBlockingResponse(c, genOut.FullText, genOut.ProfileData, parseTool)
+		writeBlockingResponse(c, content.String(), reasoning.String(), genOut.ProfileData, parseTool)
+	}
+}
+
+// =============== reasoning routing ===============
+
+// reasoningSeparated reports whether a reasoning_format moves thinking output
+// into reasoning_content. "" / "none" keep it inline in content (default,
+// back-compatible); everything else (deepseek, deepseek-legacy, auto) separates.
+func reasoningSeparated(format string) bool {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "none":
+		return false
+	default:
+		return true
+	}
+}
+
+// newReasoner returns a think-splitter when the request wants thinking moved to
+// reasoning_content, or nil to keep it inline in content (default). Tool-call
+// parsing needs the raw <think>-tagged stream, so it disables separation.
+func newReasoner(param ChatCompletionRequest, parseTool bool) *thinkfsm.Splitter {
+	if parseTool || !reasoningSeparated(param.ReasoningFormat) {
+		return nil
+	}
+	return thinkfsm.New()
+}
+
+// route classifies a generated token. emit is false for consumed markers (the
+// <think> tag itself); otherwise text goes to reasoning_content when reasoning
+// is true, else to content. A nil splitter (separation off) passes every token
+// through as content verbatim, keeping default output byte-identical.
+func route(s *thinkfsm.Splitter, token string) (text string, reasoning, emit bool) {
+	if s == nil {
+		return token, false, true
+	}
+	ev := s.Feed(token)
+	if ev.Consumed {
+		return "", false, false
+	}
+	return ev.Text, ev.Reasoning, true
+}
+
+// reasoningSink returns an OnToken callback that accumulates routed tokens into
+// content and reasoning_content — the non-streaming path only gets the joined
+// text otherwise.
+func reasoningSink(s *thinkfsm.Splitter, content, reasoning *strings.Builder) func(string) bool {
+	return func(token string) bool {
+		if text, isReasoning, emit := route(s, token); emit {
+			if isReasoning {
+				reasoning.WriteString(text)
+			} else {
+				content.WriteString(text)
+			}
+		}
+		return true
 	}
 }
 
@@ -639,11 +706,34 @@ func writeContextLengthExceeded(c *gin.Context, fullText string, profile geniex_
 	})
 }
 
+// blockingMessage mirrors the assistant message but adds reasoning_content,
+// which openai-go's ChatCompletionMessage lacks. Used only when thinking is
+// separated so the default (inline) response stays byte-identical.
+type blockingMessage struct {
+	Role             string `json:"role"`
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+type blockingChoice struct {
+	Index        int64           `json:"index"`
+	Message      blockingMessage `json:"message"`
+	FinishReason string          `json:"finish_reason"`
+}
+
+type blockingResponse struct {
+	Object  string                 `json:"object"`
+	Choices []blockingChoice       `json:"choices"`
+	Usage   openai.CompletionUsage `json:"usage"`
+}
+
 // writeBlockingResponse emits a non-streaming completion: tool-call response
 // when parseTool matches, content response otherwise (or on parse failure).
-func writeBlockingResponse(c *gin.Context, fullText string, profile geniex_sdk.ProfileData, parseTool bool) {
+// reasoning is non-empty only when the request asked to separate thinking; it
+// is surfaced under message.reasoning_content and never parsed for tool calls.
+func writeBlockingResponse(c *gin.Context, content, reasoning string, profile geniex_sdk.ProfileData, parseTool bool) {
 	if parseTool {
-		toolCall, err := utils.ParseToolCalls(fullText)
+		toolCall, err := utils.ParseToolCalls(content)
 		if err == nil {
 			choice := openai.ChatCompletionChoice{}
 			choice.FinishReason = "tool_calls"
@@ -662,13 +752,30 @@ func writeBlockingResponse(c *gin.Context, fullText string, profile geniex_sdk.P
 		slog.Warn("Tool call parse error, fallback to text", "error", err)
 	}
 
-	choice := openai.ChatCompletionChoice{}
-	choice.FinishReason = mapFinishReason(profile.StopReason)
-	choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
-	choice.Message.Content = fullText
-	c.JSON(http.StatusOK, openai.ChatCompletion{
-		Choices: []openai.ChatCompletionChoice{choice},
-		Usage:   profile2Usage(profile),
+	// Default (no separation): keep the exact openai.ChatCompletion shape.
+	if reasoning == "" {
+		choice := openai.ChatCompletionChoice{}
+		choice.FinishReason = mapFinishReason(profile.StopReason)
+		choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
+		choice.Message.Content = content
+		c.JSON(http.StatusOK, openai.ChatCompletion{
+			Choices: []openai.ChatCompletionChoice{choice},
+			Usage:   profile2Usage(profile),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, blockingResponse{
+		Object: "chat.completion",
+		Choices: []blockingChoice{{
+			Message: blockingMessage{
+				Role:             string(openai.MessageRoleAssistant),
+				Content:          content,
+				ReasoningContent: reasoning,
+			},
+			FinishReason: mapFinishReason(profile.StopReason),
+		}},
+		Usage: profile2Usage(profile),
 	})
 }
 
@@ -688,9 +795,10 @@ type streamFinish func() string
 // give the stream spec-compliant serialization.
 
 type streamDelta struct {
-	Role      string                                          `json:"role,omitempty"`
-	Content   string                                          `json:"content,omitempty"`
-	ToolCalls []openai.ChatCompletionChunkChoiceDeltaToolCall `json:"tool_calls,omitempty"`
+	Role             string                                          `json:"role,omitempty"`
+	Content          string                                          `json:"content,omitempty"`
+	ReasoningContent string                                          `json:"reasoning_content,omitempty"`
+	ToolCalls        []openai.ChatCompletionChunkChoiceDeltaToolCall `json:"tool_calls,omitempty"`
 }
 
 type streamChoice struct {
@@ -716,6 +824,18 @@ func contentChunk(content string) streamChunk {
 	}
 }
 
+// tokenChunk emits a routed token as either a content or a reasoning_content
+// delta.
+func tokenChunk(text string, reasoning bool) streamChunk {
+	delta := streamDelta{Role: string(openai.MessageRoleAssistant)}
+	if reasoning {
+		delta.ReasoningContent = text
+	} else {
+		delta.Content = text
+	}
+	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{{Delta: delta}}}
+}
+
 // finishChunk is the terminal chunk: empty delta, non-null finish_reason.
 func finishChunk(reason string) streamChunk {
 	return streamChunk{
@@ -728,13 +848,16 @@ func usageChunk(u openai.CompletionUsage) streamChunk {
 	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{}, Usage: &u}
 }
 
-// streamPlainText drains dataCh as content chunks, then emits the finishing
-// chunk, optional usage and [DONE].
-func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, usage streamUsage, finish streamFinish) {
+// streamPlainText drains dataCh, routing each token into content or
+// reasoning_content deltas, then emits the finishing chunk, optional usage and
+// [DONE].
+func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, usage streamUsage, finish streamFinish, reasoner *thinkfsm.Splitter) {
 	c.Stream(func(w io.Writer) bool {
 		r, ok := <-dataCh
 		if ok {
-			c.SSEvent("", contentChunk(r))
+			if text, reasoning, emit := route(reasoner, r); emit {
+				c.SSEvent("", tokenChunk(text, reasoning))
+			}
 			return true
 		}
 		if err := wait(); err != nil {

--- a/cli/server/handler/chat_test.go
+++ b/cli/server/handler/chat_test.go
@@ -1,0 +1,60 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/qualcomm/GenieX/cli/internal/thinkfsm"
+)
+
+func TestReasoningSeparated(t *testing.T) {
+	cases := map[string]bool{
+		"":                false,
+		"none":            false,
+		"None":            false,
+		"  none  ":        false,
+		"deepseek":        true,
+		"deepseek-legacy": true,
+		"auto":            true,
+	}
+	for format, want := range cases {
+		if got := reasoningSeparated(format); got != want {
+			t.Errorf("reasoningSeparated(%q) = %v, want %v", format, got, want)
+		}
+	}
+}
+
+func TestReasoningSink(t *testing.T) {
+	tokens := []string{"<think>", "reason", "</think>", "answer"}
+
+	t.Run("separation splits think block", func(t *testing.T) {
+		var content, reasoning strings.Builder
+		sink := reasoningSink(thinkfsm.New(), &content, &reasoning)
+		for _, tok := range tokens {
+			sink(tok)
+		}
+		if got := content.String(); got != "answer" {
+			t.Errorf("content = %q, want %q", got, "answer")
+		}
+		if got := reasoning.String(); got != "reason" {
+			t.Errorf("reasoning = %q, want %q", got, "reason")
+		}
+	})
+
+	t.Run("nil splitter keeps everything inline", func(t *testing.T) {
+		var content, reasoning strings.Builder
+		sink := reasoningSink(nil, &content, &reasoning)
+		for _, tok := range tokens {
+			sink(tok)
+		}
+		if got := content.String(); got != "<think>reason</think>answer" {
+			t.Errorf("content = %q, want raw inline", got)
+		}
+		if got := reasoning.String(); got != "" {
+			t.Errorf("reasoning = %q, want empty", got)
+		}
+	})
+}

--- a/cli/server/handler/package_test.go
+++ b/cli/server/handler/package_test.go
@@ -1,8 +1,0 @@
-// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
-// SPDX-License-Identifier: BSD-3-Clause
-
-package handler
-
-import "testing"
-
-func TestPackageBuilds(t *testing.T) {}

--- a/docs/cn/run/cli/local-server.mdx
+++ b/docs/cn/run/cli/local-server.mdx
@@ -163,6 +163,31 @@ finish_reason: stop
 usage: CompletionUsage(completion_tokens=58, prompt_tokens=19, total_tokens=77, ...)
 ```
 
+### **分离推理内容（reasoning_content）**
+
+思考模型默认会把思维链原样保留在 `message.content`（`<think>…</think>`），与最终回复混在一起。传入 `reasoning_format="deepseek"` 可让服务器把思维链拆到 OpenAI 标准的 `message.reasoning_content` 字段，`content` 只保留干净的回复。
+
+<Note>
+`reasoning_format` 与 `enable_think` 是两件事：`enable_think=False` 让模型**不产生**思维链；`reasoning_format="deepseek"` 让模型照常思考，但把思维链**移出** `content`。取值 `none`（默认）保持原样内联，`deepseek` / `deepseek-legacy` / `auto` 均触发分离。工具调用请求会忽略该参数（工具解析需要原始带标签的文本）。
+</Note>
+
+```python python
+resp = client.chat.completions.create(
+    model="unsloth/Qwen3-4B-GGUF:Q4_0",
+    messages=[
+        {"role": "user", "content": "What is 2+2? Answer briefly."},
+    ],
+    max_tokens=128,
+    extra_body={"reasoning_format": "deepseek"},
+)
+
+msg = resp.choices[0].message
+print("reasoning:", msg.model_extra.get("reasoning_content"))
+print("content:", msg.content)
+```
+
+流式响应同理——思维链以 `delta.reasoning_content` 增量返回，最终回复以 `delta.content` 返回。
+
 ### **工具调用（Tool calling）**
 
 函数/工具调用使用标准的 OpenAI `tools` schema。服务器会从模型生成的文本中解析工具调用（`<tool_call>…</tool_call>` 标签或 ` ```json ` 代码块），并以 OpenAI `tool_calls` 形式返回。VLM **也走同一条路径**——模型可以先看图，再决定搜什么、调用工具。

--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -95,6 +95,8 @@ Describe this picture </full/path/to/image.png>
 geniex serve
 ```
 
+要把思考模型的思维链从 `message.content` 移到 `message.reasoning_content`，在单次请求中设置 `reasoning_format` 字段即可——详见[分离推理内容](/cn/run/cli/local-server#分离推理内容reasoning_content)。
+
 ## **日志**
 
 `--log` 是全局标志，控制 CLI 的日志输出。它与 `GENIEX_LOG` 环境变量等效，且当二者同时设置时优先于 `GENIEX_LOG`。

--- a/docs/en/run/cli/local-server.mdx
+++ b/docs/en/run/cli/local-server.mdx
@@ -163,6 +163,31 @@ finish_reason: stop
 usage: CompletionUsage(completion_tokens=58, prompt_tokens=19, total_tokens=77, ...)
 ```
 
+### **Separating reasoning (reasoning_content)**
+
+By default a thinking model leaves its chain-of-thought inline in `message.content` (`<think>…</think>`), mixed in with the final reply. Pass `reasoning_format="deepseek"` to make the server move the chain-of-thought into the OpenAI-standard `message.reasoning_content` field, leaving `content` clean.
+
+<Note>
+`reasoning_format` is not the same as `enable_think`: `enable_think=False` makes the model **not produce** a chain-of-thought at all, while `reasoning_format="deepseek"` lets it think as usual but **moves** the thinking out of `content`. Values are `none` (default, kept inline) and `deepseek` / `deepseek-legacy` / `auto` (all separate). Tool-call requests ignore this parameter (tool parsing needs the raw tagged text).
+</Note>
+
+```python python
+resp = client.chat.completions.create(
+    model="unsloth/Qwen3-4B-GGUF:Q4_0",
+    messages=[
+        {"role": "user", "content": "What is 2+2? Answer briefly."},
+    ],
+    max_tokens=128,
+    extra_body={"reasoning_format": "deepseek"},
+)
+
+msg = resp.choices[0].message
+print("reasoning:", msg.model_extra.get("reasoning_content"))
+print("content:", msg.content)
+```
+
+Streaming works the same way — the chain-of-thought arrives as `delta.reasoning_content` deltas and the final reply as `delta.content`.
+
 ### **Tool calling**
 
 Function/tool calling uses the standard OpenAI `tools` schema. The server extracts the tool call from the model's generated text (`<tool_call>…</tool_call>` tags or a fenced ` ```json ` block) and re-emits it as OpenAI `tool_calls`. The flow works with **VLMs too** — the model can look at an image, decide what to search for, and call a tool.

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -95,6 +95,8 @@ Start the OpenAI-compatible local server. See [Local server](/en/run/cli/local-s
 geniex serve
 ```
 
+To move a thinking model's chain-of-thought out of `message.content` into `message.reasoning_content`, set the per-request `reasoning_format` field — see [Separating reasoning](/en/run/cli/local-server#separating-reasoning-reasoning_content).
+
 ## **Logging**
 
 `--log` is a global flag controlling the CLI's log output. It is equivalent to the `GENIEX_LOG` environment variable and takes precedence over it when both are set.


### PR DESCRIPTION
## Summary

`geniex serve` always emitted a thinking model's chain-of-thought inside `message.content`, with no way to disable it or move it to the OpenAI-ecosystem-standard `reasoning_content` field (#1294).

This honors the per-request `reasoning_format` body param (mirroring the llama.cpp backend that already understands it):

- `""` / `none` — keep thinking inline in `content` (default, behavior unchanged).
- `deepseek` / `deepseek-legacy` / `auto` — move the chain-of-thought into `message.reasoning_content` (blocking) or `delta.reasoning_content` (streaming).

Tool-call requests ignore the flag, since tool parsing needs the raw `<think>`-tagged text.

The reasoning split reuses the token FSM that `geniex infer`/`run` already render with, extracted into a new dependency-free `cli/internal/thinkfsm` package so both the terminal and the server drive one transition table. `reasoning_content` is not a field in `openai-go` (no version has it — it is a DeepSeek-originated de-facto standard), so the separated responses use small local structs; the default inline path still serializes the exact `openai.ChatCompletion` shape byte-for-byte.

## Test plan

- [x] `bazelisk test //cli/internal/thinkfsm:thinkfsm_test` — FSM split across plain / inline-think / gpt-oss / gemma / unterminated inputs.
- [x] `bazelisk test //cli/server/handler:handler_test` — `reasoningSeparated` mapping and `reasoningSink` routing (separation on/off).
- [x] `bazelisk build //cli` — full CLI builds.
- [x] `gofmt` clean on all touched Go files.

Closes #1294