### PR TITLE
feat(server): add raw /v1/completions for FIM autocompletion

### DIFF
--- a/cli/server/docs/swagger.yaml
+++ b/cli/server/docs/swagger.yaml
@@ -25,6 +25,30 @@ paths:
               schema:
                 $ref: "#/components/schemas/ChatCompletionResponse"
 
+  /v1/completions:
+    post:
+      summary: Creates a raw text completion for the given prompt
+      description: |
+        Generates a continuation of the prompt with no chat template applied —
+        the prompt is passed to the model verbatim. Intended for clients that
+        build the full prompt themselves, e.g. editor fill-in-the-middle (FIM)
+        code autocompletion; include the model's FIM tokens in `prompt`
+        directly. LLM models only.
+      operationId: PostV1Completions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompletionRequest"
+      responses:
+        "200":
+          description: Successful response for non-streaming requests
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CompletionResponse"
+
   /v1/logits:
     post:
       summary: Raw logits from a single prefill-only forward pass
@@ -147,6 +171,129 @@ components:
                 items:
                   type: number
                 description: top_n > 0 — top logits sorted descending; top_n == 0 — full vocab in token-id order.
+
+    # ---------- Completions ----------
+    CompletionRequest:
+      type: object
+      required: [model, prompt]
+      example:
+        model: "qualcomm/Qwen3-4B-Instruct-2507"
+        prompt: "def fibonacci(n):"
+        max_tokens: 64
+        temperature: 0.2
+        stream: false
+      properties:
+        model:
+          type: string
+          description: ID of the model to use (LLM only)
+        prompt:
+          type: string
+          description: The prompt to complete, passed to the model verbatim (no chat template). A single-element string array is also accepted.
+        max_tokens:
+          type: integer
+          minimum: 1
+          default: 16
+          description: The maximum number of tokens to generate
+        suffix:
+          type: string
+          description: Not supported — include the model's FIM tokens in `prompt` instead
+        echo:
+          type: boolean
+          default: false
+          description: Echo back the prompt in addition to the completion
+        stop:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: Sequences where generation stops; the returned text does not contain them
+        temperature:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 2
+          description: What sampling temperature to use, between 0 and 2
+        top_p:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          description: An alternative to sampling with temperature, called nucleus sampling
+        seed:
+          type: integer
+          description: Best-effort deterministic sampling seed
+        presence_penalty:
+          type: number
+          format: float
+          minimum: -2
+          maximum: 2
+          description: Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far
+        frequency_penalty:
+          type: number
+          format: float
+          minimum: -2
+          maximum: 2
+          description: Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far
+        stream:
+          type: boolean
+          description: If set, partial text deltas will be sent
+          default: false
+        stream_options:
+          type: object
+          description: Options for streaming responses. Only used when stream is true.
+          properties:
+            include_usage:
+              type: boolean
+              description: If set, an additional chunk will be streamed with token usage statistics for the entire request
+        top_k:
+          type: integer
+          minimum: 0
+          description: An alternative to sampling with temperature, called top-k sampling
+        min_p:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          description: Minimum token probability, scaled by the probability of the most likely token
+        repetition_penalty:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+          description: The parameter for repetition penalty. 1.0 means no penalty
+        nctx:
+          type: integer
+          minimum: 1
+          description: Context window size (llama_cpp only). Omit to use the server default set via `geniex serve --nctx` / `GENIEX_NCTX` (4096 out of the box).
+        ngl:
+          type: integer
+          description: Number of GPU/NPU layers to offload (llama_cpp only). Omit to use the server default set via `geniex serve --ngl` / `GENIEX_NGL` (999 out of the box); the server chooses the correct layout per backend.
+        compute:
+          type: string
+          enum: [cpu, gpu, npu, hybrid]
+          description: Compute unit to run on. Omit to use the server default set via `geniex serve --compute` / `GENIEX_COMPUTE`. QAIRT is NPU-only; other aliases are coerced with a warning.
+    CompletionResponse:
+      type: object
+      properties:
+        object:
+          type: string
+          example: "text_completion"
+        choices:
+          type: array
+          items:
+            type: object
+            properties:
+              index:
+                type: integer
+              text:
+                type: string
+                description: The generated continuation of the prompt
+              finish_reason:
+                type: string
+                enum: [stop, length]
+        usage:
+          $ref: "#/components/schemas/TokenUsage"
 
     # ---------- Chat ----------
     ChatCompletionRequest:

