### PR TITLE
refactor(server): split chat handler and unify token routing

### DIFF
--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -5,6 +5,10 @@ go_library(
     name = "handler",
     srcs = [
         "chat.go",
+        "chat_messages.go",
+        "chat_response.go",
+        "chat_stream.go",
+        "chat_token.go",
         "logits.go",
         "model.go",
     ],

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -5,10 +5,7 @@ package handler
 
 import (
 	"errors"
-	"fmt"
-	"io"
 	"log/slog"
-	"math/rand/v2"
 	"net/http"
 	"os"
 	"strings"
@@ -18,18 +15,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
 	"github.com/openai/openai-go/v3/packages/param"
-	"github.com/openai/openai-go/v3/shared/constant"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/config"
 	"github.com/qualcomm/GenieX/cli/internal/store"
-	"github.com/qualcomm/GenieX/cli/internal/thinkfsm"
 	"github.com/qualcomm/GenieX/cli/internal/types"
 	"github.com/qualcomm/GenieX/cli/server/service"
-	"github.com/qualcomm/GenieX/cli/server/utils"
 )
-
-// =============== request types ===============
 
 type ChatCompletionNewParams openai.ChatCompletionNewParams
 
@@ -41,8 +33,9 @@ type ChatCompletionRequest struct {
 	NCtx        int32  `json:"nctx"`
 	Ngl         int32  `json:"ngl"` // 0 = pure CPU, -1 = all layers, N = N layers; defaults to the server --ngl when omitted
 	Compute     string `json:"compute"`
-	// ReasoningFormat: "" / "none" keeps thinking inline in content (default);
-	// "deepseek" / "deepseek-legacy" / "auto" move it to reasoning_content.
+
+	// "" / "none" keeps thinking inline in content (default); "deepseek" /
+	// "deepseek-legacy" / "auto" move it to reasoning_content.
 	ReasoningFormat string `json:"reasoning_format"`
 
 	ImageMaxLength int32 `json:"image_max_length"`
@@ -97,8 +90,6 @@ func isWarmupRequest(param ChatCompletionRequest) bool {
 	r := param.Messages[0].GetRole()
 	return r != nil && *r == "system"
 }
-
-// =============== handlers ===============
 
 func ChatCompletions(c *gin.Context) {
 	param := defaultChatCompletionRequest()
@@ -155,9 +146,20 @@ func ChatCompletions(c *gin.Context) {
 
 	switch effectiveType {
 	case geniex_sdk.ModelTypeLLM:
-		chatCompletionsLLM(c, param, modelParam)
+		messages, ok := buildLLMMessages(c, param)
+		if !ok {
+			return
+		}
+		runChat(c, param, modelParam, messages, prepareLLM)
 	case geniex_sdk.ModelTypeVLM:
-		chatCompletionsVLM(c, param, modelParam)
+		messages, tempFiles, ok := buildVLMMessages(c, param)
+		for _, f := range tempFiles {
+			defer os.Remove(f)
+		}
+		if !ok {
+			return
+		}
+		runChat(c, param, modelParam, messages, prepareVLM)
 	default:
 		slog.Error("Model type not support", "model_type", modelType)
 		c.JSON(http.StatusBadRequest, map[string]any{"error": "model type not support"})
@@ -165,101 +167,14 @@ func ChatCompletions(c *gin.Context) {
 	}
 }
 
-func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam) {
-	messages := make([]geniex_sdk.LlmChatMessage, 0, len(param.Messages))
-	for _, msg := range param.Messages {
-		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
-			for _, tc := range toolCalls {
-				messages = append(messages, geniex_sdk.LlmChatMessage{
-					Role: geniex_sdk.LlmRole(*msg.GetRole()),
-					Content: fmt.Sprintf(`<tool_call>{"name":"%s","arguments":"%s"}</tool_call>`,
-						tc.GetFunction().Name, tc.GetFunction().Arguments),
-				})
-			}
-			continue
-		}
+// generateFn adapts LLM/VLM Generate to one shape; fullText is set even on error.
+type generateFn func(prompt string, onToken func(string) bool) (geniex_sdk.ProfileData, string, error)
 
-		if toolResp := msg.GetToolCallID(); toolResp != nil {
-			messages = append(messages, geniex_sdk.LlmChatMessage{
-				Role:    geniex_sdk.LlmRole(*msg.GetRole()),
-				Content: *msg.GetContent().AsAny().(*string),
-			})
-			continue
-		}
+// prepareFn holds the only LLM/VLM-specific work: apply the chat template, then
+// return the formatted prompt and a generateFn.
+type prepareFn[T, M any] func(p *T, messages M, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (prompt string, gen generateFn, err error)
 
-		switch content := msg.GetContent().AsAny().(type) {
-		case *string:
-			messages = append(messages, geniex_sdk.LlmChatMessage{
-				Role:    geniex_sdk.LlmRole(*msg.GetRole()),
-				Content: *content,
-			})
-
-		case *[]openai.ChatCompletionContentPartTextParam:
-			for _, ct := range *content {
-				messages = append(messages, geniex_sdk.LlmChatMessage{
-					Role:    geniex_sdk.LlmRole(*msg.GetRole()),
-					Content: ct.Text,
-				})
-			}
-		case *[]openai.ChatCompletionContentPartUnionParam:
-			for _, ct := range *content {
-				switch *ct.GetType() {
-				case "text":
-					messages = append(messages, geniex_sdk.LlmChatMessage{
-						Role:    geniex_sdk.LlmRole(*msg.GetRole()),
-						Content: *ct.GetText(),
-					})
-				default:
-					slog.Error("Not support content part type", "type", *ct.GetType())
-					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
-					return
-				}
-			}
-		case *[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
-			for _, ct := range *content {
-				switch *ct.GetType() {
-				case "text":
-					messages = append(messages, geniex_sdk.LlmChatMessage{
-						Role:    geniex_sdk.LlmRole(*msg.GetRole()),
-						Content: *ct.GetText(),
-					})
-				default:
-					slog.Error("Not support content part type", "type", *ct.GetType())
-					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
-					return
-				}
-			}
-
-		default:
-			slog.Error("Unknown content type in message", "content_type", fmt.Sprintf("%T", content))
-			c.JSON(http.StatusBadRequest, map[string]any{"error": "unknown content type"})
-			return
-		}
-	}
-
-	// Prepare tools if provided
-	parseTool, tools, err := parseTools(param)
-	if err != nil {
-		slog.Error("Failed to parse tools", "error", err)
-		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
-		return
-	}
-
-	samplerConfig := parseSamplerConfig(param)
-
-	p, err := service.KeepAliveGet[geniex_sdk.LLM](
-		string(param.Model),
-		modelParam,
-		c.GetHeader("GenieX-KeepCache") != "true",
-	)
-	if writeKeepAliveError(c, err) {
-		return
-	}
-	if isWarmupRequest(param) {
-		c.JSON(http.StatusOK, nil)
-		return
-	}
-
+func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
 	formatted, err := p.ApplyChatTemplate(geniex_sdk.LlmApplyChatTemplateInput{
 		Messages:            messages,
 		Tools:               tools,
@@ -267,234 +182,33 @@ func chatCompletionsLLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 		AddGenerationPrompt: true,
 	})
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-		return
+		return "", nil, err
 	}
-
-	reasoner := newReasoner(param, parseTool)
-
-	if param.Stream {
-		stopGen := false
-		dataCh := make(chan string)
-
-		var (
-			res   *geniex_sdk.LlmGenerateOutput
-			err   error
-			resWg sync.WaitGroup
-		)
-
-		resWg.Add(1)
-		go func() {
-			defer resWg.Done()
-			res, err = p.Generate(geniex_sdk.LlmGenerateInput{
-				PromptUTF8: formatted.FormattedText,
-				OnToken: func(token string) bool {
-					if stopGen {
-						return false
-					}
-					dataCh <- token
-					return true
-				},
-				Config: &geniex_sdk.GenerationConfig{
-					MaxTokens:     int32(param.MaxCompletionTokens.Value),
-					SamplerConfig: samplerConfig,
-				},
-			})
-			close(dataCh)
-		}()
-
-		wait := func() error { resWg.Wait(); return err }
-		usage := func() openai.CompletionUsage { return profile2Usage(res.ProfileData) }
-		finish := func() string { return mapFinishReason(res.ProfileData.StopReason) }
-		includeUsage := param.StreamOptions.IncludeUsage.Value
-		if !parseTool {
-			streamPlainText(c, dataCh, wait, includeUsage, usage, finish, reasoner)
-		} else {
-			streamToolCall(c, dataCh, wait, includeUsage, usage, finish)
-		}
-
-		stopGen = true
-		for range dataCh {
-		}
-
-	} else {
-		var content, reasoning strings.Builder
-		genOut, err := p.Generate(geniex_sdk.LlmGenerateInput{
-			PromptUTF8: formatted.FormattedText,
-			OnToken:    reasoningSink(reasoner, &content, &reasoning),
+	gen := func(prompt string, onToken func(string) bool) (geniex_sdk.ProfileData, string, error) {
+		out, err := p.Generate(geniex_sdk.LlmGenerateInput{
+			PromptUTF8: prompt,
+			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
 				MaxTokens:     int32(param.MaxCompletionTokens.Value),
-				SamplerConfig: samplerConfig,
+				SamplerConfig: sampler,
 			},
 		})
-		if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
-			writeContextLengthExceeded(c, genOut.FullText, genOut.ProfileData)
-			return
+		if out == nil {
+			return geniex_sdk.ProfileData{}, "", err
 		}
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-			return
-		}
-		writeBlockingResponse(c, content.String(), reasoning.String(), genOut.ProfileData, parseTool)
+		return out.ProfileData, out.FullText, err
 	}
+	return formatted.FormattedText, gen, nil
 }
 
-func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam) {
-	messages := make([]geniex_sdk.VlmChatMessage, 0, len(param.Messages))
-	for _, msg := range param.Messages {
-		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
-			contents := make([]geniex_sdk.VlmContent, 0, len(toolCalls))
-			for _, tc := range toolCalls {
-				contents = append(contents, geniex_sdk.VlmContent{
-					Type: geniex_sdk.VlmContentTypeText,
-					Text: fmt.Sprintf(`<tool_call>{"name":"%s","arguments":"%s"}</tool_call>`,
-						tc.GetFunction().Name, tc.GetFunction().Arguments),
-				})
-			}
-			messages = append(messages, geniex_sdk.VlmChatMessage{
-				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
-				Contents: contents,
-			})
-			continue
-		}
-
-		if toolResp := msg.GetToolCallID(); toolResp != nil {
-			messages = append(messages, geniex_sdk.VlmChatMessage{
-				Role: geniex_sdk.VlmRole(*msg.GetRole()),
-				Contents: []geniex_sdk.VlmContent{{
-					Type: geniex_sdk.VlmContentTypeText,
-					Text: *msg.GetContent().AsAny().(*string),
-				}},
-			})
-			continue
-		}
-
-		switch content := msg.GetContent().AsAny().(type) {
-		case *string:
-			messages = append(messages, geniex_sdk.VlmChatMessage{
-				Role: geniex_sdk.VlmRole(*msg.GetRole()),
-				Contents: []geniex_sdk.VlmContent{
-					{Type: geniex_sdk.VlmContentTypeText, Text: *msg.GetContent().AsAny().(*string)},
-				},
-			})
-
-		case *[]openai.ChatCompletionContentPartTextParam:
-			contents := make([]geniex_sdk.VlmContent, 0, len(*content))
-			for _, ct := range *content {
-				contents = append(contents, geniex_sdk.VlmContent{
-					Type: geniex_sdk.VlmContentTypeText,
-					Text: ct.Text,
-				})
-			}
-			messages = append(messages, geniex_sdk.VlmChatMessage{
-				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
-				Contents: contents,
-			})
-
-		case *[]openai.ChatCompletionContentPartUnionParam:
-			contents := make([]geniex_sdk.VlmContent, 0, len(*content))
-			for _, ct := range *content {
-				switch *ct.GetType() {
-				case "text":
-					contents = append(contents, geniex_sdk.VlmContent{
-						Type: geniex_sdk.VlmContentTypeText,
-						Text: *ct.GetText(),
-					})
-				case "image_url":
-					file, err := utils.SaveURIToTempFile(ct.GetImageURL().URL)
-					slog.Debug("Saved image file", "file", file)
-					if err != nil {
-						c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
-						return
-					}
-					defer os.Remove(file)
-					contents = append(contents, geniex_sdk.VlmContent{
-						Type: geniex_sdk.VlmContentTypeImage,
-						Text: file,
-					})
-				case "input_audio":
-					file, err := utils.SaveURIToTempFile(ct.GetInputAudio().Data)
-					slog.Debug("Saved audio file", "file", file)
-					if err != nil {
-						c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
-						return
-					}
-					defer os.Remove(file)
-					contents = append(contents, geniex_sdk.VlmContent{
-						Type: geniex_sdk.VlmContentTypeAudio,
-						Text: file,
-					})
-				default:
-					slog.Error("Not support content part type", "type", *ct.GetType())
-					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
-					return
-				}
-			}
-			messages = append(messages, geniex_sdk.VlmChatMessage{
-				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
-				Contents: contents,
-			})
-
-		case *[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
-			contents := make([]geniex_sdk.VlmContent, 0, len(*content))
-			for _, ct := range *content {
-				switch *ct.GetType() {
-				case "text":
-					contents = append(contents, geniex_sdk.VlmContent{
-						Type: geniex_sdk.VlmContentTypeText,
-						Text: *ct.GetText(),
-					})
-				default:
-					slog.Error("Not support content part type", "type", *ct.GetType())
-					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
-					return
-				}
-			}
-
-			messages = append(messages, geniex_sdk.VlmChatMessage{
-				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
-				Contents: contents,
-			})
-
-		default:
-			slog.Error("Unknown content type in message")
-			c.JSON(http.StatusBadRequest, map[string]any{"error": "unknown content type"})
-			return
-		}
-	}
-
-	// Prepare tools if provided
-	parseTool, tools, err := parseTools(param)
-	if err != nil {
-		slog.Error("Failed to parse tools", "error", err)
-		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
-		return
-	}
-
-	samplerConfig := parseSamplerConfig(param)
-
-	p, err := service.KeepAliveGet[geniex_sdk.VLM](
-		string(param.Model),
-		modelParam,
-		c.GetHeader("GenieX-KeepCache") != "true",
-	)
-	if writeKeepAliveError(c, err) {
-		return
-	}
-	if isWarmupRequest(param) {
-		c.JSON(http.StatusOK, nil)
-		return
-	}
-
-	// Format prompt using VLM chat template
+func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
 	formatted, err := p.ApplyChatTemplate(geniex_sdk.VlmApplyChatTemplateInput{
 		Messages:    messages,
 		Tools:       tools,
 		EnableThink: param.EnableThink,
 	})
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-		return
+		return "", nil, err
 	}
 	images := make([]string, 0)
 	audios := make([]string, 0)
@@ -506,141 +220,50 @@ func chatCompletionsVLM(c *gin.Context, param ChatCompletionRequest, modelParam 
 			audios = append(audios, content.Text)
 		}
 	}
-
-	reasoner := newReasoner(param, parseTool)
-
-	if param.Stream {
-		stopGen := false
-		dataCh := make(chan string)
-
-		var (
-			res   *geniex_sdk.VlmGenerateOutput
-			err   error
-			resWg sync.WaitGroup
-		)
-
-		resWg.Add(1)
-		go func() {
-			defer resWg.Done()
-			res, err = p.Generate(geniex_sdk.VlmGenerateInput{
-				PromptUTF8: formatted.FormattedText,
-				OnToken: func(token string) bool {
-					if stopGen {
-						return false
-					}
-					dataCh <- token
-					return true
-				},
-				Config: &geniex_sdk.GenerationConfig{
-					MaxTokens:      int32(param.MaxCompletionTokens.Value),
-					SamplerConfig:  samplerConfig,
-					ImagePaths:     images,
-					AudioPaths:     audios,
-					ImageMaxLength: param.ImageMaxLength,
-				},
-			})
-
-			close(dataCh)
-		}()
-
-		wait := func() error { resWg.Wait(); return err }
-		usage := func() openai.CompletionUsage { return profile2Usage(res.ProfileData) }
-		finish := func() string { return mapFinishReason(res.ProfileData.StopReason) }
-		includeUsage := param.StreamOptions.IncludeUsage.Value
-		if !parseTool {
-			streamPlainText(c, dataCh, wait, includeUsage, usage, finish, reasoner)
-		} else {
-			streamToolCall(c, dataCh, wait, includeUsage, usage, finish)
-		}
-
-		stopGen = true
-		for range dataCh {
-		}
-
-	} else {
-		var content, reasoning strings.Builder
-		genOut, err := p.Generate(geniex_sdk.VlmGenerateInput{
-			PromptUTF8: formatted.FormattedText,
-			OnToken:    reasoningSink(reasoner, &content, &reasoning),
+	gen := func(prompt string, onToken func(string) bool) (geniex_sdk.ProfileData, string, error) {
+		out, err := p.Generate(geniex_sdk.VlmGenerateInput{
+			PromptUTF8: prompt,
+			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
 				MaxTokens:      int32(param.MaxCompletionTokens.Value),
-				SamplerConfig:  samplerConfig,
+				SamplerConfig:  sampler,
 				ImagePaths:     images,
 				AudioPaths:     audios,
 				ImageMaxLength: param.ImageMaxLength,
 			},
 		})
-		if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) && genOut != nil {
-			writeContextLengthExceeded(c, genOut.FullText, genOut.ProfileData)
-			return
+		if out == nil {
+			return geniex_sdk.ProfileData{}, "", err
 		}
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-			return
-		}
-		writeBlockingResponse(c, content.String(), reasoning.String(), genOut.ProfileData, parseTool)
+		return out.ProfileData, out.FullText, err
 	}
+	return formatted.FormattedText, gen, nil
 }
 
-// =============== reasoning routing ===============
-
-// reasoningSeparated reports whether a reasoning_format moves thinking output
-// into reasoning_content. "" / "none" keep it inline in content (default,
-// back-compatible); everything else (deepseek, deepseek-legacy, auto) separates.
-func reasoningSeparated(format string) bool {
-	switch strings.ToLower(strings.TrimSpace(format)) {
-	case "", "none":
-		return false
-	default:
-		return true
+// runChat is the shared flow wrapping the type-specific prepareFn.
+func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam, messages M, prepare prepareFn[T, M]) {
+	// ---- prepare: parse tools, load the model, apply the chat template ----
+	parseTool, tools, err := parseTools(param)
+	if err != nil {
+		slog.Error("Failed to parse tools", "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
 	}
-}
 
-// newReasoner returns a think-splitter when the request wants thinking moved to
-// reasoning_content, or nil to keep it inline in content (default). Tool-call
-// parsing needs the raw <think>-tagged stream, so it disables separation.
-func newReasoner(param ChatCompletionRequest, parseTool bool) *thinkfsm.Splitter {
-	if parseTool || !reasoningSeparated(param.ReasoningFormat) {
-		return nil
+	p, err := service.KeepAliveGet[T](
+		string(param.Model),
+		modelParam,
+		c.GetHeader("GenieX-KeepCache") != "true",
+	)
+	if writeKeepAliveError(c, err) {
+		return
 	}
-	return thinkfsm.New()
-}
-
-// route classifies a generated token. emit is false for consumed markers (the
-// <think> tag itself); otherwise text goes to reasoning_content when reasoning
-// is true, else to content. A nil splitter (separation off) passes every token
-// through as content verbatim, keeping default output byte-identical.
-func route(s *thinkfsm.Splitter, token string) (text string, reasoning, emit bool) {
-	if s == nil {
-		return token, false, true
+	if isWarmupRequest(param) {
+		c.JSON(http.StatusOK, nil)
+		return
 	}
-	ev := s.Feed(token)
-	if ev.Consumed {
-		return "", false, false
-	}
-	return ev.Text, ev.Reasoning, true
-}
 
-// reasoningSink returns an OnToken callback that accumulates routed tokens into
-// content and reasoning_content — the non-streaming path only gets the joined
-// text otherwise.
-func reasoningSink(s *thinkfsm.Splitter, content, reasoning *strings.Builder) func(string) bool {
-	return func(token string) bool {
-		if text, isReasoning, emit := route(s, token); emit {
-			if isReasoning {
-				reasoning.WriteString(text)
-			} else {
-				content.WriteString(text)
-			}
-		}
-		return true
-	}
-}
-
-// =============== request-side helpers ===============
-
-func parseSamplerConfig(param ChatCompletionRequest) *geniex_sdk.SamplerConfig {
-	return &geniex_sdk.SamplerConfig{
+	sampler := &geniex_sdk.SamplerConfig{
 		Temperature:       float32(param.Temperature.Value),
 		TopP:              float32(param.TopP.Value),
 		TopK:              param.TopK,
@@ -651,6 +274,70 @@ func parseSamplerConfig(param ChatCompletionRequest) *geniex_sdk.SamplerConfig {
 		Seed:              int32(param.Seed.Value),
 		EnableJson:        param.EnableJson,
 	}
+	prompt, gen, err := prepare(p, messages, param, tools, sampler)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+		return
+	}
+
+	// ---- generate: stream SSE chunks or write one blocking response ----
+	if param.Stream {
+		// streaming
+		stopGen := false
+		dataCh := make(chan string)
+
+		var (
+			profile geniex_sdk.ProfileData
+			genErr  error
+			wg      sync.WaitGroup
+		)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			profile, _, genErr = gen(prompt, func(token string) bool {
+				if stopGen {
+					return false
+				}
+				dataCh <- token
+				return true
+			})
+			close(dataCh)
+		}()
+
+		wait := func() error { wg.Wait(); return genErr }
+		includeUsage := param.StreamOptions.IncludeUsage.Value
+		if parseTool {
+			streamToolCall(c, dataCh, wait, includeUsage, &profile)
+		} else {
+			class := tokenClass(plainClass)
+			if reasoningSeparated(param.ReasoningFormat) {
+				class = reasoningClass()
+			}
+			streamPlainText(c, dataCh, wait, includeUsage, &profile, render(class))
+		}
+
+		stopGen = true
+		for range dataCh {
+		}
+	} else {
+		// blocking
+		var content, reasoning strings.Builder
+		class := tokenClass(plainClass)
+		if !parseTool && reasoningSeparated(param.ReasoningFormat) {
+			class = reasoningClass()
+		}
+		profile, fullText, err := gen(prompt, sink(class, &content, &reasoning))
+		if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
+			writeContextLengthExceeded(c, fullText, profile)
+			return
+		}
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+			return
+		}
+		writeBlockingResponse(c, content.String(), reasoning.String(), profile, parseTool)
+	}
 }
 
 func parseTools(param ChatCompletionRequest) (bool, string, error) {
@@ -659,289 +346,4 @@ func parseTools(param ChatCompletionRequest) (bool, string, error) {
 	}
 	tools, err := sonic.MarshalString(param.Tools)
 	return true, tools, err
-}
-
-// =============== response-side helpers ===============
-
-// writeKeepAliveError maps a KeepAliveGet error to its HTTP response;
-// returns true when handled (caller should return).
-func writeKeepAliveError(c *gin.Context, err error) bool {
-	if err == nil {
-		return false
-	}
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		c.JSON(http.StatusNotFound, map[string]any{"error": "model not found"})
-	case errors.Is(err, geniex_sdk.ErrCommonParamNotSupported):
-		c.JSON(http.StatusBadRequest, map[string]any{
-			"error": "a parameter in the request is not supported by the runtime",
-			"code":  geniex_sdk.SDKErrorCode(err),
-		})
-	default:
-		c.JSON(http.StatusInternalServerError, map[string]any{
-			"error": err.Error(),
-			"code":  geniex_sdk.SDKErrorCode(err),
-		})
-	}
-	return true
-}
-
-// writeContextLengthExceeded mirrors OpenAI's HTTP 400 body but also surfaces
-// the partial generation under `choices` so clients can still recover the
-// truncated output. The SDK populates fullText / profile even on this error.
-func writeContextLengthExceeded(c *gin.Context, fullText string, profile geniex_sdk.ProfileData) {
-	choice := openai.ChatCompletionChoice{}
-	choice.FinishReason = "length"
-	choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
-	choice.Message.Content = fullText
-
-	c.JSON(http.StatusBadRequest, map[string]any{
-		"error": map[string]any{
-			"message": "model context window exceeded; output truncated",
-			"type":    "invalid_request_error",
-			"code":    "context_length_exceeded",
-		},
-		"choices": []openai.ChatCompletionChoice{choice},
-		"usage":   profile2Usage(profile),
-	})
-}
-
-// blockingMessage mirrors the assistant message but adds reasoning_content,
-// which openai-go's ChatCompletionMessage lacks. Used only when thinking is
-// separated so the default (inline) response stays byte-identical.
-type blockingMessage struct {
-	Role             string `json:"role"`
-	Content          string `json:"content"`
-	ReasoningContent string `json:"reasoning_content,omitempty"`
-}
-
-type blockingChoice struct {
-	Index        int64           `json:"index"`
-	Message      blockingMessage `json:"message"`
-	FinishReason string          `json:"finish_reason"`
-}
-
-type blockingResponse struct {
-	Object  string                 `json:"object"`
-	Choices []blockingChoice       `json:"choices"`
-	Usage   openai.CompletionUsage `json:"usage"`
-}
-
-// writeBlockingResponse emits a non-streaming completion: tool-call response
-// when parseTool matches, content response otherwise (or on parse failure).
-// reasoning is non-empty only when the request asked to separate thinking; it
-// is surfaced under message.reasoning_content and never parsed for tool calls.
-func writeBlockingResponse(c *gin.Context, content, reasoning string, profile geniex_sdk.ProfileData, parseTool bool) {
-	if parseTool {
-		toolCall, err := utils.ParseToolCalls(content)
-		if err == nil {
-			choice := openai.ChatCompletionChoice{}
-			choice.FinishReason = "tool_calls"
-			choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
-			choice.Message.ToolCalls = []openai.ChatCompletionMessageToolCallUnion{{
-				ID:       fmt.Sprintf("call_%d", rand.Uint32()),
-				Type:     "function",
-				Function: toolCall,
-			}}
-			c.JSON(http.StatusOK, openai.ChatCompletion{
-				Choices: []openai.ChatCompletionChoice{choice},
-				Usage:   profile2Usage(profile),
-			})
-			return
-		}
-		slog.Warn("Tool call parse error, fallback to text", "error", err)
-	}
-
-	// Default (no separation): keep the exact openai.ChatCompletion shape.
-	if reasoning == "" {
-		choice := openai.ChatCompletionChoice{}
-		choice.FinishReason = mapFinishReason(profile.StopReason)
-		choice.Message.Role = constant.Assistant(openai.MessageRoleAssistant)
-		choice.Message.Content = content
-		c.JSON(http.StatusOK, openai.ChatCompletion{
-			Choices: []openai.ChatCompletionChoice{choice},
-			Usage:   profile2Usage(profile),
-		})
-		return
-	}
-
-	c.JSON(http.StatusOK, blockingResponse{
-		Object: "chat.completion",
-		Choices: []blockingChoice{{
-			Message: blockingMessage{
-				Role:             string(openai.MessageRoleAssistant),
-				Content:          content,
-				ReasoningContent: reasoning,
-			},
-			FinishReason: mapFinishReason(profile.StopReason),
-		}},
-		Usage: profile2Usage(profile),
-	})
-}
-
-// streamUsage is read once dataCh closes; it lets callers hide whether their
-// generate result is a value or pointer.
-type streamUsage func() openai.CompletionUsage
-
-// streamFinish is read once dataCh closes; it maps the generate result's
-// stop_reason to the OpenAI finish_reason vocabulary for the final chunk.
-type streamFinish func() string
-
-// The openai-go response structs marshal FinishReason as a plain string, so
-// every chunk carried `"finish_reason": ""` and no terminal chunk was sent.
-// The OpenAI streaming spec requires null on intermediate chunks and
-// "stop" / "length" / "tool_calls" on a final chunk with an empty delta —
-// without it, clients never detect completion (#1243). These local types
-// give the stream spec-compliant serialization.
-
-type streamDelta struct {
-	Role             string                                          `json:"role,omitempty"`
-	Content          string                                          `json:"content,omitempty"`
-	ReasoningContent string                                          `json:"reasoning_content,omitempty"`
-	ToolCalls        []openai.ChatCompletionChunkChoiceDeltaToolCall `json:"tool_calls,omitempty"`
-}
-
-type streamChoice struct {
-	Index        int64       `json:"index"`
-	Delta        streamDelta `json:"delta"`
-	FinishReason *string     `json:"finish_reason"` // null until the final chunk
-}
-
-type streamChunk struct {
-	Object  string                  `json:"object"`
-	Choices []streamChoice          `json:"choices"`
-	Usage   *openai.CompletionUsage `json:"usage,omitempty"`
-}
-
-const streamChunkObject = "chat.completion.chunk"
-
-func contentChunk(content string) streamChunk {
-	return streamChunk{
-		Object: streamChunkObject,
-		Choices: []streamChoice{{
-			Delta: streamDelta{Role: string(openai.MessageRoleAssistant), Content: content},
-		}},
-	}
-}
-
-// tokenChunk emits a routed token as either a content or a reasoning_content
-// delta.
-func tokenChunk(text string, reasoning bool) streamChunk {
-	delta := streamDelta{Role: string(openai.MessageRoleAssistant)}
-	if reasoning {
-		delta.ReasoningContent = text
-	} else {
-		delta.Content = text
-	}
-	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{{Delta: delta}}}
-}
-
-// finishChunk is the terminal chunk: empty delta, non-null finish_reason.
-func finishChunk(reason string) streamChunk {
-	return streamChunk{
-		Object:  streamChunkObject,
-		Choices: []streamChoice{{FinishReason: &reason}},
-	}
-}
-
-func usageChunk(u openai.CompletionUsage) streamChunk {
-	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{}, Usage: &u}
-}
-
-// streamPlainText drains dataCh, routing each token into content or
-// reasoning_content deltas, then emits the finishing chunk, optional usage and
-// [DONE].
-func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, usage streamUsage, finish streamFinish, reasoner *thinkfsm.Splitter) {
-	c.Stream(func(w io.Writer) bool {
-		r, ok := <-dataCh
-		if ok {
-			if text, reasoning, emit := route(reasoner, r); emit {
-				c.SSEvent("", tokenChunk(text, reasoning))
-			}
-			return true
-		}
-		if err := wait(); err != nil {
-			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-			return false
-		}
-		c.SSEvent("", finishChunk(finish()))
-		if includeUsage {
-			c.SSEvent("", usageChunk(usage()))
-		}
-		c.SSEvent("", "[DONE]")
-		return false
-	})
-}
-
-// streamToolCall buffers the stream and emits a tool-call chunk once dataCh
-// closes; falls back to a content chunk when parsing fails. Either way the
-// stream ends with a finishing chunk, optional usage and [DONE].
-func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, usage streamUsage, finish streamFinish) {
-	buffer := strings.Builder{}
-	c.Stream(func(w io.Writer) bool {
-		r, ok := <-dataCh
-		if ok {
-			buffer.WriteString(r)
-			return true
-		}
-		if err := wait(); err != nil {
-			slog.Error("Generation error", "error", err)
-			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-			return false
-		}
-		finishReason := "tool_calls"
-		toolCall, err := utils.ParseToolCalls(buffer.String())
-		if err != nil {
-			slog.Warn("Tool call parse error, fallback to text", "error", err)
-			finishReason = finish()
-			c.SSEvent("", contentChunk(buffer.String()))
-		} else {
-			c.SSEvent("", streamChunk{
-				Object: streamChunkObject,
-				Choices: []streamChoice{{
-					Delta: streamDelta{
-						ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
-							ID:   fmt.Sprintf("call_%d", rand.Uint32()),
-							Type: "function",
-							Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
-								Name:      toolCall.Name,
-								Arguments: toolCall.Arguments,
-							},
-						}},
-					},
-				}},
-			})
-		}
-		c.SSEvent("", finishChunk(finishReason))
-		if includeUsage {
-			c.SSEvent("", usageChunk(usage()))
-		}
-		c.SSEvent("", "[DONE]")
-		return false
-	})
-}
-
-// =============== shared mappers ===============
-
-func profile2Usage(p geniex_sdk.ProfileData) openai.CompletionUsage {
-	return openai.CompletionUsage{
-		CompletionTokens: p.GeneratedTokens,
-		PromptTokens:     p.PromptTokens,
-		TotalTokens:      p.TotalTokens(),
-	}
-}
-
-// mapFinishReason translates the SDK's stop_reason values into the OpenAI
-// finish_reason vocabulary.
-func mapFinishReason(stopReason string) string {
-	switch stopReason {
-	case "length":
-		return "length"
-	case "user":
-		return "stop"
-	case "eos", "stop_sequence", "":
-		return "stop"
-	default:
-		return "stop"
-	}
 }

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bytedance/sonic"
 	"github.com/gin-gonic/gin"
