### PR TITLE
test(qdc): run llama_cpp LLM + VLM QDC matrix on cpu/gpu/npu

### DIFF
--- a/.github/workflows/_qdc-test.yml
+++ b/.github/workflows/_qdc-test.yml
@@ -45,7 +45,9 @@ jobs:
         if: inputs.gate_on_changed_files
         uses: ./.github/actions/changed-files
         with:
-          include: '^(sdk|third-party|tests/qdc)/|^\.github/workflows/_qdc-test\.yml$'
+          # QDC harness bundles the full tests/ tree onto the device, so any
+          # tests/** change (not just tests/qdc/**) affects the on-device run.
+          include: '^(sdk|third-party|tests)/|^\.github/workflows/_qdc-test\.yml$'
 
       - name: Decide skip
         id: skip

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,7 @@ model-manager-pull check that runs first:
 | `test_vlm_quality_keywords`   | Golden-retriever caption must match one of the canonical keywords. |
 | `test_mtp_multi_turn`         | (llama_cpp only) same "Alice" convo with `spec_type='draft-mtp'`.  |
 
-Backends per plugin: `llama_cpp` on `cpu` + `npu`; `qairt` on `npu` only.
+Backends per plugin: `llama_cpp` on `cpu` + `gpu` + `npu`; `qairt` on `npu` only.
 Model-manager pull failures are treated as FAIL, not SKIP, so a broken
 download surfaces as a red CI leg instead of a silent green skip.
 
@@ -44,8 +44,9 @@ The conftest auto-tags items by location and `device_map` value:
 | `llama_cpp`     | items in `tests/test_llama_cpp.py`                       |
 | `qairt`         | items in `tests/test_qairt.py`                           |
 | `device_cpu`    | parametrised with `device_map='cpu'`                     |
+| `device_gpu`    | parametrised with `device_map='gpu'`                     |
 | `device_npu`    | parametrised with `device_map='npu'`                     |
-| `snapdragon`    | any `device_map='npu'` cell (auto-applied)               |
+| `snapdragon`    | any `device_map` in {`gpu`, `npu`} cell (auto-applied)   |
 | `llm` / `vlm`   | applied per-test via `@pytest.mark.llm` / `.vlm`         |
 
 `snapdragon`-marked and `qairt` items skip automatically unless

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,11 @@ QUALITY_IMAGE_PATH = Path(__file__).resolve().parent / 'assets' / 'quality_dog.j
 
 _DEVICE_MARKER = {
     'cpu': 'device_cpu',
+    'gpu': 'device_gpu',
     'npu': 'device_npu',
 }
-_SNAPDRAGON_DEVICES = {'npu'}
+# GPU uses the Snapdragon OpenCL backend, so it needs real hardware just like NPU.
+_SNAPDRAGON_DEVICES = {'gpu', 'npu'}
 
 
 def _is_snapdragon_host() -> bool:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -9,6 +9,7 @@ markers =
     llm: text-only generation
     vlm: vision-language generation
     device_cpu: cpu backend (works anywhere)
+    device_gpu: OpenCL GPU backend (Snapdragon only)
     device_npu: HTP NPU backend (Snapdragon only)
     snapdragon: requires real Snapdragon host (gated by GENIEX_DEVICE_TEST=1)
 norecursedirs = qdc

--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -29,8 +29,8 @@ from _quality_data import (
     VLM_QUALITY_TEMPERATURE,
 )
 
-_LLM_BACKENDS = ['cpu', 'npu']
-_VLM_BACKENDS = ['cpu', 'npu']
+_LLM_BACKENDS = ['cpu', 'gpu', 'npu']
+_VLM_BACKENDS = ['cpu', 'gpu', 'npu']
 
 
 def test_model_manager_pull(llama_cpp_llm_paths, llama_cpp_vlm_paths, llama_cpp_mtp_paths):
@@ -80,11 +80,12 @@ def test_llm_multi_turn(llama_cpp_llm_paths, device_map):
 
 
 @pytest.mark.vlm
-def test_vlm_multi_turn(llama_cpp_vlm_paths, test_image):
+@pytest.mark.parametrize('device_map', _VLM_BACKENDS)
+def test_vlm_multi_turn(llama_cpp_vlm_paths, test_image, device_map):
     with geniex.AutoModelForVision2Seq.from_pretrained(
         LLAMA_CPP_VLM_MODEL,
         precision=LLAMA_CPP_VLM_PRECISION,
-        device_map='cpu',
+        device_map=device_map,
     ) as vlm:
         history = [
             {


### PR DESCRIPTION
## Summary

The QDC device matrix for the `llama_cpp` plugin previously exercised only `cpu` + `npu`, and `test_vlm_multi_turn` was hard-coded to `cpu`. This extends both the LLM and VLM cells to also cover the OpenCL `gpu` backend so a regression on the llama.cpp GPU path shows up on QDC just like the NPU path does.

Concretely:

- `tests/test_llama_cpp.py` — `_LLM_BACKENDS` / `_VLM_BACKENDS` are now `['cpu', 'gpu', 'npu']`; `test_vlm_multi_turn` is parametrised on `device_map` instead of pinning `'cpu'`.
- `tests/conftest.py` — `device_map='gpu'` now auto-tags `device_gpu` + `snapdragon`, so non-Snapdragon hosts skip the GPU cells the same way they already skip NPU.
- `tests/pytest.ini` — register the new `device_gpu` marker (`--strict-markers`).
- `tests/README.md` — reflect the new backend row.

`qairt` is unchanged (still `npu`-only by design — see `sdk/src/device.cpp`, which coerces `cpu`/`gpu` to NPU with a warning).

## Test plan

- [x] `pytest tests --collect-only -m "llama_cpp"` picks up the new `[gpu]` cells (20 items collected on this host, 22 deselected).
- [x] `pytest tests --collect-only -m "api or (llama_cpp and device_cpu)"` still selects only the cpu subset — the model-free + cpu shard on GitHub runners is unaffected.
- [x] `pytest tests --collect-only -m device_gpu` yields exactly the 6 new gpu cells.
- [x] pending — QDC `_qdc-test.yml` on `workflow_dispatch` to confirm the new `[gpu]` cells run green on real QCS9075M / SC8480XP hardware.