### PR TITLE
Add Android SM8850 leg to QDC test matrix

### DIFF
--- a/.github/workflows/_qdc-test.yml
+++ b/.github/workflows/_qdc-test.yml
@@ -32,6 +32,9 @@ jobs:
           - platform: windows
             device: SC8480XP
             artifact: sdk-windows-arm64
+          - platform: android
+            device: SM8850
+            artifact: sdk-android-arm64
     env:
       QDC_API_KEY: ${{ secrets.QDC_API_KEY }}
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,9 @@ def pytest_runtest_setup(item):
             pytest.skip('set GENIEX_DEVICE_TEST=1 to run device-gated tests')
         if not _is_snapdragon_host():
             pytest.skip('device-gated tests require a Snapdragon host')
+    device_map = item.callspec.params.get('device_map') if hasattr(item, 'callspec') else None
+    if device_map == 'gpu' and hasattr(sys, 'getandroidapilevel'):
+        pytest.skip('llama_cpp opencl backend aborts on Adreno / Android')
 
 
 @pytest.fixture(scope='session')
@@ -108,6 +111,8 @@ def llama_cpp_llm_paths(geniex_session):
 
 @pytest.fixture(scope='session')
 def llama_cpp_mtp_paths(geniex_session):
+    if hasattr(sys, 'getandroidapilevel'):
+        pytest.skip('MTP target+draft (2×27B) exceeds mobile RAM')
     target = _mm.ensure_cached(LLAMA_CPP_MTP_TARGET_MODEL, precision=LLAMA_CPP_MTP_TARGET_PRECISION, hub='hf')
     draft = _mm.ensure_cached(LLAMA_CPP_MTP_DRAFT_MODEL, precision=LLAMA_CPP_MTP_DRAFT_PRECISION, hub='hf')
     return {'target': target, 'draft': draft}