@@ -283,7 +284,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 	// ---- generate: stream SSE chunks or write one blocking response ----
 	if param.Stream {
 		// streaming
-		stopGen := false
+		var stopGen atomic.Bool
 		dataCh := make(chan string)
 
 		var (
@@ -296,7 +297,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		go func() {
 			defer wg.Done()
 			profile, _, genErr = gen(prompt, func(token string) bool {
-				if stopGen {
+				if stopGen.Load() {
 					return false
 				}
 				dataCh <- token
@@ -317,7 +318,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 			streamPlainText(c, dataCh, wait, includeUsage, &profile, render(class))
 		}
 
-		stopGen = true
+		stopGen.Store(true)
 		for range dataCh {
 		}
 	} else {

--- a/cli/server/handler/chat_messages.go
+++ b/cli/server/handler/chat_messages.go
@@ -1,0 +1,219 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/server/utils"
+)
+
+// On failure, writes a response and returns ok=false; the caller must return.
+func buildLLMMessages(c *gin.Context, param ChatCompletionRequest) (messages []geniex_sdk.LlmChatMessage, ok bool) {
+	messages = make([]geniex_sdk.LlmChatMessage, 0, len(param.Messages))
+	for _, msg := range param.Messages {
+		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
+			for _, tc := range toolCalls {
+				messages = append(messages, geniex_sdk.LlmChatMessage{
+					Role: geniex_sdk.LlmRole(*msg.GetRole()),
+					Content: fmt.Sprintf(`<tool_call>{"name":"%s","arguments":"%s"}</tool_call>`,
+						tc.GetFunction().Name, tc.GetFunction().Arguments),
+				})
+			}
+			continue
+		}
+
+		if toolResp := msg.GetToolCallID(); toolResp != nil {
+			messages = append(messages, geniex_sdk.LlmChatMessage{
+				Role:    geniex_sdk.LlmRole(*msg.GetRole()),
+				Content: *msg.GetContent().AsAny().(*string),
+			})
+			continue
+		}
+
+		switch content := msg.GetContent().AsAny().(type) {
+		case *string:
+			messages = append(messages, geniex_sdk.LlmChatMessage{
+				Role:    geniex_sdk.LlmRole(*msg.GetRole()),
+				Content: *content,
+			})
+
+		case *[]openai.ChatCompletionContentPartTextParam:
+			for _, ct := range *content {
+				messages = append(messages, geniex_sdk.LlmChatMessage{
+					Role:    geniex_sdk.LlmRole(*msg.GetRole()),
+					Content: ct.Text,
+				})
+			}
+		case *[]openai.ChatCompletionContentPartUnionParam:
+			for _, ct := range *content {
+				switch *ct.GetType() {
+				case "text":
+					messages = append(messages, geniex_sdk.LlmChatMessage{
+						Role:    geniex_sdk.LlmRole(*msg.GetRole()),
+						Content: *ct.GetText(),
+					})
+				default:
+					slog.Error("Not support content part type", "type", *ct.GetType())
+					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
+					return nil, false
+				}
+			}
+		case *[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
+			for _, ct := range *content {
+				switch *ct.GetType() {
+				case "text":
+					messages = append(messages, geniex_sdk.LlmChatMessage{
+						Role:    geniex_sdk.LlmRole(*msg.GetRole()),
+						Content: *ct.GetText(),
+					})
+				default:
+					slog.Error("Not support content part type", "type", *ct.GetType())
+					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
+					return nil, false
+				}
+			}
+
+		default:
+			slog.Error("Unknown content type in message", "content_type", fmt.Sprintf("%T", content))
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "unknown content type"})
+			return nil, false
+		}
+	}
+	return messages, true
+}
+
+// Image / audio data is spilled to tempFiles, which the caller must remove
+// after generation (returned on the error path too, for partial writes).
+func buildVLMMessages(c *gin.Context, param ChatCompletionRequest) (messages []geniex_sdk.VlmChatMessage, tempFiles []string, ok bool) {
+	messages = make([]geniex_sdk.VlmChatMessage, 0, len(param.Messages))
+	for _, msg := range param.Messages {
+		if toolCalls := msg.GetToolCalls(); len(toolCalls) > 0 {
+			contents := make([]geniex_sdk.VlmContent, 0, len(toolCalls))
+			for _, tc := range toolCalls {
+				contents = append(contents, geniex_sdk.VlmContent{
+					Type: geniex_sdk.VlmContentTypeText,
+					Text: fmt.Sprintf(`<tool_call>{"name":"%s","arguments":"%s"}</tool_call>`,
+						tc.GetFunction().Name, tc.GetFunction().Arguments),
+				})
+			}
+			messages = append(messages, geniex_sdk.VlmChatMessage{
+				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
+				Contents: contents,
+			})
+			continue
+		}
+
+		if toolResp := msg.GetToolCallID(); toolResp != nil {
+			messages = append(messages, geniex_sdk.VlmChatMessage{
+				Role: geniex_sdk.VlmRole(*msg.GetRole()),
+				Contents: []geniex_sdk.VlmContent{{
+					Type: geniex_sdk.VlmContentTypeText,
+					Text: *msg.GetContent().AsAny().(*string),
+				}},
+			})
+			continue
+		}
+
+		switch content := msg.GetContent().AsAny().(type) {
+		case *string:
+			messages = append(messages, geniex_sdk.VlmChatMessage{
+				Role: geniex_sdk.VlmRole(*msg.GetRole()),
+				Contents: []geniex_sdk.VlmContent{
+					{Type: geniex_sdk.VlmContentTypeText, Text: *msg.GetContent().AsAny().(*string)},
+				},
+			})
+
+		case *[]openai.ChatCompletionContentPartTextParam:
+			contents := make([]geniex_sdk.VlmContent, 0, len(*content))
+			for _, ct := range *content {
+				contents = append(contents, geniex_sdk.VlmContent{
+					Type: geniex_sdk.VlmContentTypeText,
+					Text: ct.Text,
+				})
+			}
+			messages = append(messages, geniex_sdk.VlmChatMessage{
+				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
+				Contents: contents,
+			})
+
+		case *[]openai.ChatCompletionContentPartUnionParam:
+			contents := make([]geniex_sdk.VlmContent, 0, len(*content))
+			for _, ct := range *content {
+				switch *ct.GetType() {
+				case "text":
+					contents = append(contents, geniex_sdk.VlmContent{
+						Type: geniex_sdk.VlmContentTypeText,
+						Text: *ct.GetText(),
+					})
+				case "image_url":
+					file, err := utils.SaveURIToTempFile(ct.GetImageURL().URL)
+					slog.Debug("Saved image file", "file", file)
+					if err != nil {
+						c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
+						return nil, tempFiles, false
+					}
+					tempFiles = append(tempFiles, file)
+					contents = append(contents, geniex_sdk.VlmContent{
+						Type: geniex_sdk.VlmContentTypeImage,
+						Text: file,
+					})
+				case "input_audio":
+					file, err := utils.SaveURIToTempFile(ct.GetInputAudio().Data)
+					slog.Debug("Saved audio file", "file", file)
+					if err != nil {
+						c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
+						return nil, tempFiles, false
+					}
+					tempFiles = append(tempFiles, file)
+					contents = append(contents, geniex_sdk.VlmContent{
+						Type: geniex_sdk.VlmContentTypeAudio,
+						Text: file,
+					})
+				default:
+					slog.Error("Not support content part type", "type", *ct.GetType())
+					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
+					return nil, tempFiles, false
+				}
+			}
+			messages = append(messages, geniex_sdk.VlmChatMessage{
+				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
+				Contents: contents,
+			})
+
+		case *[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
+			contents := make([]geniex_sdk.VlmContent, 0, len(*content))
+			for _, ct := range *content {
+				switch *ct.GetType() {
+				case "text":
+					contents = append(contents, geniex_sdk.VlmContent{
+						Type: geniex_sdk.VlmContentTypeText,
+						Text: *ct.GetText(),
+					})
+				default:
+					slog.Error("Not support content part type", "type", *ct.GetType())
+					c.JSON(http.StatusBadRequest, map[string]any{"error": "not support content part type"})
+					return nil, tempFiles, false
+				}
+			}
+
+			messages = append(messages, geniex_sdk.VlmChatMessage{
+				Role:     geniex_sdk.VlmRole(*msg.GetRole()),
+				Contents: contents,
+			})
+
+		default:
+			slog.Error("Unknown content type in message")
+			c.JSON(http.StatusBadRequest, map[string]any{"error": "unknown content type"})
+			return nil, tempFiles, false
+		}
+	}
+	return messages, tempFiles, true
+}

--- a/cli/server/handler/chat_response.go
+++ b/cli/server/handler/chat_response.go
@@ -1,0 +1,158 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/shared/constant"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/server/utils"
+)
+
+// Returns true when the error was written, so the caller should return.
+func writeKeepAliveError(c *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		c.JSON(http.StatusNotFound, map[string]any{"error": "model not found"})
+	case errors.Is(err, geniex_sdk.ErrCommonParamNotSupported):
+		c.JSON(http.StatusBadRequest, map[string]any{
+			"error": "a parameter in the request is not supported by the runtime",
+			"code":  geniex_sdk.SDKErrorCode(err),
+		})
+	default:
+		c.JSON(http.StatusInternalServerError, map[string]any{
+			"error": err.Error(),
+			"code":  geniex_sdk.SDKErrorCode(err),
+		})
+	}
+	return true
+}
+
+// OpenAI's 400 body, plus the partial generation under `choices` so clients can
+// recover the truncated output.
+func writeContextLengthExceeded(c *gin.Context, fullText string, profile geniex_sdk.ProfileData) {
+	choice := openai.ChatCompletionChoice{
+		FinishReason: "length",
+		Message: openai.ChatCompletionMessage{
+			Role:    constant.Assistant(openai.MessageRoleAssistant),
+			Content: fullText,
+		},
+	}
+
+	c.JSON(http.StatusBadRequest, map[string]any{
+		"error": map[string]any{
+			"message": "model context window exceeded; output truncated",
+			"type":    "invalid_request_error",
+			"code":    "context_length_exceeded",
+		},
+		"choices": []openai.ChatCompletionChoice{choice},
+		"usage":   profile2Usage(profile),
+	})
+}
+
+// Adds reasoning_content, which openai-go's ChatCompletionMessage lacks; used
+// only when thinking is separated so the inline default stays byte-identical.
+type blockingMessage struct {
+	Role             string `json:"role"`
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+}
+
+type blockingChoice struct {
+	Index        int64           `json:"index"`
+	Message      blockingMessage `json:"message"`
+	FinishReason string          `json:"finish_reason"`
+}
+
+type blockingResponse struct {
+	Object  string                 `json:"object"`
+	Choices []blockingChoice       `json:"choices"`
+	Usage   openai.CompletionUsage `json:"usage"`
+}
+
+func writeBlockingResponse(c *gin.Context, content, reasoning string, profile geniex_sdk.ProfileData, parseTool bool) {
+	if parseTool {
+		toolCall, err := utils.ParseToolCalls(content)
+		if err == nil {
+			choice := openai.ChatCompletionChoice{
+				FinishReason: "tool_calls",
+				Message: openai.ChatCompletionMessage{
+					Role: constant.Assistant(openai.MessageRoleAssistant),
+					ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
+						ID:       fmt.Sprintf("call_%d", rand.Uint32()),
+						Type:     "function",
+						Function: toolCall,
+					}},
+				},
+			}
+			c.JSON(http.StatusOK, openai.ChatCompletion{
+				Choices: []openai.ChatCompletionChoice{choice},
+				Usage:   profile2Usage(profile),
+			})
+			return
+		}
+		slog.Warn("Tool call parse error, fallback to text", "error", err)
+	}
+
+	if reasoning == "" {
+		choice := openai.ChatCompletionChoice{
+			FinishReason: mapFinishReason(profile.StopReason),
+			Message: openai.ChatCompletionMessage{
+				Role:    constant.Assistant(openai.MessageRoleAssistant),
+				Content: content,
+			},
+		}
+		c.JSON(http.StatusOK, openai.ChatCompletion{
+			Choices: []openai.ChatCompletionChoice{choice},
+			Usage:   profile2Usage(profile),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, blockingResponse{
+		Object: "chat.completion",
+		Choices: []blockingChoice{{
+			Message: blockingMessage{
+				Role:             string(openai.MessageRoleAssistant),
+				Content:          content,
+				ReasoningContent: reasoning,
+			},
+			FinishReason: mapFinishReason(profile.StopReason),
+		}},
+		Usage: profile2Usage(profile),
+	})
+}
+
+func profile2Usage(p geniex_sdk.ProfileData) openai.CompletionUsage {
+	return openai.CompletionUsage{
+		CompletionTokens: p.GeneratedTokens,
+		PromptTokens:     p.PromptTokens,
+		TotalTokens:      p.TotalTokens(),
+	}
+}
+
+func mapFinishReason(stopReason string) string {
+	switch stopReason {
+	case "length":
+		return "length"
+	case "user":
+		return "stop"
+	case "eos", "stop_sequence", "":
+		return "stop"
+	default:
+		return "stop"
+	}
+}

--- a/cli/server/handler/chat_stream.go
+++ b/cli/server/handler/chat_stream.go
@@ -1,0 +1,145 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/server/utils"
+)
+
+// Local types so finish_reason serializes as null on intermediate chunks and a
+// value on the terminal chunk; openai-go's plain-string field can't (#1243).
+type streamDelta struct {
+	Role             string                                          `json:"role,omitempty"`
+	Content          string                                          `json:"content,omitempty"`
+	ReasoningContent string                                          `json:"reasoning_content,omitempty"`
+	ToolCalls        []openai.ChatCompletionChunkChoiceDeltaToolCall `json:"tool_calls,omitempty"`
+}
+
+type streamChoice struct {
+	Index        int64       `json:"index"`
+	Delta        streamDelta `json:"delta"`
+	FinishReason *string     `json:"finish_reason"` // null until the final chunk
+}
+
+type streamChunk struct {
+	Object  string                  `json:"object"`
+	Choices []streamChoice          `json:"choices"`
+	Usage   *openai.CompletionUsage `json:"usage,omitempty"`
+}
+
+const streamChunkObject = "chat.completion.chunk"
+
+func contentChunk(content string) streamChunk {
+	return streamChunk{
+		Object: streamChunkObject,
+		Choices: []streamChoice{{
+			Delta: streamDelta{Role: string(openai.MessageRoleAssistant), Content: content},
+		}},
+	}
+}
+
+func tokenChunk(text string, reasoning bool) streamChunk {
+	delta := streamDelta{Role: string(openai.MessageRoleAssistant)}
+	if reasoning {
+		delta.ReasoningContent = text
+	} else {
+		delta.Content = text
+	}
+	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{{Delta: delta}}}
+}
+
+func finishChunk(reason string) streamChunk {
+	return streamChunk{
+		Object:  streamChunkObject,
+		Choices: []streamChoice{{FinishReason: &reason}},
+	}
+}
+
+func usageChunk(u openai.CompletionUsage) streamChunk {
+	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{}, Usage: &u}
+}
+
+func toolCallChunk(call openai.ChatCompletionMessageFunctionToolCallFunction) streamChunk {
+	return streamChunk{
+		Object: streamChunkObject,
+		Choices: []streamChoice{{
+			Delta: streamDelta{
+				ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
+					ID:   fmt.Sprintf("call_%d", rand.Uint32()),
+					Type: "function",
+					Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
+						Name:      call.Name,
+						Arguments: call.Arguments,
+					},
+				}},
+			},
+		}},
+	}
+}
+
+// profile is read only after wait() returns, when generation has filled it.
+func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData, render tokenRender) {
+	c.Stream(func(w io.Writer) bool {
+		r, ok := <-dataCh
+		if ok {
+			if chunk, emit := render(r); emit {
+				c.SSEvent("", chunk)
+			}
+			return true
+		}
+		if err := wait(); err != nil {
+			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+			return false
+		}
+		c.SSEvent("", finishChunk(mapFinishReason(profile.StopReason)))
+		if includeUsage {
+			c.SSEvent("", usageChunk(profile2Usage(*profile)))
+		}
+		c.SSEvent("", "[DONE]")
+		return false
+	})
+}
+
+// Buffers the whole stream, then emits one tool-call chunk (or a content chunk
+// on parse failure).
+func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData) {
+	buffer := strings.Builder{}
+	c.Stream(func(w io.Writer) bool {
+		r, ok := <-dataCh
+		if ok {
+			buffer.WriteString(r)
+			return true
+		}
+		if err := wait(); err != nil {
+			slog.Error("Generation error", "error", err)
+			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+			return false
+		}
+		finishReason := "tool_calls"
+		toolCall, err := utils.ParseToolCalls(buffer.String())
+		if err != nil {
+			slog.Warn("Tool call parse error, fallback to text", "error", err)
+			finishReason = mapFinishReason(profile.StopReason)
+			c.SSEvent("", contentChunk(buffer.String()))
+		} else {
+			c.SSEvent("", toolCallChunk(toolCall))
+		}
+		c.SSEvent("", finishChunk(finishReason))
+		if includeUsage {
+			c.SSEvent("", usageChunk(profile2Usage(*profile)))
+		}
+		c.SSEvent("", "[DONE]")
+		return false
+	})
+}

