### PR TITLE
docs(docs): use PowerShell backtick continuation in mtp tutorial

### DIFF
--- a/docs/en/tutorials/compute/speculative-decoding-mtp.mdx
+++ b/docs/en/tutorials/compute/speculative-decoding-mtp.mdx
@@ -54,9 +54,9 @@ geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu
 Then enable MTP:
 
 ```powershell
-geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu ^
-    --spec-type draft-mtp ^
-    --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0 ^
+geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu `
+    --spec-type draft-mtp `
+    --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0 `
     --draft-tokens 3
 ```
 
@@ -101,9 +101,9 @@ Start at `3`. Raise it only if acceptance is high — with mediocre acceptance a
 ```powershell
 geniex serve                      # terminal 1
 
-geniex run google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu ^
-    --spec-type draft-mtp ^
-    --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0 ^
+geniex run google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute npu `
+    --spec-type draft-mtp `
+    --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0 `
     --draft-tokens 3
 ```
 


### PR DESCRIPTION
## Summary

- Step 2 and Step 3 code blocks in `speculative-decoding-mtp.mdx` are fenced as ` ```powershell ` but use CMD's `^` for line continuation.
- PowerShell parses `^` as the `-bxor` operator, so pasting the multi-line `geniex infer` / `geniex run` commands only executes the first line — matches the "no reaction" reports from customers on Windows (default shell is PowerShell).
- Swap the 6 continuation characters for PowerShell's backtick `` ` ``. No other edits.

## Test plan

- [x] Pasted the corrected Step 2 and Step 3 blocks into `powershell.exe` on Snapdragon X2 Elite — all lines parsed as one command, `geniex infer` and `geniex serve` + `geniex run` executed end-to-end. Previous `^` blocks stopped after the first line.