### PR TITLE
feat(cli): auto-detect RB3 Gen2 and default compute to cpu

### DIFF
--- a/bindings/android/app/src/main/cpp/model_manager_jni.cpp
+++ b/bindings/android/app/src/main/cpp/model_manager_jni.cpp
@@ -557,9 +557,10 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_com_geniex_sdk_jni_ModelManager_l
     return arr;
 }
 
-extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_jni_ModelManager_detectChipset(JNIEnv* env, jobject /*thiz*/) {
+extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_jni_ModelManager_detectChipset(
+    JNIEnv* env, jobject /*thiz*/, jboolean offline) {
     char*   out = nullptr;
-    int32_t rc  = geniex_model_detect_chipset(&out);
+    int32_t rc  = geniex_model_detect_chipset(offline ? 1 : 0, &out);
     if (rc != GENIEX_SUCCESS || !out) return nullptr;
     jstring result = env->NewStringUTF(out);
     geniex_free(out);

--- a/bindings/android/app/src/main/java/com/geniex/sdk/ModelManagerWrapper.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/ModelManagerWrapper.kt
@@ -117,8 +117,8 @@ object ModelManagerWrapper {
         native.listChipsets().toList()
     }
 
-    suspend fun detectChipset(): String? = withContext(Dispatchers.IO) {
-        native.detectChipset()
+    suspend fun detectChipset(offline: Boolean = false): String? = withContext(Dispatchers.IO) {
+        native.detectChipset(offline)
     }
 
     suspend fun listHubModels(chipset: String? = null): List<HubModel> = withContext(Dispatchers.IO) {

--- a/bindings/android/app/src/main/java/com/geniex/sdk/jni/ModelManager.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/jni/ModelManager.kt
@@ -74,8 +74,8 @@ internal class ModelManager {
     /** Chipsets Qualcomm AI Hub supports, with aliases (sourced from platform.json). */
     external fun listChipsets(): Array<ChipsetInfo>
 
-    /** Detect the host chipset via a local probe. @return `null` if not probeable. */
-    external fun detectChipset(): String?
+    /** Detect the host chipset. [offline] stays local; else may hit the network. @return `null` if not probeable. */
+    external fun detectChipset(offline: Boolean): String?
 
     /**
      * AI Hub models with a qairt (NPU) build, sorted by name (from manifest.json).

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -280,11 +280,15 @@ func ModelListChipsets() ([]ChipsetInfo, error) {
 	return result, nil
 }
 
-// ModelDetectChipset probes the current host for its chipset via a local
-// detector (no network). Returns "" when the platform can't be probed.
-func ModelDetectChipset() (string, error) {
+// ModelDetectChipset probes the host chipset. offline=true stays local (returns
+// the canonical id); else it may hit the network. Returns "" when not probeable.
+func ModelDetectChipset(offline bool) (string, error) {
+	var cOffline C.int32_t
+	if offline {
+		cOffline = 1
+	}
 	var out *C.char
-	if res := C.geniex_model_detect_chipset(&out); res != C.GENIEX_SUCCESS {
+	if res := C.geniex_model_detect_chipset(cOffline, &out); res != C.GENIEX_SUCCESS {
 		return "", modelError(res)
 	}
 	if out == nil {

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -296,7 +296,7 @@ def _bind_all() -> None:
     lib.geniex_model_list_chipsets_free.argtypes = [POINTER(geniex_ChipsetList)]
     lib.geniex_model_list_chipsets_free.restype = None
 
-    lib.geniex_model_detect_chipset.argtypes = [POINTER(c_char_p)]
+    lib.geniex_model_detect_chipset.argtypes = [c_int32, POINTER(c_char_p)]
     lib.geniex_model_detect_chipset.restype = c_int32
 
     lib.geniex_model_list_hub.argtypes = [c_char_p, POINTER(geniex_HubModelList)]

--- a/bindings/python/geniex/model_manager.py
+++ b/bindings/python/geniex/model_manager.py
@@ -498,15 +498,14 @@ def list_chipsets() -> list[ChipsetInfo]:
         lib.geniex_model_list_chipsets_free(byref(out))
 
 
-def detect_chipset() -> str | None:
-    """Detect the current host's chipset via a local probe (no network).
-
-    Returns ``None`` when the platform cannot be probed.
+def detect_chipset(offline: bool = False) -> str | None:
+    """Detect the host chipset. ``offline`` stays local (canonical id); else it
+    may hit the network. Returns ``None`` when not probeable.
     """
     _ensure_init()
     lib = load_library()
     out = c_char_p()
-    _check(lib.geniex_model_detect_chipset(byref(out)))
+    _check(lib.geniex_model_detect_chipset(c_int32(1 if offline else 0), byref(out)))
     if not out.value:
         return None
     try:

--- a/cli/cmd/geniex/config.go
+++ b/cli/cmd/geniex/config.go
@@ -68,7 +68,9 @@ func configGetCmd() *cobra.Command {
 			// The chipset key falls back to host autodetection when unset,
 			// reporting "unknown" if the host cannot be probed.
 			if key == store.ConfigKeyChipset && value == "" {
-				value = resolveChipset()
+				if value = store.Get().ResolveChipset(false); value == "" {
+					value = "unknown"
+				}
 			}
 			// Other unset keys print nothing so the output is easy to use in
 			// scripts (e.g. `$(geniex config get chipset)`).
@@ -115,24 +117,11 @@ func configSetCmd() *cobra.Command {
 	}
 }
 
-// resolveChipset returns the host's autodetected chipset, or "unknown" when the
-// host cannot be probed. Used as the fallback for the unset "chipset" key.
-func resolveChipset() string {
-	detected, err := geniex_sdk.ModelDetectChipset()
-	if err != nil || detected == "" {
-		return "unknown"
-	}
-	return detected
-}
-
 // ensureChipset resolves a chipset: configured value, then host probe, then an
 // interactive picker (which persists the choice).
 func ensureChipset() (string, error) {
-	if c, _, _ := store.Get().ConfigGet(store.ConfigKeyChipset); c != "" {
+	if c := store.Get().ResolveChipset(false); c != "" {
 		return c, nil
-	}
-	if detected, _ := geniex_sdk.ModelDetectChipset(); detected != "" {
-		return detected, nil
 	}
 	fmt.Println(render.GetTheme().Info.Sprint("No chipset configured. Please select your chipset first."))
 	return pickChipset()
@@ -152,7 +141,7 @@ func pickChipset() (string, error) {
 	}
 
 	// Probe the host so we can preselect its chipset; failure is non-fatal.
-	detected, _ := geniex_sdk.ModelDetectChipset()
+	detected, _ := geniex_sdk.ModelDetectChipset(false)
 
 	// matches reports whether the detected chipset is c's name or an alias.
 	matches := func(c geniex_sdk.ChipsetInfo) bool {
@@ -211,7 +200,9 @@ func configListCmd() *cobra.Command {
 			for _, key := range keys {
 				value := cfg[key]
 				if key == store.ConfigKeyChipset && value == "" {
-					value = resolveChipset()
+					if value = store.Get().ResolveChipset(false); value == "" {
+						value = "unknown"
+					}
 				}
 				fmt.Println(render.GetTheme().Info.Sprintf("%s: %s", key, value))
 			}

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -20,8 +20,10 @@ import (
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/cmd/geniex/common"
+	"github.com/qualcomm/GenieX/cli/internal/config"
 	"github.com/qualcomm/GenieX/cli/internal/record"
 	"github.com/qualcomm/GenieX/cli/internal/render"
+	"github.com/qualcomm/GenieX/cli/internal/store"
 )
 
 var (
@@ -136,6 +138,13 @@ func infer() *cobra.Command {
 
 		if err := common.InitSDK(); err != nil {
 			return err
+		}
+
+		// Host-aware default (e.g. RB3 Gen 2 → cpu) before resolution, so the
+		// --verbose line and any server request see the same alias.
+		var overridden bool
+		if computeUnit, overridden = config.ComputeDefault(computeUnit, store.Get().ResolveChipset(true)); overridden {
+			fmt.Println(render.GetTheme().Info.Sprintf("Defaulting to --compute %s for this device; pass --compute to override.", computeUnit))
 		}
 
 		effectiveType := paths.ModelType

--- a/cli/internal/config/BUILD.bazel
+++ b/cli/internal/config/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "config",
-    srcs = ["config.go"],
+    srcs = [
+        "compute.go",
+        "config.go",
+    ],
     importpath = "github.com/qualcomm/GenieX/cli/internal/config",
     visibility = ["//cli:__subpackages__"],
     deps = ["@com_github_spf13_viper//:viper"],
@@ -10,6 +13,9 @@ go_library(
 
 go_test(
     name = "config_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "compute_test.go",
+        "config_test.go",
+    ],
     embed = [":config"],
 )

--- a/cli/internal/config/compute.go
+++ b/cli/internal/config/compute.go
@@ -1,0 +1,27 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package config
+
+import "strings"
+
+// cpuDefaultChipsets default to CPU because their llama.cpp NPU path is slow.
+// Keys are lower-cased and cover both forms ResolveChipset can yield: the
+// canonical id (offline probe) and the reference-device name (stored by the
+// picker).
+var cpuDefaultChipsets = map[string]bool{
+	"qualcomm-qcs6490":                true,
+	"dragonwing rb3 gen 2 vision kit": true,
+}
+
+// ComputeDefault keeps an explicit compute; an empty one becomes "cpu" on
+// cpuDefaultChipsets (overridden=true), else stays empty for the SDK's default.
+func ComputeDefault(compute, chipset string) (result string, overridden bool) {
+	if strings.TrimSpace(compute) != "" {
+		return compute, false
+	}
+	if cpuDefaultChipsets[strings.ToLower(strings.TrimSpace(chipset))] {
+		return "cpu", true
+	}
+	return compute, false
+}

--- a/cli/internal/config/compute_test.go
+++ b/cli/internal/config/compute_test.go
@@ -1,0 +1,34 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package config
+
+import "testing"
+
+func TestComputeDefault(t *testing.T) {
+	tests := []struct {
+		name           string
+		compute        string
+		chipset        string
+		want           string
+		wantOverridden bool
+	}{
+		{"explicit npu is kept on rb3", "npu", "qualcomm-qcs6490", "npu", false},
+		{"explicit cpu is kept", "cpu", "qualcomm-snapdragon-x-elite", "cpu", false},
+		{"whitespace-only is treated as unset", "  ", "qualcomm-qcs6490", "cpu", true},
+		{"unset on rb3 canonical becomes cpu", "", "qualcomm-qcs6490", "cpu", true},
+		{"unset on rb3 display name becomes cpu", "", "Dragonwing RB3 Gen 2 Vision Kit", "cpu", true},
+		{"unset on rb3 is case-insensitive", "", "Qualcomm-QCS6490", "cpu", true},
+		{"unset on other chipset stays unset", "", "qualcomm-snapdragon-x-elite", "", false},
+		{"unset with no detected chipset stays unset", "", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, overridden := ComputeDefault(tt.compute, tt.chipset)
+			if got != tt.want || overridden != tt.wantOverridden {
+				t.Fatalf("ComputeDefault(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.compute, tt.chipset, got, overridden, tt.want, tt.wantOverridden)
+			}
+		})
+	}
+}

--- a/cli/internal/store/BUILD.bazel
+++ b/cli/internal/store/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//scripts:cgo_test.bzl", "go_cgo_test")
 
 go_library(
     name = "store",
@@ -9,12 +10,13 @@ go_library(
     importpath = "github.com/qualcomm/GenieX/cli/internal/store",
     visibility = ["//cli:__subpackages__"],
     deps = [
+        "//bindings/go:geniex_sdk_go",
         "//cli/internal/config",
         "@com_github_bytedance_sonic//:sonic",
     ],
 )
 
-go_test(
+go_cgo_test(
     name = "store_test",
     srcs = ["package_test.go"],
     embed = [":store"],

--- a/cli/internal/store/config.go
+++ b/cli/internal/store/config.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 
 	"github.com/bytedance/sonic"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 )
 
 // Known configuration keys. The set is intentionally small and explicit so
@@ -108,4 +110,15 @@ func (s *Store) ConfigSet(key, value string) error {
 // ConfigList returns a snapshot of all persisted configuration entries.
 func (s *Store) ConfigList() (map[string]string, error) {
 	return s.loadConfig()
+}
+
+// ResolveChipset resolves the host chipset without prompting: the configured
+// "chipset" key wins, else a host probe, else "". Pass offline=true on the
+// infer / serve path so the probe never touches the network.
+func (s *Store) ResolveChipset(offline bool) string {
+	if c, _, err := s.ConfigGet(ConfigKeyChipset); err == nil && c != "" {
+		return c
+	}
+	detected, _ := geniex_sdk.ModelDetectChipset(offline)
+	return detected
 }

--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//bindings/go:geniex_sdk_go",
         "//cli/internal/config",
+        "//cli/internal/store",
         "//cli/internal/types",
         "//cli/server/service",
         "//cli/server/utils",

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -22,6 +22,7 @@ import (
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/config"
+	"github.com/qualcomm/GenieX/cli/internal/store"
 	"github.com/qualcomm/GenieX/cli/internal/types"
 	"github.com/qualcomm/GenieX/cli/server/service"
 	"github.com/qualcomm/GenieX/cli/server/utils"
@@ -121,7 +122,7 @@ func ChatCompletions(c *gin.Context) {
 	// Fill unset request knobs from the server-wide defaults and resolve the
 	// compute unit. Done before the MaxCompletionTokens floor so a body that
 	// omits nctx picks up the server default, not the floor.
-	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, param.NCtx, param.Ngl, param.Compute, service.SpecParam{
+	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, param.NCtx, param.Ngl, param.Compute, store.Get().ResolveChipset(true), service.SpecParam{
 		Type:       param.SpecType,
 		DraftModel: param.SpecDraftModel,
 		NMax:       param.SpecNMax,

--- a/cli/server/handler/logits.go
+++ b/cli/server/handler/logits.go
@@ -11,6 +11,7 @@ import (
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/config"
+	"github.com/qualcomm/GenieX/cli/internal/store"
 	"github.com/qualcomm/GenieX/cli/server/service"
 )
 
@@ -43,11 +44,11 @@ const defaultLogitsTopN = 20
 // top_n is 0 each row is the full vocabulary, ordered by token id, and token id
 // is the column index — TokenIDs is then omitted.
 type ForwardLogitsResponse struct {
-	Model     string        `json:"model"`
-	NRows     int           `json:"n_rows"`
-	VocabSize int           `json:"vocab_size"`
-	TopN      int           `json:"top_n"`
-	Rows      []ForwardRow  `json:"rows"`
+	Model     string       `json:"model"`
+	NRows     int          `json:"n_rows"`
+	VocabSize int          `json:"vocab_size"`
+	TopN      int          `json:"top_n"`
+	Rows      []ForwardRow `json:"rows"`
 }
 
 // ForwardRow is one position's logits. For top-N output, Logits[i] pairs with
@@ -88,7 +89,7 @@ func ForwardLogits(c *gin.Context) {
 		return
 	}
 
-	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, req.NCtx, req.Ngl, req.Compute, service.SpecParam{})
+	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, req.NCtx, req.Ngl, req.Compute, store.Get().ResolveChipset(true), service.SpecParam{})
 	if err != nil {
 		slog.Error("Failed to resolve model params", "model", req.Model, "error", err)
 		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -60,7 +60,7 @@ func resolveDraftModelPath(draft string) (string, error) {
 	return paths.ModelPath, nil
 }
 
-func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCompute string, spec SpecParam) (types.ModelParam, error) {
+func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCompute, chipset string, spec SpecParam) (types.ModelParam, error) {
 	// nctx / ngl / compute already carry the resolved value (explicit request
 	// or the server default prefilled by the handler). Non-llama_cpp plugins
 	// (e.g. qairt) reject non-zero nctx, so zero it for them; the SDK does the
@@ -68,6 +68,14 @@ func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCo
 	nctx, ngl := reqNCtx, reqNgl
 	if runtimeID != geniex_sdk.RuntimeLlamaCpp {
 		nctx = 0
+	}
+
+	// Host-aware default (e.g. RB3 Gen 2 → cpu) before the SDK's npu fallback.
+	// chipset is resolved by the caller (offline) so this stays store-free.
+	if resolved, overridden := config.ComputeDefault(reqCompute, chipset); overridden {
+		slog.Info("applied host-aware compute default", "compute", resolved)
+		fmt.Println(render.GetTheme().Info.Sprintf("Defaulting to compute %s for this device.", resolved))
+		reqCompute = resolved
 	}
 
 	resolved, err := geniex_sdk.ResolveDevice(geniex_sdk.ResolveDeviceInput{

--- a/cli/server/service/keepalive_test.go
+++ b/cli/server/service/keepalive_test.go
@@ -16,7 +16,7 @@ import (
 // TestResolveModelParam_PassesLlamaCppValuesThrough verifies that nctx / ngl are
 // forwarded verbatim for llama_cpp and the compute alias resolves to a device.
 func TestResolveModelParam_PassesLlamaCppValuesThrough(t *testing.T) {
-	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 2048, 10, "gpu", SpecParam{})
+	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 2048, 10, "gpu", "", SpecParam{})
 	if err != nil {
 		t.Fatalf("ResolveModelParam: %v", err)
 	}
@@ -31,7 +31,7 @@ func TestResolveModelParam_PassesLlamaCppValuesThrough(t *testing.T) {
 // TestResolveModelParam_NpuAliasResolvesDevice verifies the npu alias pins HTP0
 // and passes ngl through (-1 = all layers).
 func TestResolveModelParam_NpuAliasResolvesDevice(t *testing.T) {
-	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 4096, -1, "npu", SpecParam{})
+	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 4096, -1, "npu", "", SpecParam{})
 	if err != nil {
 		t.Fatalf("ResolveModelParam: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestResolveModelParam_NpuAliasResolvesDevice(t *testing.T) {
 // TestResolveModelParam_CpuAliasZeroesGpuLayers verifies ngl 0 (pure CPU) is a
 // valid value that survives resolution.
 func TestResolveModelParam_CpuAliasZeroesGpuLayers(t *testing.T) {
-	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 4096, 0, "cpu", SpecParam{})
+	got, err := ResolveModelParam(geniex_sdk.RuntimeLlamaCpp, "some-model", 4096, 0, "cpu", "", SpecParam{})
 	if err != nil {
 		t.Fatalf("ResolveModelParam: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestResolveModelParam_CpuAliasZeroesGpuLayers(t *testing.T) {
 // runtimes NCtx is zeroed so the plugin's param-guard is not tripped, even when
 // the caller passes a non-zero value.
 func TestResolveModelParam_NonLlamaCppZeroesNCtx(t *testing.T) {
-	got, err := ResolveModelParam(geniex_sdk.RuntimeQairt, "some-model", 8192, 42, "", SpecParam{})
+	got, err := ResolveModelParam(geniex_sdk.RuntimeQairt, "some-model", 8192, 42, "", "", SpecParam{})
 	if err != nil {
 		t.Fatalf("ResolveModelParam: %v", err)
 	}

--- a/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/detect.rs
@@ -354,6 +354,7 @@ mod linux {
 
     const SOC_TO_CHIPSET: &[(&str, &str)] = &[
         ("qcs6490", "qualcomm-qcs6490"),
+        ("qcm6490", "qualcomm-qcs6490"),
         ("qcs9075", "qualcomm-qcs9075"),
     ];
 
@@ -407,8 +408,8 @@ mod linux {
         }
 
         #[test]
-        fn maps_qcs6490_rb3_gen2() {
-            let bytes = b"qcom,qcs6490-rb3gen2-vision-kit\0qcom,qcs6490\0";
+        fn maps_qcs6490_rb3_gen2_real_fixture() {
+            let bytes = b"qcom,qcs6490-addons-rb3gen2\0qcom,qcm6490\0";
             assert_eq!(map_compatible(bytes), Some("qualcomm-qcs6490"));
         }
 

--- a/sdk/model-manager/crates/ffi/src/chipset.rs
+++ b/sdk/model-manager/crates/ffi/src/chipset.rs
@@ -5,7 +5,8 @@ use std::os::raw::c_char;
 
 use model_manager_core::config::StoreConfig;
 use model_manager_core::source::ai_hub::{
-    detect_host_chipset_reference, list_supported_chipsets, AiHubConfig,
+    detect::detect_host_chipset, detect_host_chipset_reference, list_supported_chipsets,
+    AiHubConfig,
 };
 
 use crate::init::{get_store, runtime_handle};
@@ -106,14 +107,19 @@ pub unsafe extern "C" fn geniex_model_list_chipsets_free(out: *mut GenieXChipset
 /* ---- geniex_model_detect_chipset ---- */
 
 #[no_mangle]
-pub extern "C" fn geniex_model_detect_chipset(out_chipset: *mut *mut c_char) -> i32 {
+pub extern "C" fn geniex_model_detect_chipset(offline: i32, out_chipset: *mut *mut c_char) -> i32 {
     ffi_guard(|| {
         if out_chipset.is_null() {
             return Err(GENIEX_ERROR_COMMON_INVALID_INPUT);
         }
-        let cfg = ai_hub_cfg_for_chipset_query(get_store()?);
-        let ptr = runtime_handle()
-            .block_on(detect_host_chipset_reference(&cfg))
+        // offline: local probe only; else translate online to the display name.
+        let detected = if offline != 0 {
+            detect_host_chipset()
+        } else {
+            let cfg = ai_hub_cfg_for_chipset_query(get_store()?);
+            runtime_handle().block_on(detect_host_chipset_reference(&cfg))
+        };
+        let ptr = detected
             .map(|s| str_to_cptr(&s))
             .unwrap_or(std::ptr::null_mut());
         unsafe { *out_chipset = ptr };

--- a/sdk/model-manager/include/geniex_model.h
+++ b/sdk/model-manager/include/geniex_model.h
@@ -440,21 +440,27 @@ GENIEX_API void geniex_model_list_chipsets_free(geniex_ChipsetList* out);
  *
  * Probes the host (Windows-on-Snapdragon X Elite / X Plus / X2 Elite / X2 Plus, Linux
  * on Qualcomm Dragonwing boards QCS6490 / QCS9075, Android on Snapdragon via
- * `ro.soc.model`), then resolves the raw id to the AI Hub reference device
- * name (e.g. "Snapdragon X Elite CRD") — the same name geniex_model_list_chipsets
- * surfaces and the picker stores. Resolution reads platform.json (24h on-disk
- * cache), so the first call may hit the network; it falls back to the raw
- * detected id when the catalogue is unavailable or has no entry for it.
+ * `ro.soc.model`) for its raw canonical chipset id (e.g. "qualcomm-qcs6490").
+ *
+ * When `offline` is 0, the raw id is then resolved to the AI Hub reference
+ * device name (e.g. "Snapdragon X Elite CRD") — the same name
+ * geniex_model_list_chipsets surfaces and the picker stores — by reading
+ * platform.json (24h on-disk cache), so that call may hit the network; it falls
+ * back to the raw id when the catalogue is unavailable or has no entry for it.
+ * Pass a non-zero `offline` to skip that translation entirely and return the
+ * raw canonical id from a purely local probe (never touches the network).
  *
  * The returned value is accepted by geniex_model_pull's `chipset` field.
  *
+ * @param offline      Non-zero: local probe only, return the raw canonical id.
+ *                     Zero: also translate to the reference-device name online.
  * @param out_chipset  Set to a heap-allocated string on success, or NULL when
  *                     the host cannot be probed on this platform. Free a
  *                     non-NULL value with geniex_free().
  * @return GENIEX_SUCCESS (even when *out_chipset is NULL), or a negative
  *         geniex_ErrorCode on a hard failure (e.g. NULL out_chipset).
  */
-GENIEX_API int32_t geniex_model_detect_chipset(char** out_chipset);
+GENIEX_API int32_t geniex_model_detect_chipset(int32_t offline, char** out_chipset);
 
 /* ============================================================
  *  Hub model catalogue


### PR DESCRIPTION
## Summary

RB3 Gen 2 Vision Kit (Rubik Pi / QCS6490) boards now auto-detect their chipset and default inference to `--compute cpu`, whose llama.cpp NPU path is slow on this platform.

- **Detection**: map the `qcm6490` device-tree compatible to `qualcomm-qcs6490`. The real board reports `qcom,qcs6490-addons-rb3gen2` + `qcom,qcm6490` — neither is a bare `qcs6490`, so the mapping is required.
- **Offline probe**: add an `offline` flag to `geniex_model_detect_chipset` (FFI). Non-zero skips the online reference-device translation and returns the raw canonical id from a purely local probe, so latency-sensitive callers never touch the network. Threaded through all bindings (Go / Python / Android JNI+Kotlin).
- **CLI default**: `infer` and `serve` resolve the host chipset offline (never blocking) and default `--compute` to `cpu` on RB3 Gen 2; an explicit `--compute` still wins. Config commands keep the online probe for the friendlier reference-device display name.

FFI signature change — all bindings updated in the same PR per CONTRIBUTING.md.

## Test plan

- [x] `bazelisk build //cli` (x86) + `//cli/internal/config:config_test`
- [x] Rust `model-manager-core` unit tests (165 pass, incl. RB3 Gen 2 real device-tree fixture)
- [x] Cross-compiled arm64 SDK + CLI, verified end-to-end on a real RB3 Gen 2 (QCS6490) via QDC:
  - `config get chipset` → `Dragonwing RB3 Gen 2 Vision Kit`
  - `infer` with no `--compute` → prints `Defaulting to --compute cpu`, runs on CPU (~20 tok/s)
  - `infer --compute npu` → explicit value kept, no override

Closes #1342