### PR TITLE
ci(test): add Rust model-manager unit-test job to PR check

### DIFF
--- a/.github/workflows/_test-rust.yml
+++ b/.github/workflows/_test-rust.yml
@@ -1,0 +1,60 @@
+name: Test Rust
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: model-manager
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve Rust file list
+        id: files
+        uses: ./.github/actions/changed-files
+        with:
+          include: '^sdk/model-manager/.*\.(rs|toml)$|^sdk/model-manager/Cargo\.lock$'
+
+      # dtolnay/rust-toolchain isn't on the org allowlist, so rustup.
+      - name: Install Rust stable
+        if: steps.files.outputs.any == 'true'
+        run: |
+          set -euo pipefail
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+          cargo --version
+          rustc --version
+
+      # Restore-keys are safe here: this job produces no downstream artifact,
+      # so an mtime-fuzzy hit at worst re-runs a passing test suite.
+      - name: Restore cargo cache
+        if: steps.files.outputs.any == 'true'
+        uses: actions/cache@v6
+        with:
+          path: |
+            sdk/model-manager/target
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: cargo-test-rust-${{ hashFiles('sdk/model-manager/Cargo.lock') }}
+          restore-keys: cargo-test-rust-
+
+      - name: cargo test
+        if: steps.files.outputs.any == 'true'
+        env:
+          CARGO_TERM_COLOR: always
+          RUST_BACKTRACE: 1
+        run: |
+          cargo test \
+            --manifest-path sdk/model-manager/Cargo.toml \
+            --workspace \
+            --locked

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -57,6 +57,13 @@ jobs:
     with:
       upload_artifact: true
 
+  test-rust:
+    name: test-rust
+    needs: [lint]
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    uses: ./.github/workflows/_test-rust.yml
+    secrets: inherit
+
   build-cli:
     name: build-cli
     needs: [build-sdk]


### PR DESCRIPTION
## Summary

- Adds a new reusable workflow `.github/workflows/_test-rust.yml` that runs `cargo test --workspace --locked` on the `sdk/model-manager/` Rust workspace.
- Wires it into `pr-check.yml` as `test-rust`, `needs: [lint]` — parallel to `build-sdk` / `build-python-sdist`, not downstream of the C++ SDK build. The Rust workspace has no `build.rs` and no C toolchain dependency, so it doesn't need the SDK artifact.
- Runs on `ubuntu-latest`, installs `stable` toolchain via `rustup` (org allowlist forbids `dtolnay/rust-toolchain`, matches the existing `rust-format` job), 20-min timeout.
- Path-gated on `^sdk/model-manager/.*\.(rs|toml)$|^sdk/model-manager/Cargo\.lock$` — dep bumps also re-run tests. Draft-gated to match every other `test-*` job.
- Cargo cache uses `restore-keys` (fuzzy hit) — safe here because the job produces no downstream artifact, unlike `_build-sdk.yml` where mtime staleness matters.

## Test plan

- [x] `cargo test --manifest-path sdk/model-manager/Cargo.toml --workspace --locked` green locally on Windows ARM64 (all inline + integration tests pass; `#[ignore]`d live-network tests in `ai_hub_live.rs` / `hf_live.rs` skipped as expected).
- [x] Sanity gate: `.rs`-only diff triggers the job; a docs-only diff under `sdk/model-manager/` short-circuits every step to a no-op green.