--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "chat_response.go",
         "chat_stream.go",
         "chat_token.go",
+        "completion.go",
         "logits.go",
         "model.go",
     ],
@@ -34,6 +35,7 @@ go_cgo_test(
     name = "handler_test",
     srcs = [
         "chat_test.go",
+        "completion_test.go",
     ],
     embed = [":handler"],
 )

--- a/cli/server/handler/completion.go
+++ b/cli/server/handler/completion.go
@@ -178,56 +178,64 @@ func Completions(c *gin.Context) {
 		echo = prompt
 	}
 
+	// ---- generate: stream SSE chunks or write one blocking response ----
 	if req.Stream {
-		streamCompletion(c, p, prompt, genConfig, echo, req.StreamOptions.IncludeUsage.Value)
-		return
+		// streaming
+		var stopGen atomic.Bool
+		dataCh := make(chan string)
+
+		var (
+			profile geniex_sdk.ProfileData
+			genErr  error
+			wg      sync.WaitGroup
+		)
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := p.Generate(geniex_sdk.LlmGenerateInput{
+				PromptUTF8: prompt,
+				OnToken: func(token string) bool {
+					if stopGen.Load() {
+						return false
+					}
+					dataCh <- token
+					return true
+				},
+				Config: genConfig,
+			})
+			genErr = err
+			if out != nil {
+				profile = out.ProfileData
+			}
+			close(dataCh)
+		}()
+
+		wait := func() error { wg.Wait(); return genErr }
+		streamCompletion(c, dataCh, wait, req.StreamOptions.IncludeUsage.Value, echo, &profile)
+
+		stopGen.Store(true)
+		for range dataCh {
+		}
+	} else {
+		// blocking
+		out, err := p.Generate(geniex_sdk.LlmGenerateInput{
+			PromptUTF8: prompt,
+			Config:     genConfig,
+		})
+		if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
+			writeCompletionContextLengthExceeded(c, echo+out.FullText, out.ProfileData)
+			return
+		}
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+			return
+		}
+		writeCompletionResponse(c, echo+out.FullText, out.ProfileData)
 	}
-
-	out, err := p.Generate(geniex_sdk.LlmGenerateInput{
-		PromptUTF8: prompt,
-		Config:     genConfig,
-	})
-	if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
-		writeCompletionContextLengthExceeded(c, echo+out.FullText, out.ProfileData)
-		return
-	}
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
-		return
-	}
-	c.JSON(http.StatusOK, completionResponse{
-		Object: "text_completion",
-		Choices: []completionChoice{{
-			Text:         echo + out.FullText,
-			FinishReason: mapFinishReason(out.ProfileData.StopReason),
-		}},
-		Usage: profile2Usage(out.ProfileData),
-	})
 }
 
