### PR TITLE
refactor(sdk)!: remove unused fields from geniex.h and sync bindings

### DIFF
--- a/bindings/android/app/src/main/cpp/android_utils.cpp
+++ b/bindings/android/app/src/main/cpp/android_utils.cpp
@@ -33,8 +33,8 @@ jobject create_java_profile_data(JNIEnv *env, geniex_ProfileData data) {
     jclass cls = env->FindClass("com/geniex/sdk/bean/ProfilingData");
     if (!cls) return nullptr;
 
-    // (DDDJJJDDDLjava/lang/String;)V
-    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDJJJDDDLjava/lang/String;)V");
+    // (DDDJJDDLjava/lang/String;)V
+    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDJJDDLjava/lang/String;)V");
     if (!ctor) return nullptr;
 
     const auto ttft_ms   = static_cast<jdouble>(data.ttft / 1000.0);
@@ -43,9 +43,8 @@ jobject create_java_profile_data(JNIEnv *env, geniex_ProfileData data) {
 
     const auto prompt_tokens = static_cast<jlong>(data.prompt_tokens);
     const auto gen_tokens    = static_cast<jlong>(data.generated_tokens);
-    const auto audio_ms      = static_cast<jlong>(data.audio_duration / 1000);
 
-    // ---- compute speeds/rtf locally (tokens/sec; RTF: audio/proc) ----
+    // ---- compute speeds locally (tokens/sec) ----
     auto tok_per_s = [](int64_t tokens, int64_t time_us) -> jdouble {
         if (time_us <= 0) return 0.0;
         return static_cast<jdouble>(tokens) * 1e6 / static_cast<jdouble>(time_us);
@@ -54,11 +53,7 @@ jobject create_java_profile_data(JNIEnv *env, geniex_ProfileData data) {
     const jdouble prefill_speed  = tok_per_s(data.prompt_tokens, data.prompt_time);
     const jdouble decoding_speed = tok_per_s(data.generated_tokens, data.decode_time);
 
-    const int64_t proc_us =
-        (data.prompt_time > 0 ? data.prompt_time : 0) + (data.decode_time > 0 ? data.decode_time : 0);
-    const jdouble rtf = (proc_us > 0) ? static_cast<jdouble>(data.audio_duration) / static_cast<jdouble>(proc_us) : 0.0;
-
-    LOGd("prefill_speed=%.6f tok/s, decoding_speed=%.6f tok/s, rtf=%.4f", prefill_speed, decoding_speed, rtf);
+    LOGd("prefill_speed=%.6f tok/s, decoding_speed=%.6f tok/s", prefill_speed, decoding_speed);
 
     jstring jStopReason = env->NewStringUTF(data.stop_reason ? data.stop_reason : "");
 
@@ -68,12 +63,10 @@ jobject create_java_profile_data(JNIEnv *env, geniex_ProfileData data) {
         prompt_ms,
         decode_ms,  // D D D
         prompt_tokens,
-        gen_tokens,
-        audio_ms,  // J J J
+        gen_tokens,  // J J
         prefill_speed,
-        decoding_speed,
-        rtf,         // D D D
-        jStopReason  // String
+        decoding_speed,  // D D
+        jStopReason      // String
     );
 
     env->DeleteLocalRef(jStopReason);

--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -115,11 +115,8 @@ geniex_GenerationConfig extract_generation_config(JNIEnv* env, jobject configObj
     if (!configObj) return cfg;
     jclass cls = env->GetObjectClass(configObj);
 
-    // ----------- mas\x token -----------
+    // ----------- max token -----------
     cfg.max_tokens = env->GetIntField(configObj, env->GetFieldID(cls, "maxTokens", "I"));
-
-    jfieldID nPastId = env->GetFieldID(cls, "nPast", "I");
-    cfg.n_past       = nPastId ? env->GetIntField(configObj, nPastId) : 0;
 
     // ----------- stopWords  -----------
     static thread_local std::vector<std::string> stopWordStorage;
@@ -246,17 +243,9 @@ geniex_ModelConfig extract_model_config(JNIEnv* env, jobject configObj) {
     // Note: old fields like system_library_path, backend_library_path, etc. are removed
     // They don't exist in geniex_ModelConfig anymore (see include/ml.h)
 
-    // max_tokens
-    fid               = env->GetFieldID(cls, "max_tokens", "I");
-    config.max_tokens = env->GetIntField(configObj, fid);
-
     // enable_thinking
     fid                    = env->GetFieldID(cls, "enable_thinking", "Z");
     config.enable_thinking = env->GetBooleanField(configObj, fid);
-
-    // verbose
-    fid            = env->GetFieldID(cls, "verbose", "Z");
-    config.verbose = env->GetBooleanField(configObj, fid);
 
     // spec_type
     fid              = env->GetFieldID(cls, "spec_type", "Ljava/lang/String;");
@@ -286,8 +275,8 @@ jobject extract_profiling_data(JNIEnv* env, const geniex_ProfileData& data) {
     jclass cls = env->FindClass("com/geniex/sdk/bean/ProfilingData");
     if (!cls) return nullptr;
 
-    // (DDDJJJDDDJJLjava/lang/String;)V
-    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDJJJDDDJJLjava/lang/String;)V");
+    // (DDDJJDDJJLjava/lang/String;)V
+    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDJJDDJJLjava/lang/String;)V");
     if (!ctor) return nullptr;
 
     const jdouble ttft_ms   = static_cast<jdouble>(data.ttft / 1000.0);
@@ -296,9 +285,8 @@ jobject extract_profiling_data(JNIEnv* env, const geniex_ProfileData& data) {
 
     const jlong prompt_tokens = static_cast<jlong>(data.prompt_tokens);
     const jlong gen_tokens    = static_cast<jlong>(data.generated_tokens);
-    const jlong audio_ms      = static_cast<jlong>(data.audio_duration / 1000);
 
-    // ---- compute speeds/rtf locally (tokens/sec; RTF: audio/proc) ----
+    // ---- compute speeds locally (tokens/sec) ----
     auto tok_per_s = [](int64_t tokens, int64_t time_us) -> jdouble {
         if (time_us <= 0) return 0.0;
         return static_cast<jdouble>(tokens) * 1e6 / static_cast<jdouble>(time_us);
@@ -307,11 +295,7 @@ jobject extract_profiling_data(JNIEnv* env, const geniex_ProfileData& data) {
     const jdouble prefill_speed  = tok_per_s(data.prompt_tokens, data.prompt_time);
     const jdouble decoding_speed = tok_per_s(data.generated_tokens, data.decode_time);
 
-    const int64_t proc_us =
-        (data.prompt_time > 0 ? data.prompt_time : 0) + (data.decode_time > 0 ? data.decode_time : 0);
-    const jdouble rtf = (proc_us > 0) ? static_cast<jdouble>(data.audio_duration) / static_cast<jdouble>(proc_us) : 0.0;
-
-    LOGe("prefill_speed=%.6f tok/s, decoding_speed=%.6f tok/s, rtf=%.4f", prefill_speed, decoding_speed, rtf);
+    LOGe("prefill_speed=%.6f tok/s, decoding_speed=%.6f tok/s", prefill_speed, decoding_speed);
 
     const jlong draft_n_total    = static_cast<jlong>(data.draft_n_total);
     const jlong draft_n_accepted = static_cast<jlong>(data.draft_n_accepted);
@@ -324,11 +308,9 @@ jobject extract_profiling_data(JNIEnv* env, const geniex_ProfileData& data) {
         prompt_ms,
         decode_ms,  // D D D
         prompt_tokens,
-        gen_tokens,
-        audio_ms,  // J J J
+        gen_tokens,  // J J
         prefill_speed,
-        decoding_speed,
-        rtf,  // D D D
+        decoding_speed,  // D D
         draft_n_total,
         draft_n_accepted,  // J J
         jStopReason        // String
@@ -363,24 +345,6 @@ geniex_LlmCreateInput extract_llm_create_input(JNIEnv* env, jobject inputObj) {
 
     jfieldID fid;
     jstring  jstr;
-
-    // === model_name (optional — QAIRT plugin reads metadata.json; currently
-    //     unused by the resolver, reserved for future model-specific defaults) ===
-    LOGi("[JNI] [extract] locating field 'model_name' (Ljava/lang/String;)");
-    fid = env->GetFieldID(cls, "model_name", "Ljava/lang/String;");
-    if (checkAndLogJniException(env, "GetFieldID(model_name)") || !fid) {
-        LOGi("[JNI] [extract] field 'model_name' not present (Kotlin property)");
-    } else {
-        jstr = (jstring)env->GetObjectField(inputObj, fid);
-        if (checkAndLogJniException(env, "GetObjectField(model_name)") || !jstr) {
-            LOGi("[JNI] [extract] model_name = (null)");
-        } else {
-            std::string s  = jstring2str(env, jstr);
-            out.model_name = hold_c_str(s);
-            LOGi("[JNI] [extract] model_name = %s", s.c_str());
-            env->DeleteLocalRef(jstr);
-        }
-    }
 
     // === model_path ===
     LOGi("[JNI] [extract] locating field 'model_path' (Ljava/lang/String;)");
@@ -460,7 +424,7 @@ geniex_LlmCreateInput extract_llm_create_input(JNIEnv* env, jobject inputObj) {
         }
     }
     {
-        ResolvedDevice r        = resolve_device(out.plugin_id, out.model_name, raw_dev, out.config.n_gpu_layers);
+        ResolvedDevice r        = resolve_device(out.plugin_id, nullptr, raw_dev, out.config.n_gpu_layers);
         out.device_id           = r.device_id.empty() ? nullptr : hold_c_str(r.device_id);
         out.config.n_gpu_layers = r.ngl;
         LOGi("[JNI] [extract] compute_unit = %s, n_gpu_layers = %d (from raw='%s')",
@@ -482,18 +446,6 @@ geniex_VlmCreateInput extract_vlm_create_input(JNIEnv* env, jobject inputObj) {
 
     jfieldID fid;
     jstring  jstr;
-
-    // model_name: String
-    fid = env->GetFieldID(cls, "model_name", "Ljava/lang/String;");
-    if (fid) {
-        jstr = (jstring)env->GetObjectField(inputObj, fid);
-        if (jstr) {
-            std::string s  = jstring2str(env, jstr);
-            out.model_name = hold_c_str(s);
-            LOGi("[JNI] [extract_vlm] model_name = %s", s.c_str());
-            env->DeleteLocalRef(jstr);
-        }
-    }
 
     // model_path : String
     fid = env->GetFieldID(cls, "model_path", "Ljava/lang/String;");
@@ -538,7 +490,7 @@ geniex_VlmCreateInput extract_vlm_create_input(JNIEnv* env, jobject inputObj) {
                 env->DeleteLocalRef(jstr);
             }
         }
-        ResolvedDevice r        = resolve_device(out.plugin_id, out.model_name, raw_dev, out.config.n_gpu_layers);
+        ResolvedDevice r        = resolve_device(out.plugin_id, nullptr, raw_dev, out.config.n_gpu_layers);
         out.device_id           = r.device_id.empty() ? nullptr : hold_c_str(r.device_id);
         out.config.n_gpu_layers = r.ngl;
         LOGi("[JNI] [extract_vlm] compute_unit = %s, n_gpu_layers = %d (from raw='%s')",

--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -243,10 +243,6 @@ geniex_ModelConfig extract_model_config(JNIEnv* env, jobject configObj) {
     // Note: old fields like system_library_path, backend_library_path, etc. are removed
     // They don't exist in geniex_ModelConfig anymore (see include/ml.h)
 
-    // enable_thinking
-    fid                    = env->GetFieldID(cls, "enable_thinking", "Z");
-    config.enable_thinking = env->GetBooleanField(configObj, fid);
-
     // spec_type
     fid              = env->GetFieldID(cls, "spec_type", "Ljava/lang/String;");
     jstr             = (jstring)env->GetObjectField(configObj, fid);

--- a/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
@@ -36,12 +36,9 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Llm_create(
         geniex_LlmCreateInput create_input = extract_llm_create_input(env, llm_create_input_obj);
         geniex_LLM*           handle       = nullptr;
         LOGd("[JNI] create() geniex_llm_create called with:");
-        LOGd("  model_name: %s", create_input.model_name);
         LOGd("  model_path: %s", create_input.model_path ? create_input.model_path : "(null)");
         LOGd("  tokenizer_path: %s", create_input.tokenizer_path ? create_input.tokenizer_path : "(null)");
-        LOGd("  config.max_tokens: %d", create_input.config.max_tokens);
         LOGd("  config.enable_thinking: %s", create_input.config.enable_thinking ? "true" : "false");
-        LOGd("  config.verbose: %s", create_input.config.verbose ? "true" : "false");
         LOGd("  plugin_id: %s", create_input.plugin_id ? create_input.plugin_id : "(null)");
 
         int32_t result = geniex_llm_create(&create_input, &handle);

--- a/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
@@ -38,7 +38,6 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Llm_create(
         LOGd("[JNI] create() geniex_llm_create called with:");
         LOGd("  model_path: %s", create_input.model_path ? create_input.model_path : "(null)");
         LOGd("  tokenizer_path: %s", create_input.tokenizer_path ? create_input.tokenizer_path : "(null)");
-        LOGd("  config.enable_thinking: %s", create_input.config.enable_thinking ? "true" : "false");
         LOGd("  plugin_id: %s", create_input.plugin_id ? create_input.plugin_id : "(null)");
 
         int32_t result = geniex_llm_create(&create_input, &handle);

--- a/bindings/android/app/src/main/cpp/vlm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/vlm_bridge_jni.cpp
@@ -27,7 +27,6 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Vlm_create(JNIEnv* en
     try {
         LOGi("[JNI] [create] Java_com_geniex_sdk_jni_Vlm_create ");
         geniex_VlmCreateInput create_input = extract_vlm_create_input(env, vlmCreateInputObj);
-        LOGi("[JNI] [create] model_name = %s", create_input.model_name ? create_input.model_name : "(null)");
         LOGi("[JNI] [create] plugin_id = %s", create_input.plugin_id ? create_input.plugin_id : "(null)");
         geniex_VLM* handle = nullptr;
         int32_t     result = geniex_vlm_create(&create_input, &handle);

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/GenerationConfig.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/GenerationConfig.kt
@@ -4,7 +4,6 @@ data class GenerationConfig(
     var maxTokens: Int = 32,
     var stopWords: Array<String>? = null,
     var stopCount: Int = 0,
-    var nPast: Int = 0,
     var samplerConfig: SamplerConfig? = null,
 
     var imagePaths: Array<String>? = null,

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/LlmCreateInput.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/LlmCreateInput.kt
@@ -1,13 +1,6 @@
 package com.geniex.sdk.bean
 
 data class LlmCreateInput(
-    /**
-     * Optional model identifier. The QAIRT plugin no longer needs it — it
-     * dispatches by reading `metadata.json` from the bundle directory. It is
-     * currently unused by `geniex_resolve_device` (reserved for future
-     * model-specific defaults) and kept for diagnostics.
-     */
-    val model_name: String? = null,
     override val model_path: String,
     val tokenizer_path: String? = null,
     override val config: ModelConfig,

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/ModelConfig.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/ModelConfig.kt
@@ -37,9 +37,6 @@ data class ModelConfig(
     /** Content of the chat template file (optional) */
     val chat_template_content: String = "",
 
-    /** Enable "thinking" mode for more detailed reasoning */
-    val enable_thinking: Boolean = false,
-
     /** Speculative decoding type(s), comma-separated (llama_cpp only; "" / "none" = disabled).
      *  Draft models: "draft-mtp","draft-eagle3","draft-simple". Self-speculative: "ngram-*". */
     val spec_type: String = "",

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/ModelConfig.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/ModelConfig.kt
@@ -37,13 +37,8 @@ data class ModelConfig(
     /** Content of the chat template file (optional) */
     val chat_template_content: String = "",
 
-    /** Maximum number of tokens to generate */
-    val max_tokens: Int = 2048,
-
     /** Enable "thinking" mode for more detailed reasoning */
     val enable_thinking: Boolean = false,
-
-    val verbose: Boolean = false,
 
     /** Speculative decoding type(s), comma-separated (llama_cpp only; "" / "none" = disabled).
      *  Draft models: "draft-mtp","draft-eagle3","draft-simple". Self-speculative: "ngram-*". */

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/ProfilingData.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/ProfilingData.kt
@@ -6,10 +6,8 @@ data class ProfilingData(
     val decodeTimeMs: Double,   /* Token generation time (ms) */
     val promptTokens: Long,    /* Number of prompt tokens */
     val generatedTokens: Long,  /* Number of generated tokens */
-    val audioDurationMs: Long,   /* Audio duration (ms) */
     val prefillSpeed: Double,   /* Prefill speed (tokens/sec) */
     val decodingSpeed: Double,  /* Decoding speed (tokens/sec) */
-    val realTimeFactor: Double,  /* Real-Time Factor(RTF) (1.0 = real-time, >1.0 = faster, <1.0 = slower) */
     val draftNTotal: Long,       /* Speculative decoding: draft tokens generated (0 when disabled) */
     val draftNAccepted: Long,    /* Speculative decoding: draft tokens accepted by the target model */
     val stopReason: String  /* Stop reason: "eos", "length", "user", "stop_sequence" */

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/VlmCreateInput.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/VlmCreateInput.kt
@@ -1,12 +1,6 @@
 package com.geniex.sdk.bean
 
 data class VlmCreateInput(
-    /**
-     * Optional model identifier. The QAIRT plugin reads `metadata.json` from
-     * the bundle directory directly; currently unused by
-     * `geniex_resolve_device` (reserved for future model-specific defaults).
-     */
-    val model_name: String? = null,
     override val model_path: String,
     val mmproj_path: String? = null,
     override val config: ModelConfig,

--- a/bindings/go/common.go
+++ b/bindings/go/common.go
@@ -19,10 +19,8 @@ type ProfileData struct {
 	DecodeTime      int64
 	PromptTokens    int64
 	GeneratedTokens int64
-	AudioDuration   int64
 	PrefillSpeed    float64
 	DecodingSpeed   float64
-	RealTimeFactor  float64
 	DraftNTotal     int64
 	DraftNAccepted  int64
 	StopReason      string
@@ -44,10 +42,8 @@ func newProfileDataFromCPtr(c C.geniex_ProfileData) ProfileData {
 		DecodeTime:      int64(c.decode_time),
 		PromptTokens:    int64(c.prompt_tokens),
 		GeneratedTokens: int64(c.generated_tokens),
-		AudioDuration:   int64(c.audio_duration),
 		PrefillSpeed:    float64(c.prefill_speed),
 		DecodingSpeed:   float64(c.decoding_speed),
-		RealTimeFactor:  float64(c.real_time_factor),
 		DraftNTotal:     int64(c.draft_n_total),
 		DraftNAccepted:  int64(c.draft_n_accepted),
 		StopReason:      C.GoString(c.stop_reason),
@@ -67,7 +63,6 @@ type SamplerConfig struct {
 	Seed              int32
 	GrammarPath       string
 	GrammarString     string
-	EnableJson        bool
 }
 
 // LCOV_EXCL_START
@@ -84,7 +79,6 @@ func (sc SamplerConfig) toCPtr() *C.geniex_SamplerConfig {
 		seed:               C.int32_t(sc.Seed),
 		grammar_path:       cStringIfSet(sc.GrammarPath),
 		grammar_string:     cStringIfSet(sc.GrammarString),
-		enable_json:        C.bool(sc.EnableJson),
 	}
 	return cPtr
 }
@@ -103,10 +97,8 @@ func freeSamplerConfig(cPtr *C.geniex_SamplerConfig) {
 type GenerationConfig struct {
 	MaxTokens      int32
 	Stop           []string
-	NPast          int32
 	SamplerConfig  *SamplerConfig
 	ImagePaths     []string
-	ImageMaxLength int32
 	AudioPaths     []string
 
 	// Opt-in ring-buffer context eviction (qairt only).
@@ -119,8 +111,6 @@ func (gc GenerationConfig) toCPtr() *C.geniex_GenerationConfig {
 	cPtr := (*C.geniex_GenerationConfig)(cMalloc(C.sizeof_geniex_GenerationConfig))
 	*cPtr = C.geniex_GenerationConfig{
 		max_tokens:            C.int32_t(gc.MaxTokens),
-		n_past:                C.int32_t(gc.NPast),
-		image_max_length:      C.int32_t(gc.ImageMaxLength),
 		sliding_window:        C.bool(gc.SlidingWindow),
 		sliding_window_n_keep: C.int32_t(gc.SlidingWindowNKeep),
 	}

--- a/bindings/go/llm.go
+++ b/bindings/go/llm.go
@@ -28,7 +28,6 @@ const (
 )
 
 type LlmCreateInput struct {
-	ModelName     string
 	ModelPath     string
 	TokenizerPath string
 	Config        ModelConfig
@@ -39,7 +38,6 @@ type LlmCreateInput struct {
 func (lci LlmCreateInput) toCPtr() *C.geniex_LlmCreateInput {
 	cPtr := (*C.geniex_LlmCreateInput)(cMalloc(C.sizeof_geniex_LlmCreateInput))
 	*cPtr = C.geniex_LlmCreateInput{
-		model_name:     cStringIfSet(lci.ModelName),
 		model_path:     cStringIfSet(lci.ModelPath),
 		tokenizer_path: cStringIfSet(lci.TokenizerPath),
 		plugin_id:      cStringIfSet(lci.RuntimeID),
@@ -53,7 +51,6 @@ func freeLlmCreateInput(cPtr *C.geniex_LlmCreateInput) {
 	if cPtr == nil {
 		return
 	}
-	cFreeIfSet(unsafe.Pointer(cPtr.model_name))
 	cFreeIfSet(unsafe.Pointer(cPtr.model_path))
 	cFreeIfSet(unsafe.Pointer(cPtr.tokenizer_path))
 	cFreeIfSet(unsafe.Pointer(cPtr.plugin_id))

--- a/bindings/go/vlm.go
+++ b/bindings/go/vlm.go
@@ -20,7 +20,6 @@ import (
 // LCOV_EXCL_START
 
 type VlmCreateInput struct {
-	ModelName     string
 	ModelPath     string
 	MmprojPath    string
 	TokenizerPath string
@@ -32,7 +31,6 @@ type VlmCreateInput struct {
 func (vci VlmCreateInput) toCPtr() *C.geniex_VlmCreateInput {
 	cPtr := (*C.geniex_VlmCreateInput)(cMalloc(C.sizeof_geniex_VlmCreateInput))
 	*cPtr = C.geniex_VlmCreateInput{
-		model_name:     cStringIfSet(vci.ModelName),
 		model_path:     cStringIfSet(vci.ModelPath),
 		mmproj_path:    cStringIfSet(vci.MmprojPath),
 		tokenizer_path: cStringIfSet(vci.TokenizerPath),
@@ -47,7 +45,6 @@ func freeVlmCreateInput(cPtr *C.geniex_VlmCreateInput) {
 	if cPtr == nil {
 		return
 	}
-	cFreeIfSet(unsafe.Pointer(cPtr.model_name))
 	cFreeIfSet(unsafe.Pointer(cPtr.model_path))
 	cFreeIfSet(unsafe.Pointer(cPtr.mmproj_path))
 	cFreeIfSet(unsafe.Pointer(cPtr.tokenizer_path))

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -36,10 +36,8 @@ class geniex_ProfileData(Structure):
         ('decode_time', c_int64),
         ('prompt_tokens', c_int64),
         ('generated_tokens', c_int64),
-        ('audio_duration', c_int64),
         ('prefill_speed', c_double),
         ('decoding_speed', c_double),
-        ('real_time_factor', c_double),
         ('draft_n_total', c_int64),
         ('draft_n_accepted', c_int64),
         ('stop_reason', c_char_p),
@@ -63,7 +61,6 @@ class geniex_SamplerConfig(Structure):
         ('seed', c_int32),
         ('grammar_path', c_char_p),
         ('grammar_string', c_char_p),
-        ('enable_json', c_bool),
     ]
 
 
@@ -77,11 +74,9 @@ class geniex_GenerationConfig(Structure):
         ('max_tokens', c_int32),
         ('stop', POINTER(c_char_p)),
         ('stop_count', c_int32),
-        ('n_past', c_int32),
         ('sampler_config', POINTER(geniex_SamplerConfig)),
         ('image_paths', POINTER(c_char_p)),
         ('image_count', c_int32),
-        ('image_max_length', c_int32),
         ('audio_paths', POINTER(c_char_p)),
         ('audio_count', c_int32),
         ('sliding_window', c_bool),
@@ -105,12 +100,7 @@ class geniex_ModelConfig(Structure):
         ('n_gpu_layers', c_int32),
         ('chat_template_path', c_char_p),
         ('chat_template_content', c_char_p),
-        ('system_prompt', c_char_p),
-        ('enable_sampling', c_bool),
-        ('grammar_str', c_char_p),
-        ('max_tokens', c_int32),
         ('enable_thinking', c_bool),
-        ('verbose', c_bool),
         ('spec_type', c_char_p),
         ('spec_draft_model', c_char_p),
         ('spec_n_max', c_int32),
@@ -147,7 +137,6 @@ class geniex_KvCacheLoadOutput(Structure):
 
 class geniex_LlmCreateInput(Structure):
     _fields_ = [
-        ('model_name', c_char_p),
         ('model_path', c_char_p),
         ('tokenizer_path', c_char_p),
         ('config', geniex_ModelConfig),
@@ -179,7 +168,6 @@ class geniex_LlmModelInfo(Structure):
         ('vocab_size', c_int32),
         ('bos_token', c_int32),
         ('add_bos', c_int32),
-        ('reserved0', c_int32),
     ]
 
 
@@ -245,7 +233,6 @@ class geniex_VlmChatMessage(Structure):
 
 class geniex_VlmCreateInput(Structure):
     _fields_ = [
-        ('model_name', c_char_p),
         ('model_path', c_char_p),
         ('mmproj_path', c_char_p),
         ('config', geniex_ModelConfig),

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -100,7 +100,6 @@ class geniex_ModelConfig(Structure):
         ('n_gpu_layers', c_int32),
         ('chat_template_path', c_char_p),
         ('chat_template_content', c_char_p),
-        ('enable_thinking', c_bool),
         ('spec_type', c_char_p),
         ('spec_draft_model', c_char_p),
         ('spec_n_max', c_int32),

--- a/bindings/python/geniex/auto.py
+++ b/bindings/python/geniex/auto.py
@@ -227,13 +227,12 @@ def _build_model_config(plugin_id: str | None, n_ctx: int, n_gpu_layers: int, **
         'n_batch',
         'n_ubatch',
         'n_seq_max',
-        'max_tokens',
         'spec_n_max',
         'spec_n_min',
     }
-    _bool_fields = {'enable_thinking', 'verbose'}
+    _bool_fields = {'enable_thinking'}
     _float_fields = {'spec_p_min'}
-    _str_fields = {'chat_template_path', 'chat_template_content', 'system_prompt', 'spec_type', 'spec_draft_model'}
+    _str_fields = {'chat_template_path', 'chat_template_content', 'spec_type', 'spec_draft_model'}
     for k, v in kwargs.items():
         if k in _int_fields:
             setattr(cfg, k, int(v))
@@ -318,7 +317,6 @@ def _is_vlm(mmproj_path: str | None, cache_key: str, model_path: str | None = No
 
 
 def _create_vlm_handle(
-    resolved_name: str,
     model_path: str,
     mmproj_path: str | None,
     tokenizer_path: str | None,
@@ -328,7 +326,6 @@ def _create_vlm_handle(
     meta: dict | None = None,
 ) -> GenieXVLM:
     inp = geniex_VlmCreateInput(
-        model_name=resolved_name.encode(),
         model_path=model_path.encode(),
         config=config,
     )
@@ -412,7 +409,6 @@ class AutoModelForCausalLM:
             is_vlm = False
         if is_vlm:
             return _create_vlm_handle(
-                resolved_name,
                 model_path,
                 resolved_mmproj,
                 tokenizer_path or _tok,
@@ -423,7 +419,6 @@ class AutoModelForCausalLM:
             )
 
         inp = geniex_LlmCreateInput(
-            model_name=resolved_name.encode(),
             model_path=model_path.encode(),
             config=config,
         )
@@ -492,7 +487,6 @@ class AutoModelForVision2Seq:
         }
 
         return _create_vlm_handle(
-            resolved_name,
             model_path,
             mmproj_path or _mmproj,
             resolved_tok_path,

--- a/bindings/python/geniex/generation/config.py
+++ b/bindings/python/geniex/generation/config.py
@@ -24,7 +24,6 @@ class GenerationConfig:
     seed: int = 0
     stop: list[str] = field(default_factory=list)
     grammar: str | None = None
-    json_mode: bool = False
     images: list[str] = field(default_factory=list)
     audios: list[str] = field(default_factory=list)
     stream: bool = False

--- a/bindings/python/geniex/modeling.py
+++ b/bindings/python/geniex/modeling.py
@@ -56,7 +56,6 @@ def _build_sampler(
     frequency_penalty: float,
     seed: int,
     grammar: str | None,
-    json_mode: bool,
 ) -> geniex_SamplerConfig:
     return geniex_SamplerConfig(
         temperature=temperature,
@@ -68,7 +67,6 @@ def _build_sampler(
         frequency_penalty=frequency_penalty,
         seed=seed,
         grammar_string=_enc(grammar),
-        enable_json=json_mode,
     )
 
 
@@ -200,7 +198,6 @@ class GenieXLLM:
         seed: int = 0,
         stop: list[str] | None = None,
         grammar: str | None = None,
-        json_mode: bool = False,
         stream: bool = False,
         # Opt-in ring-buffer context eviction (qairt only).
         sliding_window: bool = False,
@@ -224,7 +221,6 @@ class GenieXLLM:
             frequency_penalty,
             seed,
             grammar,
-            json_mode,
         )
         cfg, _sa, _ia, _aa = _build_gen_config(
             max_new_tokens, stop, sampler, [], [], sliding_window, sliding_window_n_keep
@@ -500,7 +496,6 @@ class GenieXVLM:
         seed: int = 0,
         stop: list[str] | None = None,
         grammar: str | None = None,
-        json_mode: bool = False,
         images: list[str] | None = None,
         audios: list[str] | None = None,
         stream: bool = False,
@@ -540,7 +535,6 @@ class GenieXVLM:
             frequency_penalty,
             seed,
             grammar,
-            json_mode,
         )
         cfg, _sa, _ia, _aa = _build_gen_config(max_new_tokens, stop, sampler, images, audios)
 

--- a/cli/cmd/geniex/common/process.go
+++ b/cli/cmd/geniex/common/process.go
@@ -252,14 +252,7 @@ stop reason:    %s
 		}
 
 	} else {
-		if pd.AudioDuration > 0 { // ASR TTS
-			text = fmt.Sprintf("processing_time %.2fs  |  audio_duration %.2fs  |  RTF %.2f (%.1fx realtime)",
-				float64(pd.TotalTimeUs())/1e6,
-				float64(pd.AudioDuration)/1e6,
-				pd.RealTimeFactor,
-				1.0/pd.RealTimeFactor)
-
-		} else if pd.DecodingSpeed != 0 {
+		if pd.DecodingSpeed != 0 {
 			text = fmt.Sprintf("— %.1f tok/s • %d tok • %.1f s first token",
 				pd.DecodingSpeed,
 				pd.GeneratedTokens,

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -33,7 +33,6 @@ var (
 	maxTokens      int32
 	stop           []string
 	stopFile       string
-	imageMaxLength int32
 	enableThink    bool
 	prompt         []string
 	tokenFile      string
@@ -58,7 +57,6 @@ var (
 	seed              int32
 	grammarPath       string
 	grammarString     string
-	enableJson        bool
 )
 
 // NOTE: flagset use same flag name will be ignored, but usage is different, so we keep them in different flagset
@@ -76,7 +74,6 @@ var (
 		samplerFlags.Int32VarP(&seed, "seed", "", 0, "random seed")
 		samplerFlags.StringVarP(&grammarPath, "grammar-path", "", "", "path to grammar file")
 		samplerFlags.StringVarP(&grammarString, "grammar-string", "", "", "grammar in string format")
-		samplerFlags.BoolVarP(&enableJson, "enable-json", "", false, "enable json output")
 		return samplerFlags
 	}()
 	llmFlags = func() *pflag.FlagSet {
@@ -105,7 +102,6 @@ var (
 		vlmFlags := pflag.NewFlagSet("VLM Specific", pflag.ExitOnError)
 		vlmFlags.SortFlags = false
 		vlmFlags.StringArrayVarP(&prompt, "prompt", "p", nil, "pass prompt")
-		vlmFlags.Int32VarP(&imageMaxLength, "image-max-length", "", 512, "max image length")
 		return vlmFlags
 	}()
 	flagGroups = []*pflag.FlagSet{
@@ -314,7 +310,6 @@ func inferLLM(ctx context.Context, paths *geniex_sdk.ModelPaths) error {
 		Seed:              seed,
 		GrammarPath:       grammarPath,
 		GrammarString:     grammarString,
-		EnableJson:        enableJson,
 	}
 	stopSequences, err := loadStopSequences()
 	if err != nil {
@@ -349,7 +344,6 @@ func inferLLM(ctx context.Context, paths *geniex_sdk.ModelPaths) error {
 	spin.Start()
 
 	p, err := geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
-		ModelName: paths.ModelName,
 		ModelPath: paths.ModelPath,
 		RuntimeID: paths.RuntimeID,
 		DeviceID:  deviceID,
@@ -497,7 +491,6 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 		Seed:              seed,
 		GrammarPath:       grammarPath,
 		GrammarString:     grammarString,
-		EnableJson:        enableJson,
 	}
 	stopSequences, err := loadStopSequences()
 	if err != nil {
@@ -512,7 +505,6 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 	spin := render.NewSpinner("loading model...")
 	spin.Start()
 	p, err := geniex_sdk.NewVLM(geniex_sdk.VlmCreateInput{
-		ModelName:  paths.ModelName,
 		ModelPath:  paths.ModelPath,
 		MmprojPath: paths.MmprojPath,
 		RuntimeID:  paths.RuntimeID,
@@ -584,7 +576,6 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 					Stop:           stopSequences,
 					SamplerConfig:  samplerConfig,
 					ImagePaths:     images,
-					ImageMaxLength: imageMaxLength,
 					AudioPaths:     audios,
 				},
 			})

--- a/cli/server/docs/swagger.yaml
+++ b/cli/server/docs/swagger.yaml
@@ -162,7 +162,6 @@ components:
         temperature: 0.8
         top_p: 0.95
         stream: false
-        enable_json: false
         enable_think: true
       properties:
         model:
@@ -225,10 +224,6 @@ components:
           items:
             $ref: "#/components/schemas/ChatCompletionTool"
           description: A list of tools the model may call
-        enable_json:
-          type: boolean
-          description: Whether to enable JSON response generation
-          default: false
         enable_think:
           type: boolean
           description: Whether to enable thinking mode for the model
@@ -267,9 +262,6 @@ components:
           type: string
           enum: [cpu, gpu, npu, hybrid]
           description: Compute unit to run on. Omit to use the server default set via `geniex serve --compute` / `GENIEX_COMPUTE`. QAIRT is NPU-only; other aliases are coerced with a warning.
-        image_max_length:
-          type: integer
-          description: Maximum length for image processing (VLM only)
         spec_type:
           type: string
           enum: [draft-mtp, draft-eagle3, draft-simple, ngram-simple, ngram-map-k, ngram-map-k4v, ngram-mod, ngram-cache]

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -39,14 +39,11 @@ type ChatCompletionRequest struct {
 	// "deepseek-legacy" / "auto" move it to reasoning_content.
 	ReasoningFormat string `json:"reasoning_format"`
 
-	ImageMaxLength int32 `json:"image_max_length"`
-
 	TopK              int32   `json:"top_k"`
 	MinP              float32 `json:"min_p"`
 	RepetitionPenalty float32 `json:"repetition_penalty"`
 	GrammarPath       string  `json:"grammar_path"`
 	GrammarString     string  `json:"grammar_string"`
-	EnableJson        bool    `json:"enable_json"`
 
 	SpecType       string  `json:"spec_type"`
 	SpecDraftModel string  `json:"spec_draft_model"`
@@ -71,13 +68,11 @@ func defaultChatCompletionRequest() ChatCompletionRequest {
 		NCtx:              cfg.NCtx,
 		Ngl:               cfg.Ngl,
 		Compute:           cfg.Compute,
-		ImageMaxLength:    512,
 		TopK:              0,
 		MinP:              0.0,
 		RepetitionPenalty: 1.0,
 		GrammarPath:       "",
 		GrammarString:     "",
-		EnableJson:        false,
 	}
 }
 
@@ -227,10 +222,9 @@ func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param C
 			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
 				MaxTokens:      int32(param.MaxCompletionTokens.Value),
-				SamplerConfig:  sampler,
-				ImagePaths:     images,
-				AudioPaths:     audios,
-				ImageMaxLength: param.ImageMaxLength,
+				SamplerConfig: sampler,
+				ImagePaths:    images,
+				AudioPaths:    audios,
 			},
 		})
 		if out == nil {
@@ -273,7 +267,6 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		PresencePenalty:   float32(param.PresencePenalty.Value),
 		FrequencyPenalty:  float32(param.FrequencyPenalty.Value),
 		Seed:              int32(param.Seed.Value),
-		EnableJson:        param.EnableJson,
 	}
 	prompt, gen, err := prepare(p, messages, param, tools, sampler)
 	if err != nil {

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -232,7 +232,6 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 			draftPath = p
 		}
 		t, e = geniex_sdk.NewLLM(geniex_sdk.LlmCreateInput{
-			ModelName: paths.ModelName,
 			ModelPath: modelfile,
 			DeviceID:  param.DeviceID,
 			Config: geniex_sdk.ModelConfig{
@@ -248,7 +247,6 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 		})
 	case reflect.TypeFor[geniex_sdk.VLM]():
 		t, e = geniex_sdk.NewVLM(geniex_sdk.VlmCreateInput{
-			ModelName:  paths.ModelName,
 			ModelPath:  modelfile,
 			MmprojPath: paths.MmprojPath,
 			DeviceID:   param.DeviceID,

--- a/docs/cn/models/supported.mdx
+++ b/docs/cn/models/supported.mdx
@@ -206,7 +206,7 @@ Hugging Face 上的部分模型是**受限模型（gated）**——你需要在 
         .llmCreateInput(
             LlmCreateInput(
                 model_path = paths.model_path,
-                config     = ModelConfig(enable_thinking = false),
+                config     = ModelConfig(),
                 runtime_id  = "qairt",
                 compute_unit  = null,   // qairt 仅支持 NPU
             )

--- a/docs/cn/models/supported.mdx
+++ b/docs/cn/models/supported.mdx
@@ -205,9 +205,8 @@ Hugging Face 上的部分模型是**受限模型（gated）**——你需要在 
     val llm = LlmWrapper.builder()
         .llmCreateInput(
             LlmCreateInput(
-                model_name = paths.model_name,
                 model_path = paths.model_path,
-                config     = ModelConfig(max_tokens = 2048, enable_thinking = false),
+                config     = ModelConfig(enable_thinking = false),
                 runtime_id  = "qairt",
                 compute_unit  = null,   // qairt 仅支持 NPU
             )
@@ -280,7 +279,6 @@ Hugging Face 上的部分模型是**受限模型（gated）**——你需要在 
     val llm = LlmWrapper.builder()
         .llmCreateInput(
             LlmCreateInput(
-                model_name = paths.model_name,
                 model_path = paths.model_path,
                 config     = ModelConfig(nCtx = 4096),
                 runtime_id  = "llama_cpp",

--- a/docs/cn/run/android/api-reference.mdx
+++ b/docs/cn/run/android/api-reference.mdx
@@ -166,7 +166,6 @@ data class ModelConfig(
     var nGpuLayers:            Int     = -1,    // -1 = all layers
     val chat_template_path:    String  = "",
     val chat_template_content: String  = "",
-    val enable_thinking:       Boolean = false,
 )
 ```
 
@@ -359,7 +358,7 @@ LlmWrapper.builder()
     .llmCreateInput(
         LlmCreateInput(
             model_path = paths.model_path,
-            config     = ModelConfig(enable_thinking = false),
+            config     = ModelConfig(),
             runtime_id  = "qairt",
             compute_unit  = null,           // null → NPU (only option for Qualcomm AI Engine Direct)
         )
@@ -396,7 +395,7 @@ VlmWrapper.builder()
         VlmCreateInput(
             model_path  = paths.model_path,
             mmproj_path = paths.mmproj_path,
-            config      = ModelConfig(enable_thinking = false),
+            config      = ModelConfig(),
             runtime_id   = "qairt",
             compute_unit   = null,
         )

--- a/docs/cn/run/android/api-reference.mdx
+++ b/docs/cn/run/android/api-reference.mdx
@@ -133,7 +133,6 @@ data class ModelPaths(
 
 ```kotlin
 data class LlmCreateInput(
-    val model_name:     String,
     val model_path:     String,
     val tokenizer_path: String? = null,
     val config:         ModelConfig,
@@ -146,7 +145,6 @@ data class LlmCreateInput(
 
 ```kotlin
 data class VlmCreateInput(
-    val model_name:  String,
     val model_path:  String,
     val mmproj_path: String? = null,     // vision projection weights (GGUF VLMs)
     val config:      ModelConfig,
@@ -168,9 +166,7 @@ data class ModelConfig(
     var nGpuLayers:            Int     = -1,    // -1 = all layers
     val chat_template_path:    String  = "",
     val chat_template_content: String  = "",
-    val max_tokens:            Int     = 2048,
     val enable_thinking:       Boolean = false,
-    val verbose:               Boolean = false,
 )
 ```
 
@@ -208,7 +204,6 @@ data class GenerationConfig(
     var maxTokens:     Int              = 32,
     var stopWords:     Array<String>?   = null,
     var stopCount:     Int              = 0,
-    var nPast:         Int              = 0,
     var samplerConfig: SamplerConfig?   = null,
     var imagePaths:    Array<String>?   = null,
     var imageCount:    Int              = 0,
@@ -246,7 +241,6 @@ val paths = ModelManagerWrapper.getPaths("unsloth/Qwen3-0.6B-GGUF")
 LlmWrapper.builder()
     .llmCreateInput(
         LlmCreateInput(
-            model_name = paths.model_name,
             model_path = paths.model_path,
             config     = ModelConfig(nCtx = 4096),
             runtime_id  = "llama_cpp",
@@ -289,7 +283,6 @@ val paths = ModelManagerWrapper.getPaths("unsloth/Qwen3-VL-2B-Instruct-GGUF")
 VlmWrapper.builder()
     .vlmCreateInput(
         VlmCreateInput(
-            model_name  = paths.model_name,
             model_path  = paths.model_path,
             mmproj_path = paths.mmproj_path,
             config      = ModelConfig(nCtx = 4096),
@@ -365,9 +358,8 @@ val paths = ModelManagerWrapper.getPaths("ai-hub-models/Qwen3-4B-Instruct-2507")
 LlmWrapper.builder()
     .llmCreateInput(
         LlmCreateInput(
-            model_name = paths.model_name,
             model_path = paths.model_path,
-            config     = ModelConfig(max_tokens = 2048, enable_thinking = false),
+            config     = ModelConfig(enable_thinking = false),
             runtime_id  = "qairt",
             compute_unit  = null,           // null → NPU (only option for Qualcomm AI Engine Direct)
         )
@@ -402,10 +394,9 @@ val paths = ModelManagerWrapper.getPaths("ai-hub-models/Qwen2.5-VL-7B-Instruct")
 VlmWrapper.builder()
     .vlmCreateInput(
         VlmCreateInput(
-            model_name  = paths.model_name,
             model_path  = paths.model_path,
             mmproj_path = paths.mmproj_path,
-            config      = ModelConfig(max_tokens = 2048, enable_thinking = false),
+            config      = ModelConfig(enable_thinking = false),
             runtime_id   = "qairt",
             compute_unit   = null,
         )

--- a/docs/cn/run/android/quickstart.mdx
+++ b/docs/cn/run/android/quickstart.mdx
@@ -58,7 +58,6 @@ import Feedback from "/snippets/page-feedback.mdx";
     val llm = LlmWrapper.builder()
         .llmCreateInput(
             LlmCreateInput(
-                model_name = paths.model_name,
                 model_path = paths.model_path,
                 config     = ModelConfig(nCtx = 4096),
                 runtime_id  = "llama_cpp",

--- a/docs/cn/run/python/api-reference.mdx
+++ b/docs/cn/run/python/api-reference.mdx
@@ -100,7 +100,6 @@ print(output.text)
 | `seed` | `int` | `-1` | 随机种子（`-1` 表示随机）。 |
 | `stop` | `list[str] \| None` | `None` | 停止序列。 |
 | `grammar` | `str \| None` | `None` | 用于约束生成的 GBNF 语法字符串。 |
-| `json_mode` | `bool` | `False` | 强制 JSON 输出。 |
 
 </Expandable>
 

--- a/docs/en/models/supported.mdx
+++ b/docs/en/models/supported.mdx
@@ -206,7 +206,7 @@ Bundles outside the `ai-hub-models/*` namespace — whether self-converted from 
         .llmCreateInput(
             LlmCreateInput(
                 model_path = paths.model_path,
-                config     = ModelConfig(enable_thinking = false),
+                config     = ModelConfig(),
                 runtime_id  = "qairt",
                 compute_unit  = null,   // qairt is NPU-only
             )

--- a/docs/en/models/supported.mdx
+++ b/docs/en/models/supported.mdx
@@ -205,9 +205,8 @@ Bundles outside the `ai-hub-models/*` namespace — whether self-converted from 
     val llm = LlmWrapper.builder()
         .llmCreateInput(
             LlmCreateInput(
-                model_name = paths.model_name,
                 model_path = paths.model_path,
-                config     = ModelConfig(max_tokens = 2048, enable_thinking = false),
+                config     = ModelConfig(enable_thinking = false),
                 runtime_id  = "qairt",
                 compute_unit  = null,   // qairt is NPU-only
             )
@@ -280,7 +279,6 @@ A local GGUF model is a directory (or file) holding your `.gguf` weights — sid
     val llm = LlmWrapper.builder()
         .llmCreateInput(
             LlmCreateInput(
-                model_name = paths.model_name,
                 model_path = paths.model_path,
                 config     = ModelConfig(nCtx = 4096),
                 runtime_id  = "llama_cpp",

--- a/docs/en/run/android/api-reference.mdx
+++ b/docs/en/run/android/api-reference.mdx
@@ -166,7 +166,6 @@ data class ModelConfig(
     var nGpuLayers:            Int     = -1,    // -1 = all layers
     val chat_template_path:    String  = "",
     val chat_template_content: String  = "",
-    val enable_thinking:       Boolean = false,
 )
 ```
 
@@ -359,7 +358,7 @@ LlmWrapper.builder()
     .llmCreateInput(
         LlmCreateInput(
             model_path = paths.model_path,
-            config     = ModelConfig(enable_thinking = false),
+            config     = ModelConfig(),
             runtime_id  = "qairt",
             compute_unit  = null,           // null → NPU (only option for Qualcomm AI Engine Direct)
         )
@@ -396,7 +395,7 @@ VlmWrapper.builder()
         VlmCreateInput(
             model_path  = paths.model_path,
             mmproj_path = paths.mmproj_path,
-            config      = ModelConfig(enable_thinking = false),
+            config      = ModelConfig(),
             runtime_id   = "qairt",
             compute_unit   = null,
         )

--- a/docs/en/run/android/api-reference.mdx
+++ b/docs/en/run/android/api-reference.mdx
@@ -133,7 +133,6 @@ Qualcomm AI Hub pulls on Android **require** an explicit `chipset`. The Rust sid
 
 ```kotlin
 data class LlmCreateInput(
-    val model_name:     String,
     val model_path:     String,
     val tokenizer_path: String? = null,
     val config:         ModelConfig,
@@ -146,7 +145,6 @@ data class LlmCreateInput(
 
 ```kotlin
 data class VlmCreateInput(
-    val model_name:  String,
     val model_path:  String,
     val mmproj_path: String? = null,     // vision projection weights (GGUF VLMs)
     val config:      ModelConfig,
@@ -168,9 +166,7 @@ data class ModelConfig(
     var nGpuLayers:            Int     = -1,    // -1 = all layers
     val chat_template_path:    String  = "",
     val chat_template_content: String  = "",
-    val max_tokens:            Int     = 2048,
     val enable_thinking:       Boolean = false,
-    val verbose:               Boolean = false,
 )
 ```
 
@@ -208,7 +204,6 @@ data class GenerationConfig(
     var maxTokens:     Int              = 32,
     var stopWords:     Array<String>?   = null,
     var stopCount:     Int              = 0,
-    var nPast:         Int              = 0,
     var samplerConfig: SamplerConfig?   = null,
     var imagePaths:    Array<String>?   = null,
     var imageCount:    Int              = 0,
@@ -246,7 +241,6 @@ val paths = ModelManagerWrapper.getPaths("unsloth/Qwen3-0.6B-GGUF")
 LlmWrapper.builder()
     .llmCreateInput(
         LlmCreateInput(
-            model_name = paths.model_name,
             model_path = paths.model_path,
             config     = ModelConfig(nCtx = 4096),
             runtime_id  = "llama_cpp",
@@ -289,7 +283,6 @@ val paths = ModelManagerWrapper.getPaths("unsloth/Qwen3-VL-2B-Instruct-GGUF")
 VlmWrapper.builder()
     .vlmCreateInput(
         VlmCreateInput(
-            model_name  = paths.model_name,
             model_path  = paths.model_path,
             mmproj_path = paths.mmproj_path,
             config      = ModelConfig(nCtx = 4096),
@@ -365,9 +358,8 @@ val paths = ModelManagerWrapper.getPaths("ai-hub-models/Qwen3-4B-Instruct-2507")
 LlmWrapper.builder()
     .llmCreateInput(
         LlmCreateInput(
-            model_name = paths.model_name,
             model_path = paths.model_path,
-            config     = ModelConfig(max_tokens = 2048, enable_thinking = false),
+            config     = ModelConfig(enable_thinking = false),
             runtime_id  = "qairt",
             compute_unit  = null,           // null → NPU (only option for Qualcomm AI Engine Direct)
         )
@@ -402,10 +394,9 @@ val paths = ModelManagerWrapper.getPaths("ai-hub-models/Qwen2.5-VL-7B-Instruct")
 VlmWrapper.builder()
     .vlmCreateInput(
         VlmCreateInput(
-            model_name  = paths.model_name,
             model_path  = paths.model_path,
             mmproj_path = paths.mmproj_path,
-            config      = ModelConfig(max_tokens = 2048, enable_thinking = false),
+            config      = ModelConfig(enable_thinking = false),
             runtime_id   = "qairt",
             compute_unit   = null,
         )

--- a/docs/en/run/android/quickstart.mdx
+++ b/docs/en/run/android/quickstart.mdx
@@ -58,7 +58,6 @@ The flow is the same regardless of model: **init the SDK → pull weights → lo
     val llm = LlmWrapper.builder()
         .llmCreateInput(
             LlmCreateInput(
-                model_name = paths.model_name,
                 model_path = paths.model_path,
                 config     = ModelConfig(nCtx = 4096),
                 runtime_id  = "llama_cpp",

--- a/docs/en/run/python/api-reference.mdx
+++ b/docs/en/run/python/api-reference.mdx
@@ -100,7 +100,6 @@ print(output.text)
 | `seed` | `int` | `-1` | Random seed (`-1` = random). |
 | `stop` | `list[str] \| None` | `None` | Stop sequences. |
 | `grammar` | `str \| None` | `None` | GBNF grammar string for constrained generation. |
-| `json_mode` | `bool` | `False` | Force JSON output. |
 
 </Expandable>
 

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -1061,7 +1061,6 @@ static void fill_model_config(geniex_ModelConfig* c, const options_t* o, int32_t
     c->n_ctx            = o->n_ctx;
     c->n_threads        = o->n_threads;
     c->n_gpu_layers     = ngl;
-    c->max_tokens       = o->max_new_tokens;
     c->spec_type        = o->spec_type;   /* may be NULL */
     c->spec_draft_model = o->draft_model; /* may be NULL */
     c->spec_n_max       = o->draft_tokens;
@@ -1072,7 +1071,6 @@ static void fill_model_config(geniex_ModelConfig* c, const options_t* o, int32_t
 static void run_llm(const options_t* o, const char* device_id, int32_t ngl, run_result_t* out) {
     geniex_LlmCreateInput cin;
     memset(&cin, 0, sizeof(cin));
-    cin.model_name     = "benchmark";
     cin.model_path     = o->model_path;
     cin.tokenizer_path = o->tokenizer_path; /* may be NULL */
     cin.plugin_id      = o->plugin;
@@ -1271,7 +1269,6 @@ static void run_llm(const options_t* o, const char* device_id, int32_t ngl, run_
 static void run_vlm(const options_t* o, const char* device_id, int32_t ngl, run_result_t* out) {
     geniex_VlmCreateInput cin;
     memset(&cin, 0, sizeof(cin));
-    cin.model_name     = "benchmark";
     cin.model_path     = o->model_path;
     cin.mmproj_path    = o->mmproj_path;
     cin.tokenizer_path = o->tokenizer_path;
@@ -1748,7 +1745,6 @@ static void write_md_row(const options_t* o, int32_t ngl, int64_t model_size_byt
 static void run_logits(const options_t* o, const char* device_id, int32_t ngl) {
     geniex_LlmCreateInput cin;
     memset(&cin, 0, sizeof(cin));
-    cin.model_name     = "benchmark";
     cin.model_path     = o->model_path;
     cin.tokenizer_path = o->tokenizer_path; /* may be NULL */
     cin.plugin_id      = o->plugin;

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -354,11 +354,9 @@ typedef struct {
 
     int64_t prompt_tokens;    /* Number of prompt tokens */
     int64_t generated_tokens; /* Number of generated tokens */
-    int64_t audio_duration;   /* Audio duration (us) */
 
-    double prefill_speed;    /* Prefill speed (tokens/sec) */
-    double decoding_speed;   /* Decoding speed (tokens/sec) */
-    double real_time_factor; /* Real-Time Factor(RTF) (1.0 = real-time, >1.0 = faster, <1.0 = slower) */
+    double prefill_speed;  /* Prefill speed (tokens/sec) */
+    double decoding_speed; /* Decoding speed (tokens/sec) */
 
     int64_t draft_n_total;    /* Speculative decoding: draft tokens generated (0 when disabled) */
     int64_t draft_n_accepted; /* Speculative decoding: draft tokens accepted by the target model */
@@ -382,7 +380,6 @@ typedef struct {
     int32_t     seed;               /* Random seed (-1 for random) */
     geniex_Path grammar_path;       /* Optional grammar file path */
     const char* grammar_string;     /* Optional grammar string (BNF-like format) */
-    bool        enable_json;        /* Enable JSON grammar */
 } geniex_SamplerConfig;
 
 /** LLM / VLM generation configuration (IMPROVED: support multiple images and audios) */
@@ -390,14 +387,12 @@ typedef struct {
     int32_t               max_tokens;     /* Maximum tokens to generate */
     const char**          stop;           /* Array of stop sequences */
     int32_t               stop_count;     /* Number of stop sequences */
-    int32_t               n_past;         /* Number of past tokens to consider */
     geniex_SamplerConfig* sampler_config; /* Advanced sampling config */
     // --- Improved multimodal support ---
-    geniex_Path* image_paths;      /* Array of image paths for VLM (NULL if none) */
-    int32_t      image_count;      /* Number of images */
-    int32_t      image_max_length; /* Maximum length of the image */
-    geniex_Path* audio_paths;      /* Array of audio paths for VLM (NULL if none) */
-    int32_t      audio_count;      /* Number of audios */
+    geniex_Path* image_paths; /* Array of image paths for VLM (NULL if none) */
+    int32_t      image_count; /* Number of images */
+    geniex_Path* audio_paths; /* Array of audio paths for VLM (NULL if none) */
+    int32_t      audio_count; /* Number of audios */
     // --- Context-length overflow handling (qcom-ai-hub/geniex#1197) ---
     /* qairt only; llama_cpp ignores this (it always context-shifts). When true,
      * evicts the oldest context tokens above sliding_window_n_keep instead of
@@ -416,15 +411,9 @@ typedef struct {
     int32_t n_seq_max;        // max number of sequences (i.e. distinct states for recurrent models)
     int32_t n_gpu_layers;     // number of layers to offload to GPU, 0 = all layers on CPU
 
-    // TODO: consider removing the following fields from ModelConfig, or move to another struct
     geniex_Path chat_template_path;     // path to chat template file, optional
     const char* chat_template_content;  // content of chat template file, optional
-    const char* system_prompt;          // system prompt for chat template, optional
-    bool        enable_sampling;        // DEPRECATED, use enable_json in geniex_SamplerConfig
-    const char* grammar_str;            // grammar string
-    int32_t     max_tokens;             // max tokens to generate
     bool        enable_thinking;        // enable thinking mode for Qwen models
-    bool        verbose;                // verbose logging
 
     // Speculative decoding (llama_cpp only; ignored by qairt). Disabled when
     // spec_type is NULL/""/"none". One or comma-separated llama.cpp type names,
@@ -444,7 +433,6 @@ typedef struct geniex_LLM geniex_LLM; /* Opaque LLM handle */
 
 /* ====================  Lifecycle Management  ============================== */
 typedef struct {
-    const char*        model_name;     /** Name of the model */
     geniex_Path        model_path;     /** Path to the model file */
     geniex_Path        tokenizer_path; /** Path to the tokenizer file */
     geniex_ModelConfig config;         /** Model configuration */
@@ -597,7 +585,6 @@ typedef struct {
     int32_t vocab_size; /** Number of tokens in the model vocabulary (>=1 on success). */
     int32_t bos_token;  /** BOS token id, or -1 if the model has no BOS. */
     int32_t add_bos;    /** 1 = caller should prepend BOS at position 0 when feeding raw input_ids. */
-    int32_t reserved0;  /** Reserved, must be 0. */
 } geniex_LlmModelInfo;
 
 /**
@@ -697,7 +684,6 @@ typedef struct geniex_VLM geniex_VLM; /* Opaque VLM handle */
 /* ====================  Lifecycle Management  ============================== */
 
 typedef struct {
-    const char*        model_name;     /** Name of the model */
     geniex_Path        model_path;     /** Path to the model file */
     geniex_Path        mmproj_path;    /** Path to the mmproj file */
     geniex_ModelConfig config;         /** Model configuration */

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -413,7 +413,6 @@ typedef struct {
 
     geniex_Path chat_template_path;     // path to chat template file, optional
     const char* chat_template_content;  // content of chat template file, optional
-    bool        enable_thinking;        // enable thinking mode for Qwen models
 
     // Speculative decoding (llama_cpp only; ignored by qairt). Disabled when
     // spec_type is NULL/""/"none". One or comma-separated llama.cpp type names,

--- a/sdk/include/logging.h
+++ b/sdk/include/logging.h
@@ -220,8 +220,7 @@ struct fmt::formatter<geniex_ModelConfig> {
         return fmt::format_to(ctx.out(),
             "ModelConfig(n_ctx: {}, n_threads: {}, n_threads_batch: {}, n_batch: {}, n_ubatch: {}, n_seq_max: {}, "
                       "n_gpu_layers: {}, "
-                      "chat_template_path: {}, chat_template_content: {}, "
-                      "enable_thinking: {})",
+                      "chat_template_path: {}, chat_template_content: {})",
             lp(p.n_ctx),
             lp(p.n_threads),
             lp(p.n_threads_batch),
@@ -230,8 +229,7 @@ struct fmt::formatter<geniex_ModelConfig> {
             lp(p.n_seq_max),
             lp(p.n_gpu_layers),
             lp(p.chat_template_path),
-            lp(p.chat_template_content),
-            lp(p.enable_thinking));
+            lp(p.chat_template_content));
     }
 };
 

--- a/sdk/include/logging.h
+++ b/sdk/include/logging.h
@@ -162,17 +162,15 @@ struct fmt::formatter<geniex_ProfileData> {
     auto           format(const geniex_ProfileData& p, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(),
             "ProfileData(ttft: {} us, prompt_time: {} us, decode_time: {} us, prompt_tokens: {}, "
-                      "generated_tokens: {}, audio_duration: {} us, prefill_speed: {} tokens/s, decoding_speed: {} "
-                      "tokens/s, real_time_factor: {}, stop_reason: {})",
+                      "generated_tokens: {}, prefill_speed: {} tokens/s, decoding_speed: {} "
+                      "tokens/s, stop_reason: {})",
             lp(p.ttft),
             lp(p.prompt_time),
             lp(p.decode_time),
             lp(p.prompt_tokens),
             lp(p.generated_tokens),
-            lp(p.audio_duration),
             lp(p.prefill_speed),
             lp(p.decoding_speed),
-            lp(p.real_time_factor),
             lp(p.stop_reason));
     }
 };
@@ -184,7 +182,7 @@ struct fmt::formatter<geniex_SamplerConfig> {
         return fmt::format_to(ctx.out(),
             "SamplerConfig(temperature: {}, top_p: {}, top_k: {}, min_p: {}, repetition_penalty: {}, presence_penalty: "
                       "{}, "
-                      "frequency_penalty: {}, seed: {}, grammar_path: {}, grammar_string: {}, enable_json: {})",
+                      "frequency_penalty: {}, seed: {}, grammar_path: {}, grammar_string: {})",
             lp(p.temperature),
             lp(p.top_p),
             lp(p.top_k),
@@ -194,8 +192,7 @@ struct fmt::formatter<geniex_SamplerConfig> {
             lp(p.frequency_penalty),
             lp(p.seed),
             lp(p.grammar_path),
-            lp(p.grammar_string),
-            lp(p.enable_json));
+            lp(p.grammar_string));
     }
 };
 
@@ -204,17 +201,15 @@ struct fmt::formatter<geniex_GenerationConfig> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     auto           format(const geniex_GenerationConfig& p, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(),
-            "GenerationConfig(max_tokens: {}, stop_count: {}, n_past: {}, sampler_config: {}, image_paths: {}, "
-                      "image_count: {}, audio_paths: {}, audio_count: {}, image_max_length: {})",
+            "GenerationConfig(max_tokens: {}, stop_count: {}, sampler_config: {}, image_paths: {}, "
+                      "image_count: {}, audio_paths: {}, audio_count: {})",
             lp(p.max_tokens),
             lp(p.stop_count),
-            lp(p.n_past),
             lp(p.sampler_config),
             lp(fmt::ptr(p.image_paths)),
             lp(p.image_count),
             lp(fmt::ptr(p.audio_paths)),
-            lp(p.audio_count),
-            lp(p.image_max_length));
+            lp(p.audio_count));
     }
 };
 
@@ -225,9 +220,8 @@ struct fmt::formatter<geniex_ModelConfig> {
         return fmt::format_to(ctx.out(),
             "ModelConfig(n_ctx: {}, n_threads: {}, n_threads_batch: {}, n_batch: {}, n_ubatch: {}, n_seq_max: {}, "
                       "n_gpu_layers: {}, "
-                      "chat_template_path: {}, chat_template_content: {}, system_prompt: {}, enable_sampling: {}, grammar_str: "
-                      "{}, max_tokens: {}, "
-                      "enable_thinking: {}, verbose: {})",
+                      "chat_template_path: {}, chat_template_content: {}, "
+                      "enable_thinking: {})",
             lp(p.n_ctx),
             lp(p.n_threads),
             lp(p.n_threads_batch),
@@ -237,12 +231,7 @@ struct fmt::formatter<geniex_ModelConfig> {
             lp(p.n_gpu_layers),
             lp(p.chat_template_path),
             lp(p.chat_template_content),
-            lp(p.system_prompt),
-            lp(p.enable_sampling),
-            lp(p.grammar_str),
-            lp(p.max_tokens),
-            lp(p.enable_thinking),
-            lp(p.verbose));
+            lp(p.enable_thinking));
     }
 };
 
@@ -341,9 +330,8 @@ struct fmt::formatter<geniex_VlmCreateInput> {
     constexpr auto parse(fmt::format_parse_context& ctx) { return ctx.begin(); }
     auto           format(const geniex_VlmCreateInput& p, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(),
-            "VlmCreateInput(model_name: {}, model_path: {}, mmproj_path: {}, config: {}, plugin_id: {}, device_id: {}, "
+            "VlmCreateInput(model_path: {}, mmproj_path: {}, config: {}, plugin_id: {}, device_id: {}, "
                       "tokenizer_path: {})",
-            lp(p.model_name),
             lp(p.model_path),
             lp(p.mmproj_path),
             lp(p.config),

--- a/sdk/include/profile.h
+++ b/sdk/include/profile.h
@@ -17,9 +17,6 @@ inline void calculate_profile_data(geniex_ProfileData &pd) {
     pd.decoding_speed = pd.decode_time > 0
                             ? static_cast<double>(pd.generated_tokens) / (static_cast<double>(pd.decode_time) / 1e6)
                             : 0.0;
-
-    pd.real_time_factor =
-        pd.audio_duration > 0 ? static_cast<double>(pd.decode_time) / static_cast<double>(pd.audio_duration) : 0.0;
 }
 
 }  // namespace geniex

--- a/sdk/plugins/qairt/include/llm.h
+++ b/sdk/plugins/qairt/include/llm.h
@@ -13,7 +13,6 @@ namespace geniex {
 
 class QairtLlm : public ILlm {
     std::unique_ptr<LLMPipeline> pipeline_;
-    bool                         enable_thinking_ = false;
 
     // Bundle's `dialog.sampler` defaults; parsed once at create().
     ParsedSamplerConfig bundle_sampler_;

--- a/sdk/plugins/qairt/include/vlm.h
+++ b/sdk/plugins/qairt/include/vlm.h
@@ -14,7 +14,6 @@ namespace geniex {
 class QairtVlm : public IVlm {
     std::unique_ptr<VLMPipeline> pipeline_;
 
-    bool enable_thinking_ = false;
     // True iff a vision encoder shard was located at create time. Audio is not
     // wired into the QAIRT VLM pipeline yet, so always reported as unsupported.
     bool has_vision_encoder_ = false;

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -45,8 +45,6 @@ int32_t QairtLlm::create(const geniex_LlmCreateInput* input) {
         return GENIEX_ERROR_COMMON_INVALID_INPUT;
     }
 
-    enable_thinking_ = input->config.enable_thinking;
-
     // Reject llama.cpp-only parameters that have no meaning in the QAIRT plugin
     if (input->config.n_gpu_layers != 0) {
         GENIEX_LOG_ERROR("--ngl (n_gpu_layers) is not supported by the qairt plugin");
@@ -195,7 +193,7 @@ int32_t QairtLlm::apply_chat_template(
     if (is_first_turn_ && input->tools && input->tools[0] != '\0') {
         opts.tools_json = input->tools;
     }
-    opts.enable_thinking = input->enable_thinking || enable_thinking_;
+    opts.enable_thinking = input->enable_thinking;
 
     std::string formatted;
     try {
@@ -238,7 +236,6 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
             gen_cfg.sliding_window_n_keep = input->config->sliding_window_n_keep;
         }
     }
-    gen_cfg.thinking_mode = enable_thinking_;
 
     // Wrap token callback
     std::function<bool(const char*)> on_token_fn;

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -42,8 +42,6 @@ int32_t QairtVlm::create(const geniex_VlmCreateInput* input) {
         return GENIEX_ERROR_COMMON_INVALID_INPUT;
     }
 
-    enable_thinking_ = input->config.enable_thinking;
-
     // Reject llama.cpp-only parameters that have no meaning in the QAIRT plugin
     if (input->config.n_gpu_layers != 0) {
         GENIEX_LOG_ERROR("--ngl (n_gpu_layers) is not supported by the qairt plugin");
@@ -236,6 +234,7 @@ int32_t QairtVlm::apply_chat_template(
     // Record pending size — committed to history_size_ only after a successful generate().
     pending_history_size_ = messages.size();
 
+    // TODO: honor input->enable_thinking once VisionProcessor exposes it.
     std::string formatted = pipeline_->applyChatTemplate(new_messages, /*add_generation_prompt=*/true);
 
     output->formatted_text = portable_strdup(formatted.c_str());
@@ -266,7 +265,6 @@ int32_t QairtVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
         gen_cfg.max_tokens = input->config->max_tokens > 0 ? input->config->max_tokens : 512;
         qairt::apply_sampler_config(input->config->sampler_config, gen_cfg, bundle_sampler_);
     }
-    gen_cfg.thinking_mode = enable_thinking_;
 
     // Wrap token callback
     std::function<bool(const char*)> on_token_fn;


### PR DESCRIPTION
Removes 12 fields that were declared in `sdk/include/geniex.h` but never reached the SDK core, then re-syncs every FFI binding, upper-layer API, doc, and build in the same PR (per the FFI-update rule in CONTRIBUTING.md).

## Removed fields

| Struct | Fields |
|---|---|
| `LlmCreateInput` / `VlmCreateInput` | `model_name` |
| `ModelConfig` | `max_tokens`, `verbose`, `system_prompt`, `enable_sampling`, `grammar_str` |
| `GenerationConfig` | `n_past`, `image_max_length` |
| `SamplerConfig` | `enable_json` |
| `ProfileData` | `audio_duration`, `real_time_factor` |

`ResolveDeviceInput.model_name` and `GenerationConfig.max_tokens` are distinct fields and are **kept**.

## Synced surfaces

- **Bindings** — Go (cgo), Python (ctypes `_types.py` + `auto.py`/`modeling.py`/`config.py`), Android (JNI `GetFieldID` reads and ctor signatures + Kotlin beans).
- **CLI / server** — drop the `--enable-json` and `--image-max-length` flags, the `image_max_length` / `enable_json` request fields, and the ASR RTF readout in `process.go`.
- **SDK consumers** — `logging.h` formatters, `profile.h` RTF calc, `benchmark.c`.
- **Docs (en + cn) + swagger** — remove the deleted fields from the Android / Python / models references. Troubleshooting & platform prose keeps the generic `max_tokens` wording (not binding-specific camelCase).

## Verification

- SDK rebuilt + installed; `bazelisk build //cli` OK; bridge loads via `bazelisk run //cli -- --help`.
- `bazelisk test //cli/...` and `//bindings/go/...` pass.
- Python ctypes struct sizes verified identical to the compiled C header.
- Repo-wide grep confirms no residual references to the removed fields.

## Breaking changes

Removes the `--enable-json` / `--image-max-length` CLI flags, the `image_max_length` / `enable_json` server request fields, and the `audioDurationMs` / `realTimeFactor` fields on the Android `ProfilingData`. None were wired to the SDK core. Under the pre-1.0 rule this bumps MINOR.