--- a/cli/server/handler/chat_test.go
+++ b/cli/server/handler/chat_test.go
@@ -6,8 +6,6 @@ package handler
 import (
 	"strings"
 	"testing"
-
-	"github.com/qualcomm/GenieX/cli/internal/thinkfsm"
 )
 
 func TestReasoningSeparated(t *testing.T) {
@@ -27,14 +25,14 @@ func TestReasoningSeparated(t *testing.T) {
 	}
 }
 
-func TestReasoningSink(t *testing.T) {
+func TestSinks(t *testing.T) {
 	tokens := []string{"<think>", "reason", "</think>", "answer"}
 
-	t.Run("separation splits think block", func(t *testing.T) {
+	t.Run("reasoningClass splits think block", func(t *testing.T) {
 		var content, reasoning strings.Builder
-		sink := reasoningSink(thinkfsm.New(), &content, &reasoning)
+		s := sink(reasoningClass(), &content, &reasoning)
 		for _, tok := range tokens {
-			sink(tok)
+			s(tok)
 		}
 		if got := content.String(); got != "answer" {
 			t.Errorf("content = %q, want %q", got, "answer")
@@ -44,17 +42,14 @@ func TestReasoningSink(t *testing.T) {
 		}
 	})
 
-	t.Run("nil splitter keeps everything inline", func(t *testing.T) {
+	t.Run("plainClass keeps everything inline", func(t *testing.T) {
 		var content, reasoning strings.Builder
-		sink := reasoningSink(nil, &content, &reasoning)
+		s := sink(plainClass, &content, &reasoning)
 		for _, tok := range tokens {
-			sink(tok)
+			s(tok)
 		}
 		if got := content.String(); got != "<think>reason</think>answer" {
 			t.Errorf("content = %q, want raw inline", got)
-		}
-		if got := reasoning.String(); got != "" {
-			t.Errorf("reasoning = %q, want empty", got)
 		}
 	})
 }

--- a/cli/server/handler/chat_token.go
+++ b/cli/server/handler/chat_token.go
@@ -1,0 +1,64 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"strings"
+
+	"github.com/qualcomm/GenieX/cli/internal/thinkfsm"
+)
+
+// "" / "none" keep thinking inline in content (default); others separate it.
+func reasoningSeparated(format string) bool {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "none":
+		return false
+	default:
+		return true
+	}
+}
+
+// tokenClass classifies a token; emit is false for a consumed marker (<think>).
+type tokenClass func(token string) (text string, reasoning, emit bool)
+
+// plainClass passes tokens through verbatim, keeping the default byte-identical.
+func plainClass(token string) (string, bool, bool) {
+	return token, false, true
+}
+
+func reasoningClass() tokenClass {
+	s := thinkfsm.New()
+	return func(token string) (string, bool, bool) {
+		ev := s.Feed(token)
+		if ev.Consumed {
+			return "", false, false
+		}
+		return ev.Text, ev.Reasoning, true
+	}
+}
+
+func sink(class tokenClass, content, reasoning *strings.Builder) func(string) bool {
+	return func(token string) bool {
+		if text, isReasoning, emit := class(token); emit {
+			if isReasoning {
+				reasoning.WriteString(text)
+			} else {
+				content.WriteString(text)
+			}
+		}
+		return true
+	}
+}
+
+type tokenRender func(token string) (chunk streamChunk, emit bool)
+
+func render(class tokenClass) tokenRender {
+	return func(token string) (streamChunk, bool) {
+		text, reasoning, emit := class(token)
+		if !emit {
+			return streamChunk{}, false
+		}
+		return tokenChunk(text, reasoning), true
+	}
+}


### PR DESCRIPTION
## What

Refactor the oversized `cli/server/handler/chat.go` (947 lines) with no behavior change.

- **Split** into focused files: `chat_messages.go` (build LLM/VLM messages), `chat_response.go` (blocking + error responses), `chat_stream.go` (SSE chunks), `chat_token.go` (token classification), leaving `chat.go` as the entry + shared flow.
- **Deduplicate** the LLM/VLM paths behind a generic `runChat[T, M]` driven by a `prepareFn` that holds the only type-specific work (chat-template apply + `generateFn`).
- **Unify** token handling: a single `tokenClass` classifier (`plainClass` / `reasoningClass`) is shared by the block `sink` and stream `render` adapters, replacing four parallel plain/reasoning functions.

## Why

`chat.go` had grown to nearly 1000 lines with near-identical LLM/VLM handlers and four parallel token helpers wrapping the same classification core.

## Behavior

No user-visible change. The default inline output (`reasoning_format` unset / `none`) stays byte-identical; `deepseek` / `auto` continue to split thinking into `reasoning_content`.

## Test

- `bazelisk build //cli/server/handler:handler`
- `bazelisk test //cli/server/handler:handler_test` (passes)