-type completionChoice struct {
-	Index        int64  `json:"index"`
-	Text         string `json:"text"`
-	FinishReason string `json:"finish_reason"`
-}
-
-type completionResponse struct {
-	Object  string                 `json:"object"`
-	Choices []completionChoice     `json:"choices"`
-	Usage   openai.CompletionUsage `json:"usage"`
-}
-
-func writeCompletionContextLengthExceeded(c *gin.Context, text string, profile geniex_sdk.ProfileData) {
-	c.JSON(http.StatusBadRequest, map[string]any{
-		"error": map[string]any{
-			"message": "model context window exceeded; output truncated",
-			"type":    "invalid_request_error",
-			"code":    "context_length_exceeded",
-		},
-		"choices": []completionChoice{{Text: text, FinishReason: "length"}},
-		"usage":   profile2Usage(profile),
-	})
-}
+// ---- streaming SSE chunks ----
 
 type completionStreamChoice struct {
 	Index        int64   `json:"index"`
@@ -261,33 +269,8 @@ func completionUsageChunk(u openai.CompletionUsage) completionStreamChunk {
 	return completionStreamChunk{Object: completionObject, Choices: []completionStreamChoice{}, Usage: &u}
 }
 
-func streamCompletion(c *gin.Context, p *geniex_sdk.LLM, prompt string, genConfig *geniex_sdk.GenerationConfig, echo string, includeUsage bool) {
-	var stopGen atomic.Bool
-	dataCh := make(chan string)
-
-	var (
-		out    *geniex_sdk.LlmGenerateOutput
-		genErr error
-		wg     sync.WaitGroup
-	)
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		out, genErr = p.Generate(geniex_sdk.LlmGenerateInput{
-			PromptUTF8: prompt,
-			OnToken: func(token string) bool {
-				if stopGen.Load() {
-					return false
-				}
-				dataCh <- token
-				return true
-			},
-			Config: genConfig,
-		})
-		close(dataCh)
-	}()
-
+// profile is read only after wait() returns, when generation has filled it.
+func streamCompletion(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, echo string, profile *geniex_sdk.ProfileData) {
 	first := echo != ""
 	c.Stream(func(w io.Writer) bool {
 		if first {
@@ -300,20 +283,54 @@ func streamCompletion(c *gin.Context, p *geniex_sdk.LLM, prompt string, genConfi
 			c.SSEvent("", completionTextChunk(r))
 			return true
 		}
-		wg.Wait()
-		if genErr != nil {
-			c.SSEvent("", map[string]any{"error": genErr.Error(), "code": geniex_sdk.SDKErrorCode(genErr)})
+		if err := wait(); err != nil {
+			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return false
 		}
-		c.SSEvent("", completionFinishChunk(mapFinishReason(out.ProfileData.StopReason)))
+		c.SSEvent("", completionFinishChunk(mapFinishReason(profile.StopReason)))
 		if includeUsage {
-			c.SSEvent("", completionUsageChunk(profile2Usage(out.ProfileData)))
+			c.SSEvent("", completionUsageChunk(profile2Usage(*profile)))
 		}
 		c.SSEvent("", "[DONE]")
 		return false
 	})
+}
 
-	stopGen.Store(true)
-	for range dataCh {
-	}
+// ---- blocking response ----
+
+type completionChoice struct {
+	Index        int64  `json:"index"`
+	Text         string `json:"text"`
+	FinishReason string `json:"finish_reason"`
+}
+
+type completionResponse struct {
+	Object  string                 `json:"object"`
+	Choices []completionChoice     `json:"choices"`
+	Usage   openai.CompletionUsage `json:"usage"`
+}
+
+func writeCompletionResponse(c *gin.Context, text string, profile geniex_sdk.ProfileData) {
+	c.JSON(http.StatusOK, completionResponse{
+		Object: completionObject,
+		Choices: []completionChoice{{
+			Text:         text,
+			FinishReason: mapFinishReason(profile.StopReason),
+		}},
+		Usage: profile2Usage(profile),
+	})
+}
+
+// OpenAI's 400 body, plus the partial generation under `choices` so clients can
+// recover the truncated output.
+func writeCompletionContextLengthExceeded(c *gin.Context, text string, profile geniex_sdk.ProfileData) {
+	c.JSON(http.StatusBadRequest, map[string]any{
+		"error": map[string]any{
+			"message": "model context window exceeded; output truncated",
+			"type":    "invalid_request_error",
+			"code":    "context_length_exceeded",
+		},
+		"choices": []completionChoice{{Text: text, FinishReason: "length"}},
+		"usage":   profile2Usage(profile),
+	})
 }

--- a/cli/server/handler/completion.go
+++ b/cli/server/handler/completion.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"sync/atomic"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+	"github.com/qualcomm/GenieX/cli/internal/config"
+	"github.com/qualcomm/GenieX/cli/internal/store"
+	"github.com/qualcomm/GenieX/cli/server/service"
+)
+
+type CompletionNewParams openai.CompletionNewParams
+
+type CompletionRequest struct {
+	CompletionNewParams
+	Stream bool `json:"stream"`
+
+	NCtx    int32  `json:"nctx"`
+	Ngl     int32  `json:"ngl"`
+	Compute string `json:"compute"`
+
+	TopK              int32   `json:"top_k"`
+	MinP              float32 `json:"min_p"`
+	RepetitionPenalty float32 `json:"repetition_penalty"`
+}
+
+func defaultCompletionRequest() CompletionRequest {
+	cfg := config.Get()
+	return CompletionRequest{
+		CompletionNewParams: CompletionNewParams{
+			// OpenAI's documented default for the legacy completions endpoint.
+			MaxTokens: param.NewOpt[int64](16),
+		},
+		NCtx:              cfg.NCtx,
+		Ngl:               cfg.Ngl,
+		Compute:           cfg.Compute,
+		RepetitionPenalty: 1.0,
+	}
+}
+
+func completionPrompt(u openai.CompletionNewParamsPromptUnion) (string, error) {
+	switch {
+	case !param.IsOmitted(u.OfString):
+		if u.OfString.Value == "" {
+			return "", errors.New("prompt must be non-empty")
+		}
+		return u.OfString.Value, nil
+	case u.OfArrayOfStrings != nil:
+		if len(u.OfArrayOfStrings) != 1 || u.OfArrayOfStrings[0] == "" {
+			return "", errors.New("only a single non-empty prompt is supported")
+		}
+		return u.OfArrayOfStrings[0], nil
+	case u.OfArrayOfTokens != nil || u.OfArrayOfTokenArrays != nil:
+		return "", errors.New("token prompts are not supported; send a string prompt")
+	default:
+		return "", errors.New("prompt is required")
+	}
+}
+
+func completionStop(u openai.CompletionNewParamsStopUnion) []string {
+	if !param.IsOmitted(u.OfString) {
+		if u.OfString.Value == "" {
+			return nil
+		}
+		return []string{u.OfString.Value}
+	}
+	return u.OfStringArray
+}
+
+func completionUnsupported(p CompletionNewParams) error {
+	switch {
+	case p.Suffix.Valid() && p.Suffix.Value != "":
+		return errors.New("suffix is not supported; send a prompt containing the model's FIM template instead")
+	case p.N.Valid() && p.N.Value > 1:
+		return errors.New("n > 1 is not supported")
+	case p.BestOf.Valid() && p.BestOf.Value > 1:
+		return errors.New("best_of > 1 is not supported")
+	case p.Logprobs.Valid():
+		return errors.New("logprobs is not supported")
+	case len(p.LogitBias) > 0:
+		return errors.New("logit_bias is not supported")
+	default:
+		return nil
+	}
+}
+
+// Completions serves POST /v1/completions. The prompt is passed to the model
+// verbatim — no chat template — so clients that build their own prompt (e.g.
+// editor FIM autocompletion) get a raw continuation back.
+func Completions(c *gin.Context) {
+	req := defaultCompletionRequest()
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Error("Failed to bind JSON", "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
+	slog.Info("Completions", "param", req)
+	prompt, err := completionPrompt(req.Prompt)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	if err := completionUnsupported(req.CompletionNewParams); err != nil {
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
+	name, _ := geniex_sdk.SplitNamePrecision(string(req.Model))
+	modelType, err := geniex_sdk.ModelGetType(name)
+	if err != nil {
+		slog.Error("Failed to get model type", "model", req.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+	if modelType != geniex_sdk.ModelTypeLLM {
+		c.JSON(http.StatusBadRequest, map[string]any{"error": "completions is only supported for LLM models"})
+		return
+	}
+	paths, err := geniex_sdk.ModelGetPaths(name)
+	if err != nil {
+		slog.Error("Failed to resolve model paths", "model", req.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
+	modelParam, err := service.ResolveModelParam(paths.RuntimeID, paths.ModelName, req.NCtx, req.Ngl, req.Compute, store.Get().ResolveChipset(true), service.SpecParam{})
+	if err != nil {
+		slog.Error("Failed to resolve model params", "model", req.Model, "error", err)
+		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
+		return
+	}
+
+	// Automatically adjust NCtx if MaxTokens is larger (llama_cpp only — QAIRT
+	// does not use NCtx and the 0-default must not be overwritten for non-llama_cpp plugins).
+	if paths.RuntimeID == geniex_sdk.RuntimeLlamaCpp && modelParam.NCtx < int32(req.MaxTokens.Value) {
+		slog.Debug("Adjust NCtx to MaxTokens", "from", modelParam.NCtx, "to", req.MaxTokens.Value)
+		modelParam.NCtx = int32(req.MaxTokens.Value)
+	}
+
+	p, err := service.KeepAliveGet[geniex_sdk.LLM](
+		string(req.Model),
+		modelParam,
+		c.GetHeader("GenieX-KeepCache") != "true",
+	)
+	if writeKeepAliveError(c, err) {
+		return
+	}
+
+	genConfig := &geniex_sdk.GenerationConfig{
+		MaxTokens: int32(req.MaxTokens.Value),
+		Stop:      completionStop(req.Stop),
+		SamplerConfig: &geniex_sdk.SamplerConfig{
+			Temperature:       float32(req.Temperature.Value),
+			TopP:              float32(req.TopP.Value),
+			TopK:              req.TopK,
+			MinP:              req.MinP,
+			RepetitionPenalty: req.RepetitionPenalty,
+			PresencePenalty:   float32(req.PresencePenalty.Value),
+			FrequencyPenalty:  float32(req.FrequencyPenalty.Value),
+			Seed:              int32(req.Seed.Value),
+		},
+	}
+	echo := ""
+	if req.Echo.Valid() && req.Echo.Value {
+		echo = prompt
+	}
+
+	if req.Stream {
+		streamCompletion(c, p, prompt, genConfig, echo, req.StreamOptions.IncludeUsage.Value)
+		return
+	}
+
+	out, err := p.Generate(geniex_sdk.LlmGenerateInput{
+		PromptUTF8: prompt,
+		Config:     genConfig,
+	})
+	if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
+		writeCompletionContextLengthExceeded(c, echo+out.FullText, out.ProfileData)
+		return
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
+		return
+	}
+	c.JSON(http.StatusOK, completionResponse{
+		Object: "text_completion",
+		Choices: []completionChoice{{
+			Text:         echo + out.FullText,
+			FinishReason: mapFinishReason(out.ProfileData.StopReason),
+		}},
+		Usage: profile2Usage(out.ProfileData),
+	})
+}
+
+type completionChoice struct {
+	Index        int64  `json:"index"`
+	Text         string `json:"text"`
+	FinishReason string `json:"finish_reason"`
+}
+
+type completionResponse struct {
+	Object  string                 `json:"object"`
+	Choices []completionChoice     `json:"choices"`
+	Usage   openai.CompletionUsage `json:"usage"`
+}
+
+func writeCompletionContextLengthExceeded(c *gin.Context, text string, profile geniex_sdk.ProfileData) {
+	c.JSON(http.StatusBadRequest, map[string]any{
+		"error": map[string]any{
+			"message": "model context window exceeded; output truncated",
+			"type":    "invalid_request_error",
+			"code":    "context_length_exceeded",
+		},
+		"choices": []completionChoice{{Text: text, FinishReason: "length"}},
+		"usage":   profile2Usage(profile),
+	})
+}
+
+type completionStreamChoice struct {
+	Index        int64   `json:"index"`
+	Text         string  `json:"text"`
+	FinishReason *string `json:"finish_reason"` // null until the final chunk
+}
+
+type completionStreamChunk struct {
+	Object  string                   `json:"object"`
+	Choices []completionStreamChoice `json:"choices"`
+	Usage   *openai.CompletionUsage  `json:"usage,omitempty"`
+}
+
+const completionObject = "text_completion"
+
+func completionTextChunk(text string) completionStreamChunk {
+	return completionStreamChunk{
+		Object:  completionObject,
+		Choices: []completionStreamChoice{{Text: text}},
+	}
+}
+
+func completionFinishChunk(reason string) completionStreamChunk {
+	return completionStreamChunk{
+		Object:  completionObject,
+		Choices: []completionStreamChoice{{FinishReason: &reason}},
+	}
+}
+
+func completionUsageChunk(u openai.CompletionUsage) completionStreamChunk {
+	return completionStreamChunk{Object: completionObject, Choices: []completionStreamChoice{}, Usage: &u}
+}
+
+func streamCompletion(c *gin.Context, p *geniex_sdk.LLM, prompt string, genConfig *geniex_sdk.GenerationConfig, echo string, includeUsage bool) {
+	var stopGen atomic.Bool
+	dataCh := make(chan string)
+
+	var (
+		out    *geniex_sdk.LlmGenerateOutput
+		genErr error
+		wg     sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		out, genErr = p.Generate(geniex_sdk.LlmGenerateInput{
+			PromptUTF8: prompt,
+			OnToken: func(token string) bool {
+				if stopGen.Load() {
+					return false
+				}
+				dataCh <- token
+				return true
+			},
+			Config: genConfig,
+		})
+		close(dataCh)
+	}()
+
+	first := echo != ""
+	c.Stream(func(w io.Writer) bool {
+		if first {
+			first = false
+			c.SSEvent("", completionTextChunk(echo))
+			return true
+		}
+		r, ok := <-dataCh
+		if ok {
+			c.SSEvent("", completionTextChunk(r))
+			return true
+		}
+		wg.Wait()
+		if genErr != nil {
+			c.SSEvent("", map[string]any{"error": genErr.Error(), "code": geniex_sdk.SDKErrorCode(genErr)})
+			return false
+		}
+		c.SSEvent("", completionFinishChunk(mapFinishReason(out.ProfileData.StopReason)))
+		if includeUsage {
+			c.SSEvent("", completionUsageChunk(profile2Usage(out.ProfileData)))
+		}
+		c.SSEvent("", "[DONE]")
+		return false
+	})
+
+	stopGen.Store(true)
+	for range dataCh {
+	}
+}

--- a/cli/server/handler/completion_test.go
+++ b/cli/server/handler/completion_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/packages/param"
+)
+
+func TestCompletionPrompt(t *testing.T) {
+	tests := []struct {
+		name    string
+		prompt  openai.CompletionNewParamsPromptUnion
+		want    string
+		wantErr bool
+	}{
+		{"string", openai.CompletionNewParamsPromptUnion{OfString: param.NewOpt("<|fim_prefix|>a<|fim_suffix|>b<|fim_middle|>")}, "<|fim_prefix|>a<|fim_suffix|>b<|fim_middle|>", false},
+		{"empty string", openai.CompletionNewParamsPromptUnion{OfString: param.NewOpt("")}, "", true},
+		{"single-element array", openai.CompletionNewParamsPromptUnion{OfArrayOfStrings: []string{"abc"}}, "abc", false},
+		{"multi-element array", openai.CompletionNewParamsPromptUnion{OfArrayOfStrings: []string{"a", "b"}}, "", true},
+		{"empty array", openai.CompletionNewParamsPromptUnion{OfArrayOfStrings: []string{}}, "", true},
+		{"token array", openai.CompletionNewParamsPromptUnion{OfArrayOfTokens: []int64{1, 2}}, "", true},
+		{"omitted", openai.CompletionNewParamsPromptUnion{}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := completionPrompt(tt.prompt)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("completionPrompt() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("completionPrompt() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompletionStop(t *testing.T) {
+	tests := []struct {
+		name string
+		stop openai.CompletionNewParamsStopUnion
+		want []string
+	}{
+		{"omitted", openai.CompletionNewParamsStopUnion{}, nil},
+		{"string", openai.CompletionNewParamsStopUnion{OfString: param.NewOpt("\n\n")}, []string{"\n\n"}},
+		{"empty string", openai.CompletionNewParamsStopUnion{OfString: param.NewOpt("")}, nil},
+		{"array", openai.CompletionNewParamsStopUnion{OfStringArray: []string{"<|endoftext|>", "\n"}}, []string{"<|endoftext|>", "\n"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := completionStop(tt.stop); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("completionStop() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompletionUnsupported(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  CompletionNewParams
+		wantErr bool
+	}{
+		{"defaults", CompletionNewParams{}, false},
+		{"n 1", CompletionNewParams{N: param.NewOpt[int64](1)}, false},
+		{"best_of 1", CompletionNewParams{BestOf: param.NewOpt[int64](1)}, false},
+		{"empty suffix", CompletionNewParams{Suffix: param.NewOpt("")}, false},
+		{"suffix", CompletionNewParams{Suffix: param.NewOpt("tail")}, true},
+		{"n 2", CompletionNewParams{N: param.NewOpt[int64](2)}, true},
+		{"best_of 2", CompletionNewParams{BestOf: param.NewOpt[int64](2)}, true},
+		{"logprobs", CompletionNewParams{Logprobs: param.NewOpt[int64](0)}, true},
+		{"logit_bias", CompletionNewParams{LogitBias: map[string]int64{"50256": -100}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := completionUnsupported(tt.params); (err != nil) != tt.wantErr {
+				t.Errorf("completionUnsupported() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cli/server/route.go
+++ b/cli/server/route.go
@@ -35,12 +35,8 @@ func RegisterAPIv1(r *gin.Engine) {
 
 	g.Use(middleware.CORS, middleware.GIL)
 
-	// ==== legacy ====
-	g.POST("/completions", func(c *gin.Context) {
-		c.JSON(http.StatusGone, map[string]any{"error": "this endpoint is deprecated, please use /chat/completions instead"})
-	})
-
 	// ==== openai compatible ====
+	g.POST("/completions", handler.Completions)
 	g.POST("/chat/completions", handler.ChatCompletions)
 
 	// ==== raw logits (prefill-only forward pass; not OpenAI generative logprobs) ====

--- a/docs/cn/run/cli/local-server.mdx
+++ b/docs/cn/run/cli/local-server.mdx
@@ -98,6 +98,23 @@ geniex serve
 
 ![响应体展示 200 成功响应及 VLM 对图像的描述](/Images/server/curl-5.png)
 
+## **POST /v1/completions**
+
+对 `prompt` 生成原始续写，不套用聊天模板 —— 提示词会原样传给模型。适用于自行构造完整提示词的客户端，例如编辑器的 fill-in-the-middle（FIM）代码补全：把模型的 FIM 标记直接写进 `prompt`。仅支持 LLM 模型。
+
+```json Example Value
+{
+  "model": "unsloth/Qwen2.5-Coder-3B-GGUF:Q4_0",
+  "prompt": "<|fim_prefix|>def fibonacci(n):\n    <|fim_suffix|>\n    return a<|fim_middle|>",
+  "max_tokens": 64,
+  "temperature": 0.2,
+  "stop": ["<|endoftext|>"],
+  "stream": false
+}
+```
+
+响应中的 `choices[0].text` 即原始补全内容，可直接插入光标处。`stream`、`stop`、`echo` 及采样参数（`temperature`、`top_p`、`top_k`、`min_p`、`repetition_penalty`、`seed`）与 `/v1/chat/completions` 行为一致；不支持 `suffix` —— 请改用模型的 FIM 标记把后缀编码进 `prompt`。
+
 ## **Python 客户端（OpenAI SDK）**
 
 由于服务器使用 OpenAI 协议，可直接将官方 `openai` Python 客户端指向本地端点，复用任意已有的 OpenAI 代码。先通过 `pip install openai` 安装，然后创建 client：

--- a/docs/en/run/cli/local-server.mdx
+++ b/docs/en/run/cli/local-server.mdx
@@ -98,6 +98,23 @@ In Swagger UI, replace the request body with this VLM payload, point `image_url.
 
 ![Response body showing a successful 200 response with the VLM's image description](/Images/server/curl-5.png)
 
+## **POST /v1/completions**
+
+Generates a raw continuation of `prompt` with no chat template applied — the prompt reaches the model verbatim. Use this for clients that build the full prompt themselves, such as editor fill-in-the-middle (FIM) code autocompletion: put the model's FIM tokens directly in `prompt`. LLM models only.
+
+```json Example Value
+{
+  "model": "unsloth/Qwen2.5-Coder-3B-GGUF:Q4_0",
+  "prompt": "<|fim_prefix|>def fibonacci(n):\n    <|fim_suffix|>\n    return a<|fim_middle|>",
+  "max_tokens": 64,
+  "temperature": 0.2,
+  "stop": ["<|endoftext|>"],
+  "stream": false
+}
+```
+
+The response `choices[0].text` is the raw completion, ready to insert at the cursor. `stream`, `stop`, `echo` and the sampler knobs (`temperature`, `top_p`, `top_k`, `min_p`, `repetition_penalty`, `seed`) work as on `/v1/chat/completions`; `suffix` is not supported — encode the suffix with the model's FIM tokens inside `prompt` instead.
+
 ## **Python client (OpenAI SDK)**
 
 Because the server speaks the OpenAI protocol, you can point the official `openai` Python client at the local endpoint and reuse any existing OpenAI code. Install with `pip install openai`, then create a client:


### PR DESCRIPTION
## Summary

- Replace the `/v1/completions` 410 stub with a real OpenAI legacy completions endpoint: the prompt is passed to the model verbatim (no chat template), so editor FIM autocompletion clients get a raw continuation they can insert at the cursor.
- Supports streaming and non-streaming, `stop`, `echo`, the sampler knobs and the server `nctx`/`ngl`/`compute` extensions; unsupported params (`suffix`, `n > 1`, `best_of > 1`, `logprobs`, `logit_bias`) return a clear 400.
- Document the endpoint in Swagger and the local-server docs (en/cn).

## Test plan

- [x] Unit tests for prompt/stop extraction, unsupported-param validation and request binding (`completion_test.go`)
- [ ] CI: lint, build, Go coverage

Closes #1316