### PR TITLE
ci(qdc): route matrix values through env to satisfy zizmor

### DIFF
--- a/.github/workflows/_qdc-test.yml
+++ b/.github/workflows/_qdc-test.yml
@@ -78,11 +78,14 @@ jobs:
         if: steps.skip.outputs.skip != 'true'
 
       - if: steps.skip.outputs.skip != 'true'
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          DEVICE: ${{ matrix.device }}
         run: >
           python tests/qdc/run_qdc_pytest.py
           --pkg-dir pkg-geniex
-          --platform "${{ matrix.platform }}"
-          --device "${{ matrix.device }}"
+          --platform "$PLATFORM"
+          --device "$DEVICE"
           --logs-dir qdc-logs
 
       - name: Upload QDC device logs


### PR DESCRIPTION
## Summary

`GitHub Actions Security Scan (zizmor)` blocks every PR that touches (or rebases through) `.github/workflows/_qdc-test.yml`:

```
_qdc-test.yml:83: code injection via template expansion: may expand into attacker-controllable code
_qdc-test.yml:84: code injection via template expansion: may expand into attacker-controllable code
```

The `template-injection` audit fires on any `${{ ... }}` inside a `run:` block, and the enterprise policy fails the job at `high` severity. This PR moves `matrix.platform` / `matrix.device` into the step's `env:` and references them as shell variables — zizmor no longer sees an interpolation inside `run:`, behavior of the QDC leg is unchanged.

## Test plan

- [x] `GitHub Actions Security Scan (zizmor)` on this PR reports no `_qdc-test.yml` findings and the job is green.