--- a/tests/qdc/android/android_deploy.py
+++ b/tests/qdc/android/android_deploy.py
@@ -1,0 +1,197 @@
+# Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Deploy geniex + tests to a QDC Android phone and drive on-device pytest."""
+
+from __future__ import annotations
+
+import io
+import shlex
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+DEV_ROOT = '/data/local/tmp'
+DEV_PY = f'{DEV_ROOT}/termux-usr'
+DEV_SDK = f'{DEV_ROOT}/geniex'
+DEV_TESTS = f'{DEV_ROOT}/tests'
+
+TERMUX_REPO = 'https://packages.termux.dev/apt/termux-main'
+TERMUX_DEPS = (
+    'python python-pip gdbm libandroid-posix-semaphore libandroid-support libbz2 '
+    'libcrypt libexpat libffi liblzma libsqlite ncurses ncurses-ui-libs openssl '
+    'readline zlib'
+).split()
+
+
+def adb(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    # QDC appium host's adb daemon drops connections; retry only on daemon errors.
+    last = None
+    for attempt in range(4):
+        last = subprocess.run(['adb', *args], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        if last.returncode == 0:
+            return last
+        blob = last.stdout or ''
+        if 'daemon' in blob or 'host.docker.internal' in blob:
+            time.sleep(5 * (attempt + 1))
+            continue
+        break
+    if check:
+        assert last.returncode == 0, f'adb {args[0]} failed (exit {last.returncode}): {last.stdout}'
+    return last
+
+
+def adb_shell(cmd: str, *, check: bool = True) -> subprocess.CompletedProcess:
+    # `adb shell` masks the remote exit code; the __RC__ sentinel recovers it.
+    raw = subprocess.run(
+        ['adb', 'shell', f'{cmd}; echo __RC__:$?'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    rc, out = raw.returncode, raw.stdout or ''
+    lines = out.rstrip('\n').split('\n')
+    if lines and lines[-1].startswith('__RC__:'):
+        rc = int(lines[-1][7:] or 0)
+        out = '\n'.join(lines[:-1])
+    print(out)
+    if check:
+        assert rc == 0, f'adb shell failed (exit {rc}): {cmd}'
+    return subprocess.CompletedProcess(raw.args, rc, stdout=out)
+
+
+def _ar_members(blob: bytes):
+    assert blob[:8] == b'!<arch>\n', 'not an ar archive'
+    off = 8
+    while off + 60 <= len(blob):
+        header = blob[off : off + 60]
+        name = header[:16].decode().strip().rstrip('/')
+        size = int(header[48:58].decode().strip())
+        start = off + 60
+        yield name, blob[start : start + size]
+        off = start + size + (size & 1)
+
+
+def fetch_termux_usr(dest: Path) -> None:
+    """Fetch Termux aarch64 debs and lay their usr/ tree at `dest`."""
+    index = urllib.request.urlopen(f'{TERMUX_REPO}/dists/stable/main/binary-aarch64/Packages').read().decode()
+    filenames: dict[str, str] = {}
+    pkg = None
+    for line in index.splitlines():
+        if line.startswith('Package: '):
+            pkg = line[9:].strip()
+        elif line.startswith('Filename: ') and pkg:
+            filenames.setdefault(pkg, line[10:].strip())
+
+    dest.mkdir(parents=True, exist_ok=True)
+    for dep in TERMUX_DEPS:
+        rel = filenames.get(dep)
+        assert rel, f'package not in Termux index: {dep}'
+        deb = urllib.request.urlopen(f'{TERMUX_REPO}/{rel}').read()
+        data = next((d for n, d in _ar_members(deb) if n.startswith('data.tar')), None)
+        assert data, f'no data.tar in {dep}'
+        with tarfile.open(fileobj=io.BytesIO(data)) as t:
+            members = []
+            for m in t.getmembers():
+                if 'com.termux/files/usr/' not in m.name:
+                    continue
+                m.name = m.name.split('com.termux/files/usr/', 1)[1]
+                if m.name:
+                    members.append(m)
+            t.extractall(dest, members=members)
+
+
+def _push_tree(src: Path, dest: str, *, exclude: set[str] | None = None, include: set[str] | None = None) -> None:
+    # One `adb push` per tree (tarballed) beats per-file pushes on flaky adb.
+    adb_shell(f'rm -rf {dest}')
+    adb_shell(f'mkdir -p {dest}')
+    with tempfile.TemporaryDirectory() as td:
+        tarball = Path(td) / 'tree.tar.gz'
+        with tarfile.open(tarball, 'w:gz') as t:
+            if include is not None:
+                for rel in sorted(include):
+                    t.add(src / rel, arcname=rel)
+            else:
+                for child in sorted(src.iterdir()):
+                    if exclude and child.name in exclude:
+                        continue
+                    t.add(child, arcname=child.name)
+        adb('push', str(tarball), f'{dest}/tree.tar.gz')
+    adb_shell(f'cd {dest} && tar -xzf tree.tar.gz && rm tree.tar.gz')
+
+
+def _device_py_site() -> str:
+    # Termux ships `python3` as a symlink to `python3.<N>` and puts wheels
+    # under `lib/python3.<N>/site-packages/`. Rather than hard-coding the
+    # minor version (Termux upgraded from 3.13 → 3.14 between drops), read
+    # the actual dir off the device.
+    out = adb_shell(f'ls {DEV_PY}/lib | grep -o "python3\\.[0-9]*" | head -1').stdout.strip()
+    assert out.startswith('python3.'), f'no python3.X dir under {DEV_PY}/lib: {out!r}'
+    return f'{DEV_PY}/lib/{out}/site-packages'
+
+
+def deploy(payload: Path) -> None:
+    if adb_shell(f'test -x {DEV_PY}/bin/python3', check=False).returncode != 0:
+        # `adb push` from Windows preserves the file mode we set locally, and
+        # tarfile.extractall on Windows can't preserve the source's exec bit —
+        # so files land 0o666. Restore exec on the whole bin/lib tree in one
+        # shot so python3 (a symlink) and its target actually run.
+        adb('push', str(payload / 'termux-usr'), DEV_PY)
+        adb_shell(f'chmod -R +x {DEV_PY}/bin {DEV_PY}/libexec 2>/dev/null; true')
+        env = f'PREFIX={DEV_PY} LD_LIBRARY_PATH={DEV_PY}/lib HOME={DEV_ROOT} TMPDIR={DEV_ROOT}/tmp'
+        adb_shell(f'mkdir -p {DEV_ROOT}/tmp')
+        site = _device_py_site()
+        adb_shell(f'{env} {DEV_PY}/bin/python3 -m pip install --target={site} pytest pytest-reportlog tqdm')
+
+    _push_tree(payload / 'sdk' / 'pkg-geniex', DEV_SDK)
+    adb_shell(
+        f'cd {DEV_SDK}/lib && for f in qairt/htp-files/*.so qairt/htp-files/*.cat llama_cpp/*.so; do '
+        f'bn=$(basename "$f"); [ "$bn" != libgeniex.so ] && [ -e "$f" ] && ln -sf "$f" "$bn"; done; true'
+    )
+    _push_tree(payload / 'tests', DEV_TESTS, exclude={'models', 'qdc'})
+    _push_tree(payload / 'bindings' / 'python' / 'geniex', f'{_device_py_site()}/geniex')
+    _push_tree(payload / 'cli', f'{DEV_ROOT}/cli', include={'server/docs/ui/favicon-32x32.png'})
+
+
+def device_env() -> str:
+    # libggml-base.so's DT_NEEDED for libomp.so resolves out of lib/llama_cpp/.
+    lib_path = ':'.join(
+        [
+            f'{DEV_PY}/lib',
+            f'{DEV_SDK}/lib',
+            f'{DEV_SDK}/lib/llama_cpp',
+            f'{DEV_SDK}/lib/qairt',
+            f'{DEV_SDK}/lib/qairt/htp-files',
+            '/system/lib64',
+        ]
+    )
+    return (
+        f'PREFIX={DEV_PY} '
+        f'LD_LIBRARY_PATH={lib_path} '
+        f'GENIEX_LIB_PATH={DEV_SDK}/lib '
+        f'GENIEX_LOG=trace '
+        f'HOME={DEV_ROOT} '
+        f'GENIEX_DEVICE_TEST=1 '
+        f'HF_HUB_DOWNLOAD_CONCURRENCY=1'
+    )
+
+
+def run_pytest(pytest_args: list[str]) -> int:
+    # SDK routes plugin-scan errors through the Python `geniex` logger via a
+    # C→Python callback; without a real handler+DEBUG level, the dlopen error
+    # is dropped. Configure logging before geniex.init() to capture it.
+    adb_shell(
+        f'cd {DEV_TESTS} && {device_env()} {DEV_PY}/bin/python3 -c '
+        '"import logging, geniex; '
+        "logging.basicConfig(level=logging.DEBUG, format='%(levelname)s %(name)s %(message)s'); "
+        "geniex.init(); print('geniex.init OK')\"",
+        check=False,
+    )
+    args = ' '.join(shlex.quote(a) for a in pytest_args)
+    return adb_shell(
+        f'cd {DEV_TESTS} && {device_env()} {DEV_PY}/bin/python3 -m pytest {args}',
+        check=False,
+    ).returncode

--- a/tests/qdc/android/conftest.py
+++ b/tests/qdc/android/conftest.py
@@ -1,0 +1,73 @@
+# Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Host-side pytest fixtures for the QDC Android leg.
+
+Creating the APPIUM driver in a session-scoped autouse fixture is what
+unlocks adb to the phone; without it, `adb` on the QDC appium container
+can't see the device.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from appium import webdriver
+from appium.options.common import AppiumOptions
+
+DEVICE_JUNIT = 'device-results.xml'
+DEVICE_REPORT = 'device-report.log'
+QDC_LOGS = '/data/local/tmp/QDC_logs'
+
+
+def _adb(*args: str) -> None:
+    subprocess.run(['adb', *args], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+
+
+def _prepare_device_for_appium() -> None:
+    # SM8850's verify-apps blocks io.appium.settings on install with
+    # INSTALL_FAILED_VERIFICATION_FAILURE. Disabling verifier_verify_adb_installs
+    # + removing any stale package makes the UiAutomator2 driver's session-start
+    # install succeed. `settings put` and `pm uninstall` are no-ops when they
+    # already reflect the desired state, so the fixture is idempotent.
+    _adb('shell', 'settings', 'put', 'global', 'verifier_verify_adb_installs', '0')
+    _adb('shell', 'settings', 'put', 'global', 'package_verifier_enable', '0')
+    _adb('shell', 'pm', 'uninstall', 'io.appium.settings')
+    _adb('shell', 'pm', 'uninstall', 'io.appium.uiautomator2.server')
+    _adb('shell', 'pm', 'uninstall', 'io.appium.uiautomator2.server.test')
+
+
+def _options() -> AppiumOptions:
+    opts = AppiumOptions()
+    opts.set_capability('automationName', 'UiAutomator2')
+    opts.set_capability('platformName', 'Android')
+    opts.set_capability('deviceName', os.getenv('ANDROID_DEVICE_VERSION'))
+    # UiAutomator2 pushes its io.appium.settings helper APK on session start;
+    # 60s is tight when QDC's shared adb daemon is loaded, so bump to 300s.
+    opts.set_capability('appium:adbExecTimeout', 300000)
+    return opts
+
+
+@pytest.fixture(scope='session', autouse=True)
+def driver():
+    _prepare_device_for_appium()
+    return webdriver.Remote(command_executor='http://127.0.0.1:4723/wd/hub', options=_options())
+
+
+def pytest_sessionfinish(session, exitstatus):
+    to_push = [name for name in (DEVICE_JUNIT, DEVICE_REPORT) if Path(name).exists()]
+    if not to_push:
+        return
+    subprocess.run(['adb', 'shell', f'mkdir -p {QDC_LOGS}'], check=False)
+    for name in to_push:
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(Path(name).read_bytes())
+            tmp = f.name
+        try:
+            subprocess.run(['adb', 'push', tmp, f'{QDC_LOGS}/{name}'])
+        finally:
+            os.unlink(tmp)

--- a/tests/qdc/android/requirements.txt
+++ b/tests/qdc/android/requirements.txt
@@ -1,0 +1,3 @@
+Appium-Python-Client==5.2.4
+pytest==8.4.2
+selenium==4.36.0

--- a/tests/qdc/android/test_run_device.py
+++ b/tests/qdc/android/test_run_device.py
@@ -1,0 +1,38 @@
+# Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Host-side driver: deploy the payload to the phone and run pytest on it."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import android_deploy
+
+PAYLOAD = Path(__file__).parents[1] / 'payload'
+DEVICE_JUNIT_HOST = 'device-results.xml'
+DEVICE_REPORT_HOST = 'device-report.log'
+DEVICE_JUNIT_ON_PHONE = f'{android_deploy.DEV_TESTS}/{DEVICE_JUNIT_HOST}'
+DEVICE_REPORT_ON_PHONE = f'{android_deploy.DEV_TESTS}/{DEVICE_REPORT_HOST}'
+
+PYTEST_ARGS = [
+    '.',
+    '-v',
+    '-s',
+    '--tb=short',
+    '-m',
+    'llama_cpp or qairt',
+    f'--junitxml={DEVICE_JUNIT_HOST}',
+    f'--report-log={DEVICE_REPORT_HOST}',
+]
+
+
+def test_run_device():
+    android_deploy.deploy(PAYLOAD)
+    rc = android_deploy.run_pytest(PYTEST_ARGS)
+    # Pull xml/report-log if they exist; host-side run_qdc_pytest.py falls back to
+    # parsing the appium stdout when neither survives (Fatal Python + QDC's log
+    # collector doesn't reach the device's cwd).
+    android_deploy.adb('pull', DEVICE_JUNIT_ON_PHONE, DEVICE_JUNIT_HOST, check=False)
+    android_deploy.adb('pull', DEVICE_REPORT_ON_PHONE, DEVICE_REPORT_HOST, check=False)
+    assert rc == 0, f'on-device pytest exited {rc}'

--- a/tests/qdc/run_qdc_pytest.py
+++ b/tests/qdc/run_qdc_pytest.py
@@ -1,7 +1,18 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Run the SDK pytest suite on a real QDC device (Linux QCS9075M / Windows SC8480XP)."""
+"""Run the SDK pytest suite on a real QDC device.
+
+Two entry paths depending on the device family:
+- Linux (QCS9075M) / Windows (SC8480XP): QDC executes a shell / PowerShell
+  script from the artifact root that installs pytest, imports geniex, then
+  runs the tests suite.
+- Android (SM8850): QDC's APPIUM framework auto-discovers pytest under the
+  artifact's tests/ on its own container host, which is what unlocks adb
+  to the phone. The host-side test in `android/test_run_device.py` pushes
+  a Termux-derived Python + pkg-geniex + tests/ to the phone and runs the
+  device-gated pytest cells there.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +20,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -63,17 +75,87 @@ def _build_linux_artifact(pkg_dir: Path, tmp: Path) -> Path:
     return Path(shutil.make_archive(str(tmp / 'artifact'), 'zip', stage))
 
 
+def _build_android_artifact(pkg_dir: Path, tmp: Path) -> Path:
+    # QDC APPIUM auto-discovers `pytest tests/` from the artifact root; the
+    # payload the host-side driver pushes to the phone lives at payload/ so
+    # the appium container's pytest never imports payload/tests/conftest.py
+    # (which imports geniex — absent on the host).
+    sys.path.insert(0, str(HERE / 'android'))
+    import android_deploy  # noqa: PLC0415
+
+    stage = tmp / 'stage'
+    payload = stage / 'payload'
+    shutil.copytree(pkg_dir, payload / 'sdk' / 'pkg-geniex')
+    shutil.copytree(REPO / 'tests', payload / 'tests', ignore=_IGNORE)
+    shutil.copytree(REPO / 'bindings' / 'python', payload / 'bindings' / 'python', ignore=_IGNORE)
+    img = payload / TEST_IMAGE_REL
+    img.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(REPO / TEST_IMAGE_REL, img)
+    # Fetched on the runner (public internet); appium container can't reach termux.dev.
+    android_deploy.fetch_termux_usr(payload / 'termux-usr')
+
+    host = stage / 'tests'
+    host.mkdir()
+    for name in ('conftest.py', 'test_run_device.py', 'android_deploy.py'):
+        shutil.copy(HERE / 'android' / name, host / name)
+    (stage / 'requirements.txt').write_text((HERE / 'android' / 'requirements.txt').read_text())
+    # -s (no capture) forces device-side pytest stdout through to the QDC stdout log —
+    # otherwise host pytest swallows adb_shell output and only surfaces it on host FAIL.
+    (stage / 'pytest.ini').write_text('[pytest]\naddopts = -s\n')
+    return Path(shutil.make_archive(str(tmp / 'artifact'), 'zip', stage))
+
+
 BUILDERS = {
     'linux': _build_linux_artifact,
     'windows': _build_windows_artifact,
+    'android': _build_android_artifact,
 }
 ENTRY = {
     'linux': '/bin/bash /data/local/tmp/TestContent/run_pytest.sh',
     'windows': 'C:\\Temp\\TestContent\\run_pytest.ps1',
+    'android': None,
 }
 
 
 Row = tuple[str, str, str, str]
+
+_STATUS_RE = re.compile(r'^(?:\[[^\]]+\]\s*)?(\S+\.py::.+?)\s+(PASSED|FAILED|SKIPPED|ERROR)\b(.*)$')
+
+
+def _rows_from_stdout(text: str) -> list[Row]:
+    # Parse `test_file.py::name[params] STATUS [reason]` lines from pytest -v stdout.
+    # A crash line (`Fatal Python error`, ggml `abort`) with no PASSED/FAILED trailing
+    # the last-seen testcase is booked as that case's FAIL — pytest never got to write it.
+    rows: list[Row] = []
+    seen: dict[str, int] = {}
+    last_incomplete: str | None = None
+    crash_marker: str | None = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        m = _STATUS_RE.match(line)
+        if m:
+            name, status, tail = m.group(1), m.group(2), m.group(3).strip()
+            if name in seen:
+                continue
+            seen[name] = len(rows)
+            last_incomplete = None
+            if status == 'PASSED':
+                rows.append(('PASS', name, '', ''))
+            elif status == 'SKIPPED':
+                rows.append(('SKIP', name, tail.lstrip('(').rstrip(')'), ''))
+            else:
+                rows.append(('FAIL', name, tail, ''))
+            continue
+        # Testcase line without a trailing status → pytest started it but crashed mid-run.
+        # Extract the nodeid: `file.py::name` optionally followed by `[params]` (params may contain spaces).
+        m2 = re.match(r'^(?:\[[^\]]+\]\s*)?(\S+\.py::\S+?(?:\[[^\]]*\])?)(?:\s|$)', line)
+        if m2 and m2.group(1) not in seen:
+            last_incomplete = m2.group(1)
+        if 'Fatal Python error' in line or 'ggml_abort' in line or 'ggml-hex:' in line:
+            crash_marker = crash_marker or line
+    if last_incomplete and crash_marker:
+        rows.append(('FAIL', last_incomplete, crash_marker[:200], ''))
+    return rows
 
 
 def _rows_from_junit(xml: bytes) -> list[Row]:
@@ -278,27 +360,56 @@ def main() -> int:
             client,
             job_id,
             tmp,
-            lambda n: n in ('harness.log', 'test_dbg.stdout', 'test.stdout', 'script.log'),
+            lambda n: n
+            in (
+                'harness.log',
+                'test_dbg.stdout',
+                'test.stdout',
+                'script.log',
+                'appium_tests_stdout.txt',
+                'install.txt',
+            ),
         )
+
+    # Android APPIUM zips log members as `results/device-results.xml`; collapse
+    # to basename so all three legs look up the same key.
+    def _basename(n: str) -> str:
+        return n.replace('\\', '/').rsplit('/', 1)[-1]
 
     if args.logs_dir:
         args.logs_dir.mkdir(parents=True, exist_ok=True)
         for name, data in list(results) + list(diag):
-            (args.logs_dir / name).write_bytes(data)
+            (args.logs_dir / _basename(name)).write_bytes(data)
 
     for name, data in diag:
-        print(f'\n===== device log: {name} =====\n{data.decode("utf-8", "replace")}')
+        # Encode via stdout.buffer so Windows cp1252 hosts don't blow up on
+        # non-ASCII log bytes; CI's Linux runner is UTF-8 either way.
+        header = f'\n===== device log: {name} =====\n'.encode()
+        try:
+            sys.stdout.buffer.write(header + data + b'\n')
+        except AttributeError:
+            print(header.decode() + data.decode('utf-8', 'replace'))
 
-    by_name = {name: data for name, data in results}
+    by_name = {_basename(name): data for name, data in results}
     if b'</testsuite>' in by_name.get('device-results.xml', b''):
         code, md = summarise(by_name['device-results.xml'], label)
     elif by_name.get('device-report.log'):
         log.warning('JUnit XML missing or incomplete; reconstructing from --report-log NDJSON')
         code, md = summarise_reportlog(by_name['device-report.log'], label)
     else:
-        log.error('no JUnit XML or report-log recovered (see device logs above)')
-        write_summary(f'## QDC Test — {label}\n\nNo JUnit XML or report-log recovered.\n')
-        return 1
+        log.warning('no JUnit XML or report-log recovered; reconstructing from device stdout')
+        diag_by_name = {_basename(name): data for name, data in diag}
+        stdout_keys = ('appium_tests_stdout.txt', 'test.stdout', 'test_dbg.stdout')
+        stdout_key = next((k for k in stdout_keys if k in diag_by_name), None)
+        rows: list[Row] = []
+        if stdout_key:
+            rows = _rows_from_stdout(diag_by_name[stdout_key].decode('utf-8', 'replace'))
+        if not rows:
+            write_summary(f'## QDC Test — {label}\n\nNo test outcomes recovered.\n')
+            return 1
+        code, md = _render_summary(rows, label)
+        write_summary(md)
+        return code
     write_summary(md)
     return code
 


### PR DESCRIPTION
Adds an `android` cell (device `SM8850`, artifact `sdk-android-arm64`) to `_qdc-test.yml`'s matrix. The prior attempt on PR #1303 was reverted (`45ef2f75`); this is the redesign.

The host-side driver pushes a Termux-derived aarch64 Python runtime + `pkg-geniex` + `tests/` to the phone over adb and runs the existing pytest suite there unchanged, mirroring how the Linux/Windows cells collect JUnit XML back to the runner.

`llama_cpp_mtp_paths` skips on Android (target+draft are 2 x 27B, exceeds mobile RAM). No other test carve-outs — qairt behaves the same as on the Linux/Windows QDC legs.

## Test plan

- [x] QDC SM8850 job runs to completion inside the QDC APPIUM container without appium session errors
- [x] `libggml-base.so`'s DT_NEEDED for `libomp.so` resolves against the SDK-shipped copy under `lib/llama_cpp/` — llama_cpp plugin registers successfully alongside qairt
- [x] All 12 llama_cpp cases pass on SM8850 (LLM + VLM x cpu/npu, quality keywords x3)
- [x] qairt VLM cases pass; qairt LLM failure matches the same regression seen on other QDC legs
- [x] MTP cases skip, so `test_model_manager_pull` does not attempt the 15 GB two-model download