### PR TITLE
fix(sdk): harden model lifecycle and Xray validation

### DIFF
--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -56,8 +56,8 @@ ResolvedDevice resolve_device(
     geniex_ResolveDeviceOutput out{};
     int32_t                    rc = geniex_resolve_device(&in, &out);
     if (rc != GENIEX_SUCCESS) {
-        LOGe("[JNI] geniex_resolve_device failed (rc=%d), falling back to empty device", rc);
-        return r;
+        LOGe("[JNI] geniex_resolve_device failed closed (rc=%d)", rc);
+        throw std::runtime_error("device route resolution failed");
     }
 
     if (out.device_id) {
@@ -70,6 +70,8 @@ ResolvedDevice resolve_device(
         geniex_free(out.warning);
     }
     r.ngl = out.ngl;
+    r.requested_route = out.requested_route;
+    r.selected_route  = out.selected_route;
     return r;
 }
 

--- a/bindings/android/app/src/main/cpp/jniutils.h
+++ b/bindings/android/app/src/main/cpp/jniutils.h
@@ -33,12 +33,14 @@ std::string jstring2str(JNIEnv* env, jstring jstr);
 struct ResolvedDevice {
     std::string device_id;
     int32_t     ngl = -1;
-    std::string warning;  // non-empty when the alias was coerced
+    std::string warning;
+    geniex_RouteId requested_route = GENIEX_ROUTE_AUTO;
+    geniex_RouteId selected_route  = GENIEX_ROUTE_AUTO;
 };
 
 /**
  * Thin wrapper over the SDK's `geniex_resolve_device`. The alias table
- * (cpu / gpu / npu / hybrid, qairt coercion) lives in
+ * (cpu / gpu / npu / hybrid, including fail-closed compatibility) lives in
  * `sdk/src/device.cpp` — this helper just marshals the result into
  * Android-local types so the 8 JNI call sites stay stable.
  *

--- a/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/llm_bridge_jni.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -22,9 +23,27 @@
 
 using namespace jniutils;
 
-// Global map to track stop flags for each LLM handle
-static std::unordered_map<void*, std::atomic<bool>*> g_stopFlags;
-static std::mutex                                    g_stopFlagsMutex;
+struct HandleState {
+    std::mutex                         operation_mutex;
+    std::mutex                         stop_mutex;
+    std::shared_ptr<std::atomic<bool>> stop_flag;
+    std::atomic<bool>                  closing{false};
+};
+
+static std::unordered_map<void*, std::shared_ptr<HandleState>> g_handleStates;
+static std::mutex                                              g_handleStatesMutex;
+
+static std::shared_ptr<HandleState> get_handle_state(void* handle) {
+    std::lock_guard<std::mutex> lock(g_handleStatesMutex);
+    auto                        it = g_handleStates.find(handle);
+    return it == g_handleStates.end() ? nullptr : it->second;
+}
+
+static void request_stop(const std::shared_ptr<HandleState>& state) {
+    if (!state) return;
+    std::lock_guard<std::mutex> lock(state->stop_mutex);
+    if (state->stop_flag) state->stop_flag->store(true);
+}
 
 using namespace jniutils;
 using namespace geniex_android_sdk;
@@ -33,6 +52,7 @@ using namespace geniex_android_sdk;
 extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Llm_create(
     JNIEnv* env, jobject thiz, jobject llm_create_input_obj) {
     try {
+        clear_jni_cstr_pool();
         geniex_LlmCreateInput create_input = extract_llm_create_input(env, llm_create_input_obj);
         geniex_LLM*           handle       = nullptr;
         LOGd("[JNI] create() geniex_llm_create called with:");
@@ -45,6 +65,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Llm_create(
         LOGd("  plugin_id: %s", create_input.plugin_id ? create_input.plugin_id : "(null)");
 
         int32_t result = geniex_llm_create(&create_input, &handle);
+        clear_jni_cstr_pool();
 
         if (result != GENIEX_SUCCESS || !handle) {
             LOGe("[JNI] create() failed, error code: %d", result);
@@ -52,10 +73,15 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Llm_create(
                 env, "Llm create failed: %s", geniex_get_error_message(static_cast<geniex_ErrorCode>(result)));
             return 0;
         }
+        {
+            std::lock_guard<std::mutex> lock(g_handleStatesMutex);
+            g_handleStates[handle] = std::make_shared<HandleState>();
+        }
         LOGd("[JNI] create() geniex_llm_create returned handle=%p", handle);
         return reinterpret_cast<jlong>(handle);
 
     } catch (const std::exception& e) {
+        clear_jni_cstr_pool();
         LOGe("[JNI] create() exception: %s", e.what());
         return 0;
     }
@@ -65,7 +91,19 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Llm_create(
 extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_jni_Llm_destroy(JNIEnv*, jobject, jlong handle) {
     LOGd("[JNI] destroy() called, handle=%p", (void*)handle);
     if (handle) {
+        void* h     = reinterpret_cast<void*>(handle);
+        auto  state = get_handle_state(h);
+        if (state) {
+            state->closing.store(true);
+            request_stop(state);
+        }
+        std::unique_lock<std::mutex> operation_lock;
+        if (state) operation_lock = std::unique_lock<std::mutex>(state->operation_mutex);
         int32_t result = geniex_llm_destroy((geniex_LLM*)handle);
+        {
+            std::lock_guard<std::mutex> lock(g_handleStatesMutex);
+            g_handleStates.erase(h);
+        }
         if (result != GENIEX_SUCCESS) {
             LOGe("[JNI] destroy() failed, error code: %d", result);
         }
@@ -78,19 +116,30 @@ extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_jni_Llm_destroy(JNIEnv*, j
 extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_generate(
     JNIEnv* env, jobject /*thiz*/, jlong handle, jstring prompt, jobject configObj, jobject callback) {
     try {
-        void* h = (void*)handle;
-
-        // Setup stop flag for streaming control
-        std::atomic<bool>* stop_flag = nullptr;
-        if (callback) {
-            std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-            if (g_stopFlags.count(h)) delete g_stopFlags[h];
-            g_stopFlags[h] = new std::atomic<bool>(false);
-            stop_flag      = g_stopFlags[h];
+        void* h     = (void*)handle;
+        auto  state = get_handle_state(h);
+        if (!state) {
+            throw_runtime_exception(env, "LLM generate failed: invalid handle");
+            return nullptr;
         }
 
-        std::string             cprompt = jstring2str(env, prompt);
-        geniex_GenerationConfig cfg     = extract_generation_config(env, configObj);
+        std::unique_lock<std::mutex> operation_lock(state->operation_mutex);
+        if (state->closing.load()) {
+            throw_runtime_exception(env, "LLM generate failed: handle is closing");
+            return nullptr;
+        }
+
+        // Setup stop flag for streaming control
+        std::shared_ptr<std::atomic<bool>> stop_flag;
+        if (callback) {
+            stop_flag = std::make_shared<std::atomic<bool>>(false);
+            std::lock_guard<std::mutex> lock(state->stop_mutex);
+            state->stop_flag = stop_flag;
+        }
+
+        std::string                           cprompt = jstring2str(env, prompt);
+        geniex_GenerationConfig               cfg     = extract_generation_config(env, configObj);
+        std::unique_ptr<geniex_SamplerConfig> sampler_config(cfg.sampler_config);
 
         geniex_LlmGenerateInput  input  = {};
         geniex_LlmGenerateOutput output = {};
@@ -105,11 +154,10 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_generate(
                     "(Ljava/lang/String;)Z",
                     /* onComplete*/ "onComplete",
                     "(Lcom/geniex/sdk/bean/LlmGenerateResult;)V",
-                    stop_flag,
+                    stop_flag.get(),
                     &cbCtx)) {
-                std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-                delete g_stopFlags[h];
-                g_stopFlags.erase(h);
+                std::lock_guard<std::mutex> lock(state->stop_mutex);
+                state->stop_flag.reset();
                 return nullptr;
             }
             input.on_token = [](const char* token, void* user) -> bool {
@@ -121,9 +169,9 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_generate(
         int32_t ret = geniex_llm_generate(reinterpret_cast<geniex_LLM*>(handle), &input, &output);
         if (ret < 0 || !output.full_text) {
             if (callback) {
-                std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-                delete g_stopFlags[h];
-                g_stopFlags.erase(h);
+                jni_cb_dispose(env, &cbCtx);
+                std::lock_guard<std::mutex> lock(state->stop_mutex);
+                if (state->stop_flag == stop_flag) state->stop_flag.reset();
             }
             throw_runtime_exception(
                 env, "LLM generate failed: %s", geniex_get_error_message(static_cast<geniex_ErrorCode>(ret)));
@@ -148,9 +196,8 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_generate(
             jni_cb_dispose(env, &cbCtx);
 
             {
-                std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-                delete g_stopFlags[h];
-                g_stopFlags.erase(h);
+                std::lock_guard<std::mutex> lock(state->stop_mutex);
+                if (state->stop_flag == stop_flag) state->stop_flag.reset();
             }
 
             free(output.full_text);
@@ -171,14 +218,23 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_generate(
 
 // JNI: stopStream - Stop ongoing generation
 extern "C" JNIEXPORT void JNICALL Java_com_geniex_sdk_jni_Llm_stopStream(JNIEnv*, jobject, jlong handle) {
-    void*                       h = (void*)handle;
-    std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-    if (g_stopFlags.count(h)) g_stopFlags[h]->store(true);
+    request_stop(get_handle_state((void*)handle));
 }
 
 // JNI: applyChatTemplate - Format messages with chat template
 extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_applyChatTemplate(JNIEnv* env, jobject thiz,
     jlong handle, jobjectArray jmessages, jstring jtools, jboolean jEnableThinking, jboolean jAddGenerationPrompt) {
+    auto state = get_handle_state((void*)handle);
+    if (!state) {
+        throw_runtime_exception(env, "LLM applyChatTemplate failed: invalid handle");
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(state->operation_mutex);
+    if (state->closing.load()) {
+        throw_runtime_exception(env, "LLM applyChatTemplate failed: handle is closing");
+        return nullptr;
+    }
+
     static thread_local std::vector<std::string> str_buf;
     auto                                         msgs = extract_llm_chat_messages(env, jmessages, str_buf);
 
@@ -215,5 +271,9 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Llm_applyChatTempla
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_jni_Llm_reset(JNIEnv* env, jobject thiz, jlong handle) {
+    auto state = get_handle_state((void*)handle);
+    if (!state || state->closing.load()) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
+    std::lock_guard<std::mutex> lock(state->operation_mutex);
+    if (state->closing.load()) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
     return geniex_llm_reset(reinterpret_cast<geniex_LLM*>(handle));
 }

--- a/bindings/android/app/src/main/cpp/vlm_bridge_jni.cpp
+++ b/bindings/android/app/src/main/cpp/vlm_bridge_jni.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
@@ -16,8 +17,27 @@
 #include "jni_cb.h"
 #include "jniutils.h"
 
-static std::unordered_map<void*, std::atomic<bool>*> g_stopFlags;
-static std::mutex                                    g_stopFlagsMutex;
+struct HandleState {
+    std::mutex                         operation_mutex;
+    std::mutex                         stop_mutex;
+    std::shared_ptr<std::atomic<bool>> stop_flag;
+    std::atomic<bool>                  closing{false};
+};
+
+static std::unordered_map<void*, std::shared_ptr<HandleState>> g_handleStates;
+static std::mutex                                              g_handleStatesMutex;
+
+static std::shared_ptr<HandleState> get_handle_state(void* handle) {
+    std::lock_guard<std::mutex> lock(g_handleStatesMutex);
+    auto                        it = g_handleStates.find(handle);
+    return it == g_handleStates.end() ? nullptr : it->second;
+}
+
+static void request_stop(const std::shared_ptr<HandleState>& state) {
+    if (!state) return;
+    std::lock_guard<std::mutex> lock(state->stop_mutex);
+    if (state->stop_flag) state->stop_flag->store(true);
+}
 
 using namespace jniutils;
 using namespace geniex_android_sdk;
@@ -25,12 +45,14 @@ using namespace geniex_android_sdk;
 // JNI: create
 extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Vlm_create(JNIEnv* env, jobject, jobject vlmCreateInputObj) {
     try {
+        clear_jni_cstr_pool();
         LOGi("[JNI] [create] Java_com_geniex_sdk_jni_Vlm_create ");
         geniex_VlmCreateInput create_input = extract_vlm_create_input(env, vlmCreateInputObj);
         LOGi("[JNI] [create] model_name = %s", create_input.model_name ? create_input.model_name : "(null)");
         LOGi("[JNI] [create] plugin_id = %s", create_input.plugin_id ? create_input.plugin_id : "(null)");
         geniex_VLM* handle = nullptr;
         int32_t     result = geniex_vlm_create(&create_input, &handle);
+        clear_jni_cstr_pool();
 
         if (result != GENIEX_SUCCESS || !handle) {
             LOGe("[JNI] create() failed, error code: %d", result);
@@ -39,10 +61,16 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Vlm_create(JNIEnv* en
             return 0;
         }
 
+        {
+            std::lock_guard<std::mutex> lock(g_handleStatesMutex);
+            g_handleStates[handle] = std::make_shared<HandleState>();
+        }
+
         LOGi("[JNI] create() geniex_vlm_create returned handle=%p", handle);
         return reinterpret_cast<jlong>(handle);
 
     } catch (const std::exception& e) {
+        clear_jni_cstr_pool();
         LOGe("[JNI] create() exception: %s", e.what());
         return 0;
     }
@@ -52,7 +80,19 @@ extern "C" JNIEXPORT jlong JNICALL Java_com_geniex_sdk_jni_Vlm_create(JNIEnv* en
 extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_jni_Vlm_destroy(JNIEnv*, jobject, jlong handle) {
     LOGd("[JNI] destroy() called, handle=%p", (void*)handle);
     if (handle) {
+        void* h     = reinterpret_cast<void*>(handle);
+        auto  state = get_handle_state(h);
+        if (state) {
+            state->closing.store(true);
+            request_stop(state);
+        }
+        std::unique_lock<std::mutex> operation_lock;
+        if (state) operation_lock = std::unique_lock<std::mutex>(state->operation_mutex);
         int32_t result = geniex_vlm_destroy(reinterpret_cast<geniex_VLM*>(handle));
+        {
+            std::lock_guard<std::mutex> lock(g_handleStatesMutex);
+            g_handleStates.erase(h);
+        }
         if (result != GENIEX_SUCCESS) {
             LOGe("[JNI] destroy() failed, error code: %d", result);
         }
@@ -68,6 +108,10 @@ extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_jni_Vlm_reset(JNIEnv* env,
         throw_runtime_exception(env, "VLM reset failed: invalid handle");
         return GENIEX_ERROR_COMMON_INVALID_INPUT;
     }
+    auto state = get_handle_state((void*)handle);
+    if (!state || state->closing.load()) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
+    std::lock_guard<std::mutex> lock(state->operation_mutex);
+    if (state->closing.load()) return GENIEX_ERROR_COMMON_NOT_INITIALIZED;
     int32_t result = geniex_vlm_reset(reinterpret_cast<geniex_VLM*>(handle));
     if (result != GENIEX_SUCCESS) {
         LOGe("[JNI] reset() failed, error code: %d", result);
@@ -79,6 +123,16 @@ extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_jni_Vlm_reset(JNIEnv* env,
 extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_getCapabilities(JNIEnv* env, jobject, jlong handle) {
     if (!handle) {
         throw_runtime_exception(env, "VLM getCapabilities failed: invalid handle");
+        return nullptr;
+    }
+    auto state = get_handle_state((void*)handle);
+    if (!state) {
+        throw_runtime_exception(env, "VLM getCapabilities failed: invalid handle");
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(state->operation_mutex);
+    if (state->closing.load()) {
+        throw_runtime_exception(env, "VLM getCapabilities failed: handle is closing");
         return nullptr;
     }
     geniex_VlmCapabilities caps{};
@@ -99,18 +153,29 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_getCapabilities
 extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_generate(
     JNIEnv* env, jobject /*thiz*/, jlong handle, jstring prompt, jobject configObj, jobject callback) {
     try {
-        void* h = (void*)handle;
-
-        std::atomic<bool>* stop_flag = nullptr;
-        if (callback) {
-            std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-            if (g_stopFlags.count(h)) delete g_stopFlags[h];
-            g_stopFlags[h] = new std::atomic<bool>(false);
-            stop_flag      = g_stopFlags[h];
+        void* h     = (void*)handle;
+        auto  state = get_handle_state(h);
+        if (!state) {
+            throw_runtime_exception(env, "VLM generate failed: invalid handle");
+            return nullptr;
         }
 
-        std::string             cprompt = jstring2str(env, prompt);
-        geniex_GenerationConfig cfg     = extract_generation_config(env, configObj);
+        std::unique_lock<std::mutex> operation_lock(state->operation_mutex);
+        if (state->closing.load()) {
+            throw_runtime_exception(env, "VLM generate failed: handle is closing");
+            return nullptr;
+        }
+
+        std::shared_ptr<std::atomic<bool>> stop_flag;
+        if (callback) {
+            stop_flag = std::make_shared<std::atomic<bool>>(false);
+            std::lock_guard<std::mutex> lock(state->stop_mutex);
+            state->stop_flag = stop_flag;
+        }
+
+        std::string                           cprompt = jstring2str(env, prompt);
+        geniex_GenerationConfig               cfg     = extract_generation_config(env, configObj);
+        std::unique_ptr<geniex_SamplerConfig> sampler_config(cfg.sampler_config);
 
         geniex_VlmGenerateInput  input  = {};
         geniex_VlmGenerateOutput output = {};
@@ -125,11 +190,10 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_generate(
                     "(Ljava/lang/String;)Z",
                     /* onComplete*/ "onComplete",
                     "(Lcom/geniex/sdk/bean/LlmGenerateResult;)V",
-                    stop_flag,
+                    stop_flag.get(),
                     &cbCtx)) {
-                std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-                delete g_stopFlags[h];
-                g_stopFlags.erase(h);
+                std::lock_guard<std::mutex> lock(state->stop_mutex);
+                state->stop_flag.reset();
                 return nullptr;
             }
             input.on_token = [](const char* token, void* user) -> bool {
@@ -142,9 +206,9 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_generate(
 
         if (ret < 0 || !output.full_text) {
             if (callback) {
-                std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-                delete g_stopFlags[h];
-                g_stopFlags.erase(h);
+                jni_cb_dispose(env, &cbCtx);
+                std::lock_guard<std::mutex> lock(state->stop_mutex);
+                if (state->stop_flag == stop_flag) state->stop_flag.reset();
             }
             throw_runtime_exception(
                 env, "VLM generate failed: %s", geniex_get_error_message(static_cast<geniex_ErrorCode>(ret)));
@@ -169,9 +233,8 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_generate(
             jni_cb_dispose(env, &cbCtx);
 
             {
-                std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-                delete g_stopFlags[h];
-                g_stopFlags.erase(h);
+                std::lock_guard<std::mutex> lock(state->stop_mutex);
+                if (state->stop_flag == stop_flag) state->stop_flag.reset();
             }
 
             free(output.full_text);
@@ -188,6 +251,17 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_generate(
 
 extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_applyChatTemplate(
     JNIEnv* env, jobject /*thiz*/, jlong handle, jobjectArray jmessages, jstring jtools, jboolean jEnableThinking) {
+    auto state = get_handle_state((void*)handle);
+    if (!state) {
+        throw_runtime_exception(env, "VLM applyChatTemplate failed: invalid handle");
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(state->operation_mutex);
+    if (state->closing.load()) {
+        throw_runtime_exception(env, "VLM applyChatTemplate failed: handle is closing");
+        return nullptr;
+    }
+
     clear_jni_cstr_pool();
     auto msgs = extract_vlm_chat_messages(env, jmessages);
 
@@ -233,9 +307,7 @@ extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_Vlm_applyChatTempla
 }
 
 extern "C" JNIEXPORT void JNICALL Java_com_geniex_sdk_jni_Vlm_stopStream(JNIEnv*, jobject, jlong handle) {
-    void*                       h = (void*)handle;
-    std::lock_guard<std::mutex> lock(g_stopFlagsMutex);
-    if (g_stopFlags.count(h)) g_stopFlags[h]->store(true);
+    request_stop(get_handle_state((void*)handle));
 }
 
 // Extract media paths from VlmChatMessage contents

--- a/bindings/android/app/src/main/java/com/geniex/sdk/LlmWrapper.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/LlmWrapper.kt
@@ -48,6 +48,7 @@ class LlmWrapper private constructor(
                 val input = llmCreateInput ?: throw IllegalArgumentException("modelPath required")
                 val wrapper = LlmWrapper(dispatcher)
                 wrapper.handle = wrapper.llm.create(input)
+                check(wrapper.handle != 0L) { "Native LLM creation returned an invalid handle" }
                 Result.success(wrapper)
             } catch (e: Exception) {
                 Result.failure(e)
@@ -123,9 +124,9 @@ class LlmWrapper private constructor(
 
     // Clean up native resources
     fun destroy(): Int {
-        var result = 0
-        if (handle != 0L) {
-            result = llm.destroy(handle)
+        if (handle == 0L) return 0
+        val result = llm.destroy(handle)
+        if (result == 0) {
             handle = 0L
         }
         return result

--- a/bindings/android/app/src/main/java/com/geniex/sdk/VlmWrapper.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/VlmWrapper.kt
@@ -69,6 +69,7 @@ private constructor(
                                         ?: throw IllegalArgumentException("modelPath required")
                         val wrapper = VlmWrapper(dispatcher)
                         wrapper.handle = wrapper.vlm.create(input)
+                        check(wrapper.handle != 0L) { "Native VLM creation returned an invalid handle" }
                         Result.success(wrapper)
                     } catch (e: Exception) {
                         Result.failure(e)
@@ -174,9 +175,9 @@ private constructor(
 
     /** Destroys the native VLM instance and clears the handle. */
     fun destroy(): Int {
-        var result = 0
-        if (handle != 0L) {
-            result = vlm.destroy(handle)
+        if (handle == 0L) return 0
+        val result = vlm.destroy(handle)
+        if (result == 0) {
             handle = 0L
         }
         return result

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -122,7 +122,10 @@ add_custom_target(model_manager_build ALL
     VERBATIM
 )
 
-enable_testing()
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
 
 # ===============================================================================
 # Third-party patches

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -1512,8 +1512,9 @@ static void json_field_i64(FILE* f, const char* k, int64_t v, bool last) {
     fprintf(f, "    \"%s\": %lld%s", k, (long long)v, last ? "\n" : ",\n");
 }
 
-static void write_json(const options_t* o, const char* device_id, int32_t ngl, int64_t model_size_bytes,
-    const run_result_t* runs, const agg_t* a) {
+static void write_json(const options_t* o, const char* device_id, int32_t ngl,
+    geniex_RouteId requested_route, geniex_RouteId selected_route,
+    int64_t model_size_bytes, const run_result_t* runs, const agg_t* a) {
     FILE* f = fopen(o->output_json, "w");
     if (!f) {
         fprintf(stderr, "ERROR: cannot open %s for write\n", o->output_json);
@@ -1525,6 +1526,8 @@ static void write_json(const options_t* o, const char* device_id, int32_t ngl, i
     json_field_str(f, "plugin", o->plugin, false);
     json_field_str(f, "device", o->device, false);
     json_field_str(f, "device_id", device_id, false);
+    json_field_i64(f, "requested_route_id", requested_route, false);
+    json_field_i64(f, "selected_route_id", selected_route, false);
     json_field_str(f, "model_path", o->model_path, false);
     json_field_i64(f, "model_size_bytes", model_size_bytes, false);
     json_field_str(f, "qairt_version", geniex_get_plugin_version("qairt"), false);
@@ -1876,6 +1879,9 @@ static int run_one_cell(options_t* o) {
     }
     const char* device_id = o->device_id ? o->device_id : rout.device_id;
     int32_t     ngl       = rout.ngl;
+    geniex_RouteId requested_route = rout.requested_route;
+    geniex_RouteId selected_route =
+        o->device_id ? GENIEX_ROUTE_EXPLICIT : rout.selected_route;
     /* --n-gpu-layers overrides the resolved value. */
     if (o->ngl_override >= 0) {
         ngl = o->ngl_override;
@@ -1940,7 +1946,9 @@ static int run_one_cell(options_t* o) {
 
     int64_t model_size_bytes = compute_model_size(o->model_path);
 
-    if (o->output_json) write_json(o, device_id, ngl, model_size_bytes, runs, &a);
+    if (o->output_json)
+        write_json(o, device_id, ngl, requested_route, selected_route,
+            model_size_bytes, runs, &a);
     if (o->output_md) write_md_row(o, ngl, model_size_bytes, &a);
 
     free(runs);

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -305,20 +305,29 @@ typedef struct {
  * llama_cpp gpu / npu / hybrid pass `ngl_default` through unchanged (a
  * negative value means "all layers" to llama.cpp).
  *
- * `warning` is non-NULL when the alias was coerced (e.g. qairt only has
- * an NPU device, so cpu/gpu/hybrid fall back to NPU with a warning).
- * Callers should surface the warning and continue — geniex_resolve_device
- * never returns an error for coerced modes.
+ * `warning` is reserved for causal, non-route-changing notices.
+ * Route changes are never warning-only fallbacks. In particular, qairt
+ * rejects cpu/gpu/hybrid because it supports only NPU.
  *
- * An error (GENIEX_ERROR_COMMON_INVALID_DEVICE) is returned only when
- * `mode` is a non-empty, non-"auto" string that is not one of the
- * documented aliases. Both `device_id` and `warning` are heap-allocated;
+ * GENIEX_ERROR_COMMON_INVALID_DEVICE is returned when `mode` is unknown
+ * or incompatible with the selected plugin. Both `device_id` and `warning` are heap-allocated;
  * call `geniex_free` on each non-NULL pointer when done.
  */
+typedef enum {
+    GENIEX_ROUTE_AUTO = 0,
+    GENIEX_ROUTE_CPU,
+    GENIEX_ROUTE_GPU,
+    GENIEX_ROUTE_NPU,
+    GENIEX_ROUTE_HYBRID,
+    GENIEX_ROUTE_EXPLICIT
+} geniex_RouteId;
+
 typedef struct {
     char*   device_id; /**< Resolved device id; may be NULL (caller must free with geniex_free) */
     int32_t ngl;       /**< Resolved n_gpu_layers */
-    char*   warning;   /**< Optional coercion warning; may be NULL (caller must free with geniex_free) */
+    char*   warning;   /**< Optional causal warning; may be NULL (caller must free with geniex_free) */
+    geniex_RouteId requested_route; /**< Normalized user request */
+    geniex_RouteId selected_route;  /**< Route selected by the resolver */
 } geniex_ResolveDeviceOutput;
 
 /**
@@ -334,8 +343,8 @@ typedef struct {
  *                    `device_id` / `warning` may be heap-allocated and
  *                    must be freed by the caller with `geniex_free`.
  *
- * @return GENIEX_SUCCESS on success (including coerced aliases, where
- *         `warning` is populated). Returns GENIEX_ERROR_COMMON_INVALID_INPUT
+ * @return GENIEX_SUCCESS when the requested route is supported. Returns
+ *         GENIEX_ERROR_COMMON_INVALID_INPUT
  *         if `input` / `output` / `input->plugin_id` is NULL, or
  *         GENIEX_ERROR_COMMON_INVALID_DEVICE if `mode` is a non-empty
  *         string that is not a documented alias.

--- a/sdk/include/xray.h
+++ b/sdk/include/xray.h
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace geniex::xray {
+
+inline constexpr uint32_t kSchemaVersion = 1;
+
+enum class Mode : uint8_t { Off = 0, Light = 1, Deep = 2 };
+
+enum class Phase : uint8_t {
+    Startup = 0,
+    Residency,
+    Prefill,
+    Decode,
+    ContextGrowth,
+    ThermalEquilibrium,
+    Stop,
+    Unload,
+    Recovery,
+    Count,
+};
+
+inline constexpr size_t kPhaseCount = static_cast<size_t>(Phase::Count);
+inline constexpr uint64_t phase_bit(Phase phase) {
+    return uint64_t{1} << static_cast<uint8_t>(phase);
+}
+inline constexpr uint64_t kFullLapPhases =
+    phase_bit(Phase::Startup) | phase_bit(Phase::Residency) |
+    phase_bit(Phase::Prefill) | phase_bit(Phase::Decode) |
+    phase_bit(Phase::ContextGrowth) | phase_bit(Phase::ThermalEquilibrium) |
+    phase_bit(Phase::Stop) | phase_bit(Phase::Unload) |
+    phase_bit(Phase::Recovery);
+
+enum class Envelope : uint8_t {
+    Artifact = 0,
+    Storage,
+    PeakRam,
+    ResidentWeights,
+    DynamicKv,
+    Context,
+    Runtime,
+    Safety,
+    Backend,
+    Thermal,
+    Energy,
+    OutputValidity,
+    Lifecycle,
+    Residue,
+};
+
+inline constexpr uint64_t envelope_bit(Envelope envelope) {
+    return uint64_t{1} << static_cast<uint8_t>(envelope);
+}
+
+enum class Validation : uint8_t { Unknown = 0, Pass = 1, Fail = 2 };
+enum class Lifecycle : uint8_t {
+    Unknown = 0,
+    Starting,
+    Resident,
+    Running,
+    Stopping,
+    Unloading,
+    Recovering,
+    Released,
+    Failed,
+};
+enum class EnergyConfidence : uint8_t {
+    Unavailable = 0,
+    Estimated,
+    Measured,
+    Calibrated,
+};
+
+struct CausalError {
+    int32_t code{0};
+    Envelope envelope{Envelope::Runtime};
+    Phase phase{Phase::Startup};
+};
+
+struct Event {
+    uint32_t schema_version{kSchemaVersion};
+    uint64_t timestamp_us{0};
+    uint64_t execution_id{0};
+    uint64_t module_id{0};
+    uint32_t module_version{0};
+    uint64_t input_hash{0};
+    uint64_t explicit_state_hash{0};
+    Phase phase{Phase::Startup};
+    uint64_t requested_route_id{0};
+    uint64_t selected_route_id{0};
+    uint64_t observed_route_id{0};
+
+    uint64_t elapsed_us{0};
+    uint64_t work_units{0};
+    uint64_t prompt_tokens_delta{0};
+    uint64_t generated_tokens_delta{0};
+
+    uint64_t artifact_bytes{0};
+    uint64_t resident_weight_bytes{0};
+    uint64_t kv_bytes{0};
+    int64_t kv_delta_bytes{0};
+    uint64_t runtime_bytes{0};
+    uint64_t peak_rss_bytes{0};
+    uint64_t memory_read_bytes{0};
+    uint64_t memory_write_bytes{0};
+
+    uint64_t energy_delta_uj{0};
+    EnergyConfidence energy_confidence{EnergyConfidence::Unavailable};
+    int32_t thermal_headroom_millic{std::numeric_limits<int32_t>::max()};
+    int32_t thermal_slope_millic_per_min{0};
+    bool throttled{false};
+
+    uint64_t active_envelopes{0};
+    uint64_t passed_envelopes{0};
+    Validation validation{Validation::Unknown};
+    Lifecycle lifecycle{Lifecycle::Unknown};
+
+    uint32_t live_handles{0};
+    uint32_t live_threads{0};
+    uint32_t live_file_descriptors{0};
+    uint32_t live_services{0};
+    uint32_t live_jobs{0};
+    uint32_t live_wake_locks{0};
+    uint64_t mapped_model_bytes{0};
+    bool output_checked{false};
+    bool output_valid{false};
+    CausalError error{};
+};
+
+struct CounterSnapshot {
+    std::array<uint64_t, kPhaseCount> events{};
+    std::array<uint64_t, kPhaseCount> elapsed_us{};
+    std::array<uint64_t, kPhaseCount> work_units{};
+    uint64_t peak_rss_bytes{0};
+    uint64_t max_kv_bytes{0};
+    uint64_t energy_uj{0};
+    uint64_t errors{0};
+};
+
+class Counters {
+public:
+    Counters() {
+        for (auto& value : events_) value.store(0, std::memory_order_relaxed);
+        for (auto& value : elapsed_us_) value.store(0, std::memory_order_relaxed);
+        for (auto& value : work_units_) value.store(0, std::memory_order_relaxed);
+    }
+
+    void record(const Event& event) noexcept {
+        const auto index = static_cast<size_t>(event.phase);
+        if (index >= kPhaseCount) return;
+        events_[index].fetch_add(1, std::memory_order_relaxed);
+        elapsed_us_[index].fetch_add(event.elapsed_us, std::memory_order_relaxed);
+        work_units_[index].fetch_add(event.work_units, std::memory_order_relaxed);
+        atomic_max(peak_rss_bytes_, event.peak_rss_bytes);
+        atomic_max(max_kv_bytes_, event.kv_bytes);
+        energy_uj_.fetch_add(event.energy_delta_uj, std::memory_order_relaxed);
+        if (event.error.code != 0 || event.validation == Validation::Fail) {
+            errors_.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    CounterSnapshot snapshot() const noexcept {
+        CounterSnapshot result;
+        for (size_t i = 0; i < kPhaseCount; ++i) {
+            result.events[i] = events_[i].load(std::memory_order_relaxed);
+            result.elapsed_us[i] = elapsed_us_[i].load(std::memory_order_relaxed);
+            result.work_units[i] = work_units_[i].load(std::memory_order_relaxed);
+        }
+        result.peak_rss_bytes = peak_rss_bytes_.load(std::memory_order_relaxed);
+        result.max_kv_bytes = max_kv_bytes_.load(std::memory_order_relaxed);
+        result.energy_uj = energy_uj_.load(std::memory_order_relaxed);
+        result.errors = errors_.load(std::memory_order_relaxed);
+        return result;
+    }
+
+private:
+    static void atomic_max(std::atomic<uint64_t>& target, uint64_t value) noexcept {
+        auto current = target.load(std::memory_order_relaxed);
+        while (current < value &&
+               !target.compare_exchange_weak(
+                   current, value, std::memory_order_relaxed, std::memory_order_relaxed)) {
+        }
+    }
+
+    std::array<std::atomic<uint64_t>, kPhaseCount> events_;
+    std::array<std::atomic<uint64_t>, kPhaseCount> elapsed_us_;
+    std::array<std::atomic<uint64_t>, kPhaseCount> work_units_;
+    std::atomic<uint64_t> peak_rss_bytes_{0};
+    std::atomic<uint64_t> max_kv_bytes_{0};
+    std::atomic<uint64_t> energy_uj_{0};
+    std::atomic<uint64_t> errors_{0};
+};
+
+class Sink {
+public:
+    virtual ~Sink() = default;
+    virtual void emit(const Event& event) noexcept = 0;
+};
+
+class Recorder {
+public:
+    explicit Recorder(Mode mode = Mode::Light, Sink* sink = nullptr) noexcept
+        : mode_(mode), sink_(sink) {}
+
+    void set_mode(Mode mode) noexcept { mode_.store(mode, std::memory_order_relaxed); }
+    Mode mode() const noexcept { return mode_.load(std::memory_order_relaxed); }
+
+    void record(const Event& event) noexcept {
+        const auto current = mode();
+        if (current == Mode::Off) return;
+        counters_.record(event);
+        if (current == Mode::Deep && sink_) sink_->emit(event);
+    }
+
+    CounterSnapshot snapshot() const noexcept { return counters_.snapshot(); }
+
+private:
+    std::atomic<Mode> mode_;
+    Sink* sink_;
+    Counters counters_;
+};
+
+struct LapResult {
+    uint32_t schema_version{kSchemaVersion};
+    bool valid{false};
+    uint64_t observed_phases{0};
+    uint64_t missing_phases{kFullLapPhases};
+    uint64_t failed_envelopes{0};
+    uint64_t execution_id{0};
+    uint64_t module_id{0};
+    uint32_t module_version{0};
+    uint64_t input_hash{0};
+    uint64_t explicit_state_hash{0};
+    uint64_t requested_route_id{0};
+    uint64_t selected_route_id{0};
+    uint64_t observed_route_id{0};
+    uint64_t end_to_end_us{0};
+    uint64_t prompt_tokens{0};
+    uint64_t generated_tokens{0};
+    uint64_t energy_uj{0};
+    EnergyConfidence energy_confidence{EnergyConfidence::Unavailable};
+    bool energy_qualified{false};
+    double tokens_per_joule{0.0};
+    int32_t minimum_thermal_headroom_millic{std::numeric_limits<int32_t>::max()};
+    int32_t maximum_thermal_slope_millic_per_min{0};
+    bool throttled{false};
+    bool validation_failed{false};
+    bool validation_complete{false};
+    bool identity_complete{false};
+    bool identity_consistent{false};
+    bool output_valid{false};
+    Lifecycle final_lifecycle{Lifecycle::Unknown};
+    uint64_t residue_count{0};
+    CausalError first_error{};
+
+    bool better_than(const LapResult& other) const noexcept {
+        if (valid != other.valid) return valid;
+        if (!valid) {
+            if (failed_envelopes != other.failed_envelopes) {
+                return failed_envelopes < other.failed_envelopes;
+            }
+            return missing_phases < other.missing_phases;
+        }
+        if (end_to_end_us != other.end_to_end_us) return end_to_end_us < other.end_to_end_us;
+        if (tokens_per_joule != other.tokens_per_joule) {
+            return tokens_per_joule > other.tokens_per_joule;
+        }
+        return minimum_thermal_headroom_millic >
+               other.minimum_thermal_headroom_millic;
+    }
+};
+
+class LapScorer {
+public:
+    void record(const Event& event) noexcept {
+        observed_phases_ |= phase_bit(event.phase);
+        failed_envelopes_ |= event.active_envelopes & ~event.passed_envelopes;
+        if (event.validation == Validation::Fail) {
+            validation_failed_ = true;
+            failed_envelopes_ |= envelope_bit(event.error.envelope);
+        }
+        validation_complete_ =
+            validation_complete_ && event.validation != Validation::Unknown;
+
+        const bool event_identity_complete =
+            event.schema_version == kSchemaVersion && event.execution_id != 0 &&
+            event.module_id != 0 &&
+            event.module_version != 0 && event.input_hash != 0 &&
+            event.explicit_state_hash != 0 && event.requested_route_id != 0 &&
+            event.selected_route_id != 0 && event.observed_route_id != 0;
+        identity_complete_ = identity_complete_ && event_identity_complete;
+        if (!identity_initialized_) {
+            execution_id_ = event.execution_id;
+            module_id_ = event.module_id;
+            module_version_ = event.module_version;
+            input_hash_ = event.input_hash;
+            explicit_state_hash_ = event.explicit_state_hash;
+            requested_route_id_ = event.requested_route_id;
+            selected_route_id_ = event.selected_route_id;
+            observed_route_id_ = event.observed_route_id;
+            identity_initialized_ = true;
+        } else if (execution_id_ != event.execution_id || module_id_ != event.module_id ||
+                   module_version_ != event.module_version ||
+                   input_hash_ != event.input_hash ||
+                   requested_route_id_ != event.requested_route_id ||
+                   selected_route_id_ != event.selected_route_id ||
+                   observed_route_id_ != event.observed_route_id) {
+            identity_consistent_ = false;
+        }
+
+        if (!started_ || event.timestamp_us < first_timestamp_us_) {
+            first_timestamp_us_ = event.timestamp_us;
+            started_ = true;
+        }
+        if (event.timestamp_us + event.elapsed_us > last_timestamp_us_) {
+            last_timestamp_us_ = event.timestamp_us + event.elapsed_us;
+        }
+
+        prompt_tokens_ += event.prompt_tokens_delta;
+        generated_tokens_ += event.generated_tokens_delta;
+        energy_uj_ += event.energy_delta_uj;
+        if (event.energy_delta_uj != 0) {
+            if (!energy_observed_ || event.energy_confidence < energy_confidence_) {
+                energy_confidence_ = event.energy_confidence;
+            }
+            energy_observed_ = true;
+        }
+        throttled_ = throttled_ || event.throttled;
+        if (event.output_checked) {
+            output_observed_ = true;
+            output_invalid_ = output_invalid_ || !event.output_valid;
+            if (!event.output_valid) {
+                failed_envelopes_ |= envelope_bit(Envelope::OutputValidity);
+            }
+        }
+        final_lifecycle_ = event.lifecycle;
+
+        if (event.thermal_headroom_millic != std::numeric_limits<int32_t>::max() &&
+            event.thermal_headroom_millic < minimum_thermal_headroom_millic_) {
+            minimum_thermal_headroom_millic_ = event.thermal_headroom_millic;
+        }
+        const int32_t absolute_slope =
+            event.thermal_slope_millic_per_min < 0
+                ? -event.thermal_slope_millic_per_min
+                : event.thermal_slope_millic_per_min;
+        if (absolute_slope > maximum_thermal_slope_millic_per_min_) {
+            maximum_thermal_slope_millic_per_min_ = absolute_slope;
+        }
+
+        if (event.phase == Phase::Recovery) {
+            residue_count_ =
+                static_cast<uint64_t>(event.live_handles) + event.live_threads +
+                event.live_file_descriptors + event.live_services + event.live_jobs +
+                event.live_wake_locks + event.mapped_model_bytes;
+        }
+        if (first_error_.code == 0 && event.error.code != 0) first_error_ = event.error;
+    }
+
+    LapResult finish() const noexcept {
+        LapResult result;
+        result.observed_phases = observed_phases_;
+        result.missing_phases = kFullLapPhases & ~observed_phases_;
+        result.failed_envelopes = failed_envelopes_;
+        result.execution_id = execution_id_;
+        result.module_id = module_id_;
+        result.module_version = module_version_;
+        result.input_hash = input_hash_;
+        result.explicit_state_hash = explicit_state_hash_;
+        result.requested_route_id = requested_route_id_;
+        result.selected_route_id = selected_route_id_;
+        result.observed_route_id = observed_route_id_;
+        result.end_to_end_us =
+            started_ && last_timestamp_us_ >= first_timestamp_us_
+                ? last_timestamp_us_ - first_timestamp_us_
+                : 0;
+        result.prompt_tokens = prompt_tokens_;
+        result.generated_tokens = generated_tokens_;
+        result.energy_uj = energy_uj_;
+        result.energy_confidence =
+            energy_observed_ ? energy_confidence_ : EnergyConfidence::Unavailable;
+        result.energy_qualified =
+            energy_uj_ != 0 && result.energy_confidence >= EnergyConfidence::Measured;
+        result.tokens_per_joule =
+            !result.energy_qualified
+                ? 0.0
+                : static_cast<double>(generated_tokens_) * 1000000.0 /
+                      static_cast<double>(energy_uj_);
+        result.minimum_thermal_headroom_millic = minimum_thermal_headroom_millic_;
+        result.maximum_thermal_slope_millic_per_min =
+            maximum_thermal_slope_millic_per_min_;
+        result.throttled = throttled_;
+        result.validation_failed = validation_failed_;
+        result.validation_complete = validation_complete_;
+        result.identity_complete = identity_complete_;
+        result.identity_consistent = identity_consistent_;
+        result.output_valid = output_observed_ && !output_invalid_;
+        result.final_lifecycle = final_lifecycle_;
+        result.residue_count = residue_count_;
+        result.first_error = first_error_;
+        if (!result.energy_qualified) {
+            result.failed_envelopes |= envelope_bit(Envelope::Energy);
+        }
+        if (!result.identity_complete || !result.identity_consistent) {
+            result.failed_envelopes |= envelope_bit(Envelope::Safety);
+        }
+        if (!result.validation_complete) {
+            result.failed_envelopes |= envelope_bit(Envelope::Runtime);
+        }
+        result.valid =
+            result.missing_phases == 0 && result.failed_envelopes == 0 &&
+            !result.throttled && !result.validation_failed && result.validation_complete &&
+            result.identity_complete && result.identity_consistent &&
+            result.energy_qualified && result.output_valid &&
+            result.final_lifecycle == Lifecycle::Released &&
+            result.residue_count == 0 && result.first_error.code == 0;
+        return result;
+    }
+
+private:
+    bool started_{false};
+    uint64_t first_timestamp_us_{0};
+    uint64_t last_timestamp_us_{0};
+    uint64_t observed_phases_{0};
+    uint64_t failed_envelopes_{0};
+    uint64_t prompt_tokens_{0};
+    uint64_t generated_tokens_{0};
+    uint64_t energy_uj_{0};
+    EnergyConfidence energy_confidence_{EnergyConfidence::Calibrated};
+    bool energy_observed_{false};
+    int32_t minimum_thermal_headroom_millic_{std::numeric_limits<int32_t>::max()};
+    int32_t maximum_thermal_slope_millic_per_min_{0};
+    bool throttled_{false};
+    bool validation_failed_{false};
+    bool validation_complete_{true};
+    bool identity_initialized_{false};
+    bool identity_complete_{true};
+    bool identity_consistent_{true};
+    uint64_t execution_id_{0};
+    uint64_t module_id_{0};
+    uint32_t module_version_{0};
+    uint64_t input_hash_{0};
+    uint64_t explicit_state_hash_{0};
+    uint64_t requested_route_id_{0};
+    uint64_t selected_route_id_{0};
+    uint64_t observed_route_id_{0};
+    bool output_observed_{false};
+    bool output_invalid_{false};
+    Lifecycle final_lifecycle_{Lifecycle::Unknown};
+    uint64_t residue_count_{0};
+    CausalError first_error_{};
+};
+
+}  // namespace geniex::xray

--- a/sdk/include/xray_c.h
+++ b/sdk/include/xray_c.h
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GENIEX_XRAY_SCHEMA_VERSION 1u
+#define GENIEX_XRAY_PHASE_COUNT 9u
+
+typedef enum {
+    GENIEX_XRAY_STARTUP = 0,
+    GENIEX_XRAY_RESIDENCY,
+    GENIEX_XRAY_PREFILL,
+    GENIEX_XRAY_DECODE,
+    GENIEX_XRAY_CONTEXT_GROWTH,
+    GENIEX_XRAY_THERMAL_EQUILIBRIUM,
+    GENIEX_XRAY_STOP,
+    GENIEX_XRAY_UNLOAD,
+    GENIEX_XRAY_RECOVERY
+} geniex_XrayPhase;
+
+typedef enum {
+    GENIEX_XRAY_VALIDATION_UNKNOWN = 0,
+    GENIEX_XRAY_VALIDATION_PASS = 1,
+    GENIEX_XRAY_VALIDATION_FAIL = 2
+} geniex_XrayValidation;
+
+typedef enum {
+    GENIEX_XRAY_ENERGY_UNAVAILABLE = 0,
+    GENIEX_XRAY_ENERGY_ESTIMATED,
+    GENIEX_XRAY_ENERGY_MEASURED,
+    GENIEX_XRAY_ENERGY_CALIBRATED
+} geniex_XrayEnergyConfidence;
+
+typedef enum {
+    GENIEX_XRAY_LIFECYCLE_UNKNOWN = 0,
+    GENIEX_XRAY_LIFECYCLE_STARTING,
+    GENIEX_XRAY_LIFECYCLE_RESIDENT,
+    GENIEX_XRAY_LIFECYCLE_RUNNING,
+    GENIEX_XRAY_LIFECYCLE_STOPPING,
+    GENIEX_XRAY_LIFECYCLE_UNLOADING,
+    GENIEX_XRAY_LIFECYCLE_RECOVERING,
+    GENIEX_XRAY_LIFECYCLE_RELEASED,
+    GENIEX_XRAY_LIFECYCLE_FAILED
+} geniex_XrayLifecycle;
+
+typedef enum {
+    GENIEX_XRAY_ENVELOPE_ARTIFACT = 0,
+    GENIEX_XRAY_ENVELOPE_STORAGE,
+    GENIEX_XRAY_ENVELOPE_PEAK_RAM,
+    GENIEX_XRAY_ENVELOPE_RESIDENT_WEIGHTS,
+    GENIEX_XRAY_ENVELOPE_DYNAMIC_KV,
+    GENIEX_XRAY_ENVELOPE_CONTEXT,
+    GENIEX_XRAY_ENVELOPE_RUNTIME,
+    GENIEX_XRAY_ENVELOPE_SAFETY,
+    GENIEX_XRAY_ENVELOPE_BACKEND,
+    GENIEX_XRAY_ENVELOPE_THERMAL,
+    GENIEX_XRAY_ENVELOPE_ENERGY,
+    GENIEX_XRAY_ENVELOPE_OUTPUT_VALIDITY,
+    GENIEX_XRAY_ENVELOPE_LIFECYCLE,
+    GENIEX_XRAY_ENVELOPE_RESIDUE
+} geniex_XrayEnvelope;
+
+#define GENIEX_XRAY_ENVELOPE_BIT(value) (UINT64_C(1) << (value))
+
+typedef struct {
+    uint32_t schema_version;
+    uint64_t timestamp_us;
+    uint64_t execution_id;
+    uint64_t module_id;
+    uint32_t module_version;
+    uint64_t input_hash;
+    uint64_t explicit_state_hash;
+    uint32_t phase;
+    uint64_t requested_route_id;
+    uint64_t selected_route_id;
+    uint64_t observed_route_id;
+    uint64_t elapsed_us;
+    uint64_t work_units;
+    uint64_t prompt_tokens_delta;
+    uint64_t generated_tokens_delta;
+    uint64_t artifact_bytes;
+    uint64_t resident_weight_bytes;
+    uint64_t kv_bytes;
+    int64_t kv_delta_bytes;
+    uint64_t runtime_bytes;
+    uint64_t peak_rss_bytes;
+    uint64_t memory_read_bytes;
+    uint64_t memory_write_bytes;
+    uint64_t energy_delta_uj;
+    uint32_t energy_confidence;
+    int32_t thermal_headroom_millic;
+    int32_t thermal_slope_millic_per_min;
+    bool throttled;
+    uint64_t active_envelopes;
+    uint64_t passed_envelopes;
+    uint32_t validation;
+    uint32_t lifecycle;
+    uint32_t live_handles;
+    uint32_t live_threads;
+    uint32_t live_file_descriptors;
+    uint32_t live_services;
+    uint32_t live_jobs;
+    uint32_t live_wake_locks;
+    uint64_t mapped_model_bytes;
+    bool output_checked;
+    bool output_valid;
+    int32_t error_code;
+    uint32_t error_envelope;
+} geniex_XrayEvent;
+
+typedef struct {
+    uint32_t schema_version;
+    bool valid;
+    uint64_t observed_phases;
+    uint64_t missing_phases;
+    uint64_t failed_envelopes;
+    uint64_t execution_id;
+    uint64_t module_id;
+    uint32_t module_version;
+    uint64_t input_hash;
+    uint64_t explicit_state_hash;
+    uint64_t requested_route_id;
+    uint64_t selected_route_id;
+    uint64_t observed_route_id;
+    uint64_t end_to_end_us;
+    uint64_t prompt_tokens;
+    uint64_t generated_tokens;
+    uint64_t energy_uj;
+    uint32_t energy_confidence;
+    bool energy_qualified;
+    double tokens_per_joule;
+    int32_t minimum_thermal_headroom_millic;
+    int32_t maximum_thermal_slope_millic_per_min;
+    bool throttled;
+    bool validation_failed;
+    bool validation_complete;
+    bool identity_complete;
+    bool identity_consistent;
+    bool output_valid;
+    uint32_t final_lifecycle;
+    uint64_t residue_count;
+    int32_t first_error_code;
+} geniex_XrayLapResult;
+
+typedef struct geniex_XrayScorer geniex_XrayScorer;
+
+geniex_XrayScorer* geniex_xray_scorer_create(void);
+void geniex_xray_scorer_destroy(geniex_XrayScorer* scorer);
+int32_t geniex_xray_scorer_record(geniex_XrayScorer* scorer, const geniex_XrayEvent* event);
+int32_t geniex_xray_scorer_finish(const geniex_XrayScorer* scorer, geniex_XrayLapResult* result);
+
+#ifdef __cplusplus
+}
+#endif

--- a/sdk/model-manager/crates/core/src/source/ai_hub/selector.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/selector.rs
@@ -7,9 +7,8 @@
 //! `cli/internal/model_hub/aihub/selector.go`:
 //!
 //! - Resolve the user-supplied chipset against `platform.json` aliases.
-//! - Filter to assets whose `runtime == RUNTIME_GENIE`. The CLI only
-//!   supports the Genie runtime (LLM / VLM domains); other assets are
-//!   rejected up front.
+//! - Filter to assets whose `runtime == RUNTIME_GENIEX_QAIRT`, matching the
+//!   runtime used to admit models into the Android QAIRT catalog.
 //! - Filter to assets whose canonical chipset matches.
 //! - If multiple precisions survive, pick the lex-first precision string
 //!   for a deterministic default. The Go CLI sorts by enum value, which
@@ -20,9 +19,8 @@
 use super::dto::{AssetDetails, ModelReleaseAssets, PlatformInfo};
 use crate::error::{Error, Result};
 
-/// Runtime string the public bucket uses for Genie-compatible assets.
-/// Matches `qaihm.Runtime_RUNTIME_GENIE`.
-const RUNTIME_GENIE: &str = "RUNTIME_GENIE";
+/// Runtime string the public bucket uses for GenieX QAIRT assets.
+const RUNTIME_GENIEX_QAIRT: &str = "RUNTIME_GENIEX_QAIRT";
 
 /// Domains the SDK currently supports — same subset the Go CLI accepts
 /// in `RuntimeForDomain`.
@@ -80,7 +78,7 @@ pub fn resolve_chipset_display(plat: &PlatformInfo, chipset: &str) -> Option<Str
     None
 }
 
-/// Pick one asset matching `(chipset, RUNTIME_GENIE)`. Returns the list of
+/// Pick one asset matching `(chipset, RUNTIME_GENIEX_QAIRT)`. Returns the list of
 /// supported chipsets (for actionable error messages) when nothing matches.
 pub fn match_asset<'a>(
     ra: &'a ModelReleaseAssets,
@@ -107,7 +105,9 @@ pub fn match_asset<'a>(
     let mut candidates: Vec<&AssetDetails> = ra
         .assets
         .iter()
-        .filter(|a| a.runtime == RUNTIME_GENIE && a.chipset.as_deref() == Some(canonical.as_str()))
+        .filter(|a| {
+            a.runtime == RUNTIME_GENIEX_QAIRT && a.chipset.as_deref() == Some(canonical.as_str())
+        })
         .collect();
 
     if candidates.is_empty() {
@@ -260,13 +260,13 @@ mod tests {
             model_id: "m".into(),
             assets: vec![
                 asset("SD8G3", "RUNTIME_TFLITE", "PRECISION_FP16"),
-                asset("SD8G3", "RUNTIME_GENIE", "PRECISION_W4A16"),
-                asset("Other", "RUNTIME_GENIE", "PRECISION_FP16"),
+                asset("SD8G3", "RUNTIME_GENIEX_QAIRT", "PRECISION_W4A16"),
+                asset("Other", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
             ],
         };
         let got = match_asset(&ra, &plat, "sm8650").unwrap();
         assert_eq!(got.chipset.as_deref(), Some("SD8G3"));
-        assert_eq!(got.runtime, "RUNTIME_GENIE");
+        assert_eq!(got.runtime, "RUNTIME_GENIEX_QAIRT");
     }
 
     #[test]
@@ -275,8 +275,8 @@ mod tests {
         let ra = ModelReleaseAssets {
             model_id: "m".into(),
             assets: vec![
-                asset("A", "RUNTIME_GENIE", "PRECISION_FP16"),
-                asset("B", "RUNTIME_GENIE", "PRECISION_FP16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
+                asset("B", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
             ],
         };
         let err = match_asset(&ra, &plat, "C").unwrap_err();
@@ -297,7 +297,7 @@ mod tests {
             model_id: "m".into(),
             assets: vec![asset(
                 "qualcomm-snapdragon-x-elite",
-                "RUNTIME_GENIE",
+                "RUNTIME_GENIEX_QAIRT",
                 "PRECISION_FP16",
             )],
         };
@@ -311,8 +311,8 @@ mod tests {
         let ra = ModelReleaseAssets {
             model_id: "m".into(),
             assets: vec![
-                asset("A", "RUNTIME_GENIE", "PRECISION_W4A16"),
-                asset("A", "RUNTIME_GENIE", "PRECISION_FP16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_W4A16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
             ],
         };
         let picked = match_asset(&ra, &plat, "A").unwrap();

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -20,6 +20,10 @@
 namespace geniex {
 
 LlamaVlm::~LlamaVlm() {
+    if (this->sampler) {
+        common_sampler_free(this->sampler);
+        this->sampler = nullptr;
+    }
     if (this->ctx) {
         llama_free(this->ctx);
         this->ctx = nullptr;
@@ -27,6 +31,10 @@ LlamaVlm::~LlamaVlm() {
     if (this->ctx_vision) {
         mtmd_free(this->ctx_vision);
         this->ctx_vision = nullptr;
+    }
+    if (this->model) {
+        llama_model_free(this->model);
+        this->model = nullptr;
     }
 }
 

--- a/sdk/src/device.cpp
+++ b/sdk/src/device.cpp
@@ -54,6 +54,14 @@ bool is_known_alias(const std::string& s) {
     return s == kAliasCPU || s == kAliasGPU || s == kAliasNPU || s == kAliasHybrid;
 }
 
+geniex_RouteId route_id(const std::string& alias) {
+    if (alias == kAliasCPU) return GENIEX_ROUTE_CPU;
+    if (alias == kAliasGPU) return GENIEX_ROUTE_GPU;
+    if (alias == kAliasNPU) return GENIEX_ROUTE_NPU;
+    if (alias == kAliasHybrid) return GENIEX_ROUTE_HYBRID;
+    return GENIEX_ROUTE_AUTO;
+}
+
 }  // namespace
 
 int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_ResolveDeviceOutput* output) {
@@ -66,6 +74,8 @@ int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_Res
     output->device_id = nullptr;
     output->ngl       = input->ngl_default;
     output->warning   = nullptr;
+    output->requested_route = GENIEX_ROUTE_AUTO;
+    output->selected_route  = GENIEX_ROUTE_AUTO;
 
     if (!input->plugin_id) {
         GENIEX_LOG_ERROR("geniex_resolve_device: plugin_id is null");
@@ -74,6 +84,7 @@ int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_Res
 
     const std::string plugin = input->plugin_id;
     std::string       alias  = to_lower_trim(input->mode);
+    output->requested_route = route_id(alias);
 
     if (!alias.empty() && alias != kAliasAuto && !is_known_alias(alias)) {
         GENIEX_LOG_ERROR("geniex_resolve_device: invalid device mode '{}'", alias);
@@ -85,14 +96,14 @@ int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_Res
     if (alias.empty() || alias == kAliasAuto) {
         alias = kAliasNPU;
     }
+    output->selected_route = route_id(alias);
 
-    // QAIRT is NPU-only and rejects any non-zero n_gpu_layers, so force
-    // ngl to 0. Non-npu aliases are coerced with a warning, not an error.
+    // QAIRT is NPU-only. Reject incompatible requests: route changes must
+    // never be a silent or warning-only fallback.
     if (plugin == kPluginQairt) {
         if (alias != kAliasNPU) {
-            std::string msg =
-                "qairt plugin only supports NPU inference; ignoring device='" + alias + "' and running on NPU";
-            output->warning = portable_strdup(msg.c_str());
+            GENIEX_LOG_ERROR("qairt plugin does not support requested route '{}'", alias);
+            return GENIEX_ERROR_COMMON_INVALID_DEVICE;
         }
         output->device_id = portable_strdup(kDeviceQairtNPU);
         output->ngl       = 0;

--- a/sdk/src/xray.cpp
+++ b/sdk/src/xray.cpp
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xray_c.h"
+
+#include <new>
+
+#include "xray.h"
+
+namespace gx = geniex::xray;
+
+struct geniex_XrayScorer {
+    gx::LapScorer scorer;
+    bool adapter_failed{false};
+};
+
+namespace {
+
+bool valid_event(const geniex_XrayEvent& event) {
+    return event.schema_version == GENIEX_XRAY_SCHEMA_VERSION &&
+           event.phase < GENIEX_XRAY_PHASE_COUNT &&
+           event.validation <= GENIEX_XRAY_VALIDATION_FAIL &&
+           event.lifecycle <= GENIEX_XRAY_LIFECYCLE_FAILED &&
+           event.energy_confidence <= GENIEX_XRAY_ENERGY_CALIBRATED &&
+           event.error_envelope <= GENIEX_XRAY_ENVELOPE_RESIDUE;
+}
+
+gx::Event convert(const geniex_XrayEvent& source) {
+    gx::Event event;
+    event.schema_version = source.schema_version;
+    event.timestamp_us = source.timestamp_us;
+    event.execution_id = source.execution_id;
+    event.module_id = source.module_id;
+    event.module_version = source.module_version;
+    event.input_hash = source.input_hash;
+    event.explicit_state_hash = source.explicit_state_hash;
+    event.phase = static_cast<gx::Phase>(source.phase);
+    event.requested_route_id = source.requested_route_id;
+    event.selected_route_id = source.selected_route_id;
+    event.observed_route_id = source.observed_route_id;
+    event.elapsed_us = source.elapsed_us;
+    event.work_units = source.work_units;
+    event.prompt_tokens_delta = source.prompt_tokens_delta;
+    event.generated_tokens_delta = source.generated_tokens_delta;
+    event.artifact_bytes = source.artifact_bytes;
+    event.resident_weight_bytes = source.resident_weight_bytes;
+    event.kv_bytes = source.kv_bytes;
+    event.kv_delta_bytes = source.kv_delta_bytes;
+    event.runtime_bytes = source.runtime_bytes;
+    event.peak_rss_bytes = source.peak_rss_bytes;
+    event.memory_read_bytes = source.memory_read_bytes;
+    event.memory_write_bytes = source.memory_write_bytes;
+    event.energy_delta_uj = source.energy_delta_uj;
+    event.energy_confidence = static_cast<gx::EnergyConfidence>(source.energy_confidence);
+    event.thermal_headroom_millic = source.thermal_headroom_millic;
+    event.thermal_slope_millic_per_min = source.thermal_slope_millic_per_min;
+    event.throttled = source.throttled;
+    event.active_envelopes = source.active_envelopes;
+    event.passed_envelopes = source.passed_envelopes;
+    event.validation = static_cast<gx::Validation>(source.validation);
+    event.lifecycle = static_cast<gx::Lifecycle>(source.lifecycle);
+    event.live_handles = source.live_handles;
+    event.live_threads = source.live_threads;
+    event.live_file_descriptors = source.live_file_descriptors;
+    event.live_services = source.live_services;
+    event.live_jobs = source.live_jobs;
+    event.live_wake_locks = source.live_wake_locks;
+    event.mapped_model_bytes = source.mapped_model_bytes;
+    event.output_checked = source.output_checked;
+    event.output_valid = source.output_valid;
+    event.error.code = source.error_code;
+    event.error.envelope = static_cast<gx::Envelope>(source.error_envelope);
+    event.error.phase = event.phase;
+    return event;
+}
+
+void convert(const gx::LapResult& source, geniex_XrayLapResult& result) {
+    result = {};
+    result.schema_version = source.schema_version;
+    result.valid = source.valid;
+    result.observed_phases = source.observed_phases;
+    result.missing_phases = source.missing_phases;
+    result.failed_envelopes = source.failed_envelopes;
+    result.execution_id = source.execution_id;
+    result.module_id = source.module_id;
+    result.module_version = source.module_version;
+    result.input_hash = source.input_hash;
+    result.explicit_state_hash = source.explicit_state_hash;
+    result.requested_route_id = source.requested_route_id;
+    result.selected_route_id = source.selected_route_id;
+    result.observed_route_id = source.observed_route_id;
+    result.end_to_end_us = source.end_to_end_us;
+    result.prompt_tokens = source.prompt_tokens;
+    result.generated_tokens = source.generated_tokens;
+    result.energy_uj = source.energy_uj;
+    result.energy_confidence = static_cast<uint32_t>(source.energy_confidence);
+    result.energy_qualified = source.energy_qualified;
+    result.tokens_per_joule = source.tokens_per_joule;
+    result.minimum_thermal_headroom_millic =
+        source.minimum_thermal_headroom_millic;
+    result.maximum_thermal_slope_millic_per_min =
+        source.maximum_thermal_slope_millic_per_min;
+    result.throttled = source.throttled;
+    result.validation_failed = source.validation_failed;
+    result.validation_complete = source.validation_complete;
+    result.identity_complete = source.identity_complete;
+    result.identity_consistent = source.identity_consistent;
+    result.output_valid = source.output_valid;
+    result.final_lifecycle = static_cast<uint32_t>(source.final_lifecycle);
+    result.residue_count = source.residue_count;
+    result.first_error_code = source.first_error.code;
+}
+
+}  // namespace
+
+extern "C" geniex_XrayScorer* geniex_xray_scorer_create(void) {
+    return new (std::nothrow) geniex_XrayScorer;
+}
+
+extern "C" void geniex_xray_scorer_destroy(geniex_XrayScorer* scorer) {
+    delete scorer;
+}
+
+extern "C" int32_t geniex_xray_scorer_record(
+    geniex_XrayScorer* scorer, const geniex_XrayEvent* event) {
+    if (!scorer || !event) return -1;
+    if (!valid_event(*event)) {
+        scorer->adapter_failed = true;
+        return -2;
+    }
+    scorer->scorer.record(convert(*event));
+    return 0;
+}
+
+extern "C" int32_t geniex_xray_scorer_finish(
+    const geniex_XrayScorer* scorer, geniex_XrayLapResult* result) {
+    if (!scorer || !result) return -1;
+    auto lap = scorer->scorer.finish();
+    if (scorer->adapter_failed) {
+        lap.valid = false;
+        lap.failed_envelopes |= gx::envelope_bit(gx::Envelope::Safety);
+    }
+    convert(lap, *result);
+    return 0;
+}

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+add_executable(geniex_xray_contract_test xray_contract_test.cpp)
+target_compile_features(geniex_xray_contract_test PRIVATE cxx_std_17)
+target_include_directories(geniex_xray_contract_test PRIVATE
+    "${CMAKE_SOURCE_DIR}/include")
+
+add_test(NAME geniex.xray.contract COMMAND geniex_xray_contract_test)

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -6,3 +6,12 @@ target_include_directories(geniex_xray_contract_test PRIVATE
     "${CMAKE_SOURCE_DIR}/include")
 
 add_test(NAME geniex.xray.contract COMMAND geniex_xray_contract_test)
+
+add_executable(geniex_xray_c_contract_test
+    xray_c_contract_test.cpp
+    ../src/xray.cpp)
+target_compile_features(geniex_xray_c_contract_test PRIVATE cxx_std_17)
+target_include_directories(geniex_xray_c_contract_test PRIVATE
+    "${CMAKE_SOURCE_DIR}/include")
+
+add_test(NAME geniex.xray.c_contract COMMAND geniex_xray_c_contract_test)

--- a/sdk/tests/CMakeLists.txt
+++ b/sdk/tests/CMakeLists.txt
@@ -15,3 +15,15 @@ target_include_directories(geniex_xray_c_contract_test PRIVATE
     "${CMAKE_SOURCE_DIR}/include")
 
 add_test(NAME geniex.xray.c_contract COMMAND geniex_xray_c_contract_test)
+
+add_executable(geniex_device_route_test
+    device_route_test.cpp
+    ../src/device.cpp
+    ../src/utils.cpp
+    ../src/error.cpp)
+target_compile_features(geniex_device_route_test PRIVATE cxx_std_17)
+target_compile_definitions(geniex_device_route_test PRIVATE
+    PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+target_include_directories(geniex_device_route_test PRIVATE
+    "${CMAKE_SOURCE_DIR}/include")
+add_test(NAME geniex.device.route COMMAND geniex_device_route_test)

--- a/sdk/tests/device_route_test.cpp
+++ b/sdk/tests/device_route_test.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BSD-3-Clause
+#include "geniex.h"
+#include "logging.h"
+#include <cstdlib>
+#include <iostream>
+
+geniex_log_callback geniex_log = nullptr;
+geniex_LogLevel geniex_log_level = GENIEX_LOG_LEVEL_TRACE;
+extern "C" void geniex_free(void* ptr) { std::free(ptr); }
+namespace { int failures=0; void check(bool v,const char* e,int l){if(!v){++failures;std::cerr<<"CHECK failed "<<l<<": "<<e<<'\n';}} }
+#define CHECK(x) check(!!(x),#x,__LINE__)
+int main(){
+ geniex_ResolveDeviceInput in{"llama_cpp",nullptr,"gpu",-1}; geniex_ResolveDeviceOutput out{};
+ CHECK(geniex_resolve_device(&in,&out)==GENIEX_SUCCESS);
+ CHECK(out.requested_route==GENIEX_ROUTE_GPU); CHECK(out.selected_route==GENIEX_ROUTE_GPU);
+ if(out.device_id) geniex_free(out.device_id); if(out.warning) geniex_free(out.warning);
+ in.plugin_id="qairt"; in.mode="cpu"; out={};
+ CHECK(geniex_resolve_device(&in,&out)==GENIEX_ERROR_COMMON_INVALID_DEVICE);
+ in.mode="auto"; out={}; CHECK(geniex_resolve_device(&in,&out)==GENIEX_SUCCESS);
+ CHECK(out.requested_route==GENIEX_ROUTE_AUTO); CHECK(out.selected_route==GENIEX_ROUTE_NPU);
+ if(out.device_id) geniex_free(out.device_id); if(out.warning) geniex_free(out.warning);
+ return failures?1:0;
+}

--- a/sdk/tests/xray_c_contract_test.cpp
+++ b/sdk/tests/xray_c_contract_test.cpp
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xray_c.h"
+
+#include <cstdint>
+#include <iostream>
+
+namespace {
+int failures = 0;
+void check(bool condition, const char* expression, int line) {
+    if (condition) return;
+    ++failures;
+    std::cerr << "CHECK failed at line " << line << ": " << expression << '\n';
+}
+#define CHECK(expression) check(static_cast<bool>(expression), #expression, __LINE__)
+
+constexpr uint64_t all_envelopes =
+    (UINT64_C(1) << (GENIEX_XRAY_ENVELOPE_RESIDUE + 1)) - 1;
+
+geniex_XrayEvent passing_event(uint32_t phase, uint64_t timestamp) {
+    geniex_XrayEvent event{};
+    event.schema_version = GENIEX_XRAY_SCHEMA_VERSION;
+    event.timestamp_us = timestamp;
+    event.execution_id = 7;
+    event.module_id = 5;
+    event.module_version = 1;
+    event.input_hash = 13;
+    event.explicit_state_hash = 17 + phase;
+    event.phase = phase;
+    event.requested_route_id = 11;
+    event.selected_route_id = 11;
+    event.observed_route_id = 11;
+    event.elapsed_us = 100;
+    event.work_units = 1;
+    event.energy_confidence = GENIEX_XRAY_ENERGY_UNAVAILABLE;
+    event.thermal_headroom_millic = 5000;
+    event.active_envelopes = all_envelopes;
+    event.passed_envelopes = all_envelopes;
+    event.validation = GENIEX_XRAY_VALIDATION_PASS;
+    event.lifecycle = GENIEX_XRAY_LIFECYCLE_RUNNING;
+    event.error_envelope = GENIEX_XRAY_ENVELOPE_RUNTIME;
+    return event;
+}
+
+void test_valid_lap() {
+    auto* scorer = geniex_xray_scorer_create();
+    CHECK(scorer != nullptr);
+    for (uint32_t phase = 0; phase < GENIEX_XRAY_PHASE_COUNT; ++phase) {
+        auto event = passing_event(phase, 1000 + phase * 100);
+        if (phase == GENIEX_XRAY_PREFILL) event.prompt_tokens_delta = 32;
+        if (phase == GENIEX_XRAY_DECODE) {
+            event.generated_tokens_delta = 128;
+            event.energy_delta_uj = 1000000;
+            event.energy_confidence = GENIEX_XRAY_ENERGY_MEASURED;
+            event.output_checked = true;
+            event.output_valid = true;
+        }
+        if (phase == GENIEX_XRAY_RECOVERY)
+            event.lifecycle = GENIEX_XRAY_LIFECYCLE_RELEASED;
+        CHECK(geniex_xray_scorer_record(scorer, &event) == 0);
+    }
+    geniex_XrayLapResult result{};
+    CHECK(geniex_xray_scorer_finish(scorer, &result) == 0);
+    CHECK(result.valid);
+    CHECK(result.tokens_per_joule == 128.0);
+    CHECK(result.requested_route_id == 11);
+    CHECK(result.selected_route_id == 11);
+    CHECK(result.observed_route_id == 11);
+    CHECK(result.validation_complete);
+    CHECK(result.identity_complete);
+    CHECK(result.identity_consistent);
+    CHECK(result.minimum_thermal_headroom_millic == 5000);
+    geniex_xray_scorer_destroy(scorer);
+}
+
+void test_adapter_and_contract_fail_closed() {
+    auto* scorer = geniex_xray_scorer_create();
+    auto invalid = passing_event(GENIEX_XRAY_PHASE_COUNT, 1);
+    CHECK(geniex_xray_scorer_record(scorer, &invalid) == -2);
+    geniex_XrayLapResult result{};
+    CHECK(geniex_xray_scorer_finish(scorer, &result) == 0);
+    CHECK(!result.valid);
+    CHECK((result.failed_envelopes &
+           GENIEX_XRAY_ENVELOPE_BIT(GENIEX_XRAY_ENVELOPE_SAFETY)) != 0);
+    geniex_xray_scorer_destroy(scorer);
+
+    scorer = geniex_xray_scorer_create();
+    auto failed = passing_event(GENIEX_XRAY_STARTUP, 1);
+    failed.validation = GENIEX_XRAY_VALIDATION_FAIL;
+    failed.error_code = 0;
+    CHECK(geniex_xray_scorer_record(scorer, &failed) == 0);
+    CHECK(geniex_xray_scorer_finish(scorer, &result) == 0);
+    CHECK(result.validation_failed);
+    CHECK(!result.valid);
+    geniex_xray_scorer_destroy(scorer);
+
+    scorer = geniex_xray_scorer_create();
+    auto first = passing_event(GENIEX_XRAY_STARTUP, 1);
+    auto drift = passing_event(GENIEX_XRAY_RESIDENCY, 2);
+    drift.observed_route_id = 12;
+    CHECK(geniex_xray_scorer_record(scorer, &first) == 0);
+    CHECK(geniex_xray_scorer_record(scorer, &drift) == 0);
+    CHECK(geniex_xray_scorer_finish(scorer, &result) == 0);
+    CHECK(!result.identity_consistent);
+    CHECK(!result.valid);
+    geniex_xray_scorer_destroy(scorer);
+}
+
+void test_unqualified_energy_never_claims_efficiency() {
+    auto* scorer = geniex_xray_scorer_create();
+    auto event = passing_event(GENIEX_XRAY_DECODE, 1);
+    event.generated_tokens_delta = 32;
+    event.energy_delta_uj = 1000;
+    event.energy_confidence = GENIEX_XRAY_ENERGY_ESTIMATED;
+    CHECK(geniex_xray_scorer_record(scorer, &event) == 0);
+    geniex_XrayLapResult result{};
+    CHECK(geniex_xray_scorer_finish(scorer, &result) == 0);
+    CHECK(!result.energy_qualified);
+    CHECK(result.tokens_per_joule == 0.0);
+    geniex_xray_scorer_destroy(scorer);
+}
+}  // namespace
+
+int main() {
+    test_valid_lap();
+    test_adapter_and_contract_fail_closed();
+    test_unqualified_energy_never_claims_efficiency();
+    if (failures != 0) {
+        std::cerr << failures << " Xray C adapter test(s) failed\n";
+        return 1;
+    }
+    std::cout << "Xray C adapter tests passed\n";
+    return 0;
+}

--- a/sdk/tests/xray_contract_test.cpp
+++ b/sdk/tests/xray_contract_test.cpp
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "xray.h"
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+
+using namespace geniex::xray;
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* expression, int line) {
+    if (condition) return;
+    ++failures;
+    std::cerr << "CHECK failed at line " << line << ": " << expression << '\n';
+}
+
+#define CHECK(expression) check(static_cast<bool>(expression), #expression, __LINE__)
+
+constexpr uint64_t kAllEnvelopes =
+    envelope_bit(Envelope::Artifact) | envelope_bit(Envelope::Storage) |
+    envelope_bit(Envelope::PeakRam) | envelope_bit(Envelope::ResidentWeights) |
+    envelope_bit(Envelope::DynamicKv) | envelope_bit(Envelope::Context) |
+    envelope_bit(Envelope::Runtime) | envelope_bit(Envelope::Safety) |
+    envelope_bit(Envelope::Backend) | envelope_bit(Envelope::Thermal) |
+    envelope_bit(Envelope::Energy) | envelope_bit(Envelope::OutputValidity) |
+    envelope_bit(Envelope::Lifecycle) | envelope_bit(Envelope::Residue);
+
+Event passing_event(Phase phase, uint64_t timestamp) {
+    Event event;
+    event.timestamp_us = timestamp;
+    event.execution_id = 7;
+    event.module_id = 5;
+    event.module_version = 1;
+    event.input_hash = 13;
+    event.explicit_state_hash = 17 + static_cast<uint8_t>(phase);
+    event.phase = phase;
+    event.requested_route_id = 11;
+    event.selected_route_id = 11;
+    event.observed_route_id = 11;
+    event.elapsed_us = 100;
+    event.work_units = 1;
+    event.active_envelopes = kAllEnvelopes;
+    event.passed_envelopes = kAllEnvelopes;
+    event.validation = Validation::Pass;
+    event.lifecycle = Lifecycle::Running;
+    event.thermal_headroom_millic = 5000;
+    return event;
+}
+
+LapResult valid_lap(uint64_t decode_elapsed_us = 100) {
+    LapScorer scorer;
+    uint64_t timestamp = 1000;
+    for (uint8_t raw = 0; raw < static_cast<uint8_t>(Phase::Count); ++raw) {
+        auto event = passing_event(static_cast<Phase>(raw), timestamp);
+        timestamp += 100;
+        if (event.phase == Phase::Prefill) event.prompt_tokens_delta = 32;
+        if (event.phase == Phase::Decode) {
+            event.generated_tokens_delta = 128;
+            event.energy_delta_uj = 1000000;
+            event.energy_confidence = EnergyConfidence::Measured;
+            event.output_checked = true;
+            event.output_valid = true;
+            event.elapsed_us = decode_elapsed_us;
+        }
+        if (event.phase == Phase::Recovery) {
+            event.lifecycle = Lifecycle::Released;
+            event.live_handles = 0;
+            event.live_threads = 0;
+            event.live_file_descriptors = 0;
+            event.live_services = 0;
+            event.live_jobs = 0;
+            event.live_wake_locks = 0;
+            event.mapped_model_bytes = 0;
+        }
+        scorer.record(event);
+    }
+    return scorer.finish();
+}
+
+void test_valid_full_lap() {
+    const auto result = valid_lap();
+    CHECK(result.valid);
+    CHECK(result.missing_phases == 0);
+    CHECK(result.failed_envelopes == 0);
+    CHECK(result.generated_tokens == 128);
+    CHECK(result.energy_confidence == EnergyConfidence::Measured);
+    CHECK(result.energy_qualified);
+    CHECK(result.tokens_per_joule == 128.0);
+    CHECK(result.identity_complete);
+    CHECK(result.identity_consistent);
+    CHECK(result.execution_id == 7);
+    CHECK(result.module_id == 5);
+    CHECK(result.module_version == 1);
+    CHECK(result.input_hash == 13);
+    CHECK(result.requested_route_id == 11);
+    CHECK(result.selected_route_id == 11);
+    CHECK(result.observed_route_id == 11);
+    CHECK(result.final_lifecycle == Lifecycle::Released);
+    CHECK(result.residue_count == 0);
+}
+
+void test_missing_phase_fails_closed() {
+    LapScorer scorer;
+    scorer.record(passing_event(Phase::Startup, 1));
+    const auto result = scorer.finish();
+    CHECK(!result.valid);
+    CHECK((result.missing_phases & phase_bit(Phase::Recovery)) != 0);
+}
+
+void test_unknown_active_envelope_fails_closed() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::Startup, 1);
+    event.passed_envelopes &= ~envelope_bit(Envelope::PeakRam);
+    scorer.record(event);
+    const auto result = scorer.finish();
+    CHECK(!result.valid);
+    CHECK((result.failed_envelopes & envelope_bit(Envelope::PeakRam)) != 0);
+}
+
+void test_explicit_fail_cannot_be_masked() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::Startup, 1);
+    event.validation = Validation::Fail;
+    event.error = {0, Envelope::Runtime, Phase::Startup};
+    scorer.record(event);
+    const auto result = scorer.finish();
+    CHECK(result.validation_failed);
+    CHECK((result.failed_envelopes & envelope_bit(Envelope::Runtime)) != 0);
+    CHECK(!result.valid);
+}
+
+void test_unknown_validation_fails_closed() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::Startup, 1);
+    event.validation = Validation::Unknown;
+    scorer.record(event);
+    const auto result = scorer.finish();
+    CHECK(!result.validation_complete);
+    CHECK((result.failed_envelopes & envelope_bit(Envelope::Runtime)) != 0);
+    CHECK(!result.valid);
+}
+
+void test_throttling_fails_endurance() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::ThermalEquilibrium, 1);
+    event.throttled = true;
+    scorer.record(event);
+    CHECK(scorer.finish().throttled);
+    CHECK(!scorer.finish().valid);
+}
+
+void test_recovery_residue_fails() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::Recovery, 1);
+    event.lifecycle = Lifecycle::Released;
+    event.live_handles = 1;
+    scorer.record(event);
+    const auto result = scorer.finish();
+    CHECK(result.residue_count == 1);
+    CHECK(!result.valid);
+}
+
+void test_later_invalid_output_cannot_be_masked() {
+    LapScorer scorer;
+    auto valid_output = passing_event(Phase::Decode, 1);
+    valid_output.output_checked = true;
+    valid_output.output_valid = true;
+    scorer.record(valid_output);
+    auto invalid_output = passing_event(Phase::Decode, 2);
+    invalid_output.output_checked = true;
+    invalid_output.output_valid = false;
+    scorer.record(invalid_output);
+    const auto result = scorer.finish();
+    CHECK(!result.output_valid);
+    CHECK((result.failed_envelopes & envelope_bit(Envelope::OutputValidity)) != 0);
+}
+
+void test_energy_requires_authoritative_measurement() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::Decode, 1);
+    event.generated_tokens_delta = 128;
+    event.energy_delta_uj = 1000000;
+    event.energy_confidence = EnergyConfidence::Estimated;
+    scorer.record(event);
+    const auto result = scorer.finish();
+    CHECK(result.energy_confidence == EnergyConfidence::Estimated);
+    CHECK(!result.energy_qualified);
+    CHECK((result.failed_envelopes & envelope_bit(Envelope::Energy)) != 0);
+    CHECK(!result.valid);
+}
+
+void test_zero_energy_never_claims_efficiency() {
+    LapScorer scorer;
+    scorer.record(passing_event(Phase::Decode, 1));
+    const auto result = scorer.finish();
+    CHECK(result.energy_confidence == EnergyConfidence::Unavailable);
+    CHECK(!result.energy_qualified);
+    CHECK(result.tokens_per_joule == 0.0);
+}
+
+void test_identity_and_route_fields_are_mandatory() {
+    LapScorer scorer;
+    auto event = passing_event(Phase::Startup, 1);
+    event.observed_route_id = 0;
+    scorer.record(event);
+    const auto result = scorer.finish();
+    CHECK(!result.identity_complete);
+    CHECK((result.failed_envelopes & envelope_bit(Envelope::Safety)) != 0);
+    CHECK(!result.valid);
+
+    LapScorer drift_scorer;
+    drift_scorer.record(passing_event(Phase::Startup, 1));
+    auto drift = passing_event(Phase::Residency, 2);
+    drift.observed_route_id = 12;
+    drift_scorer.record(drift);
+    const auto drift_result = drift_scorer.finish();
+    CHECK(!drift_result.identity_consistent);
+    CHECK((drift_result.failed_envelopes & envelope_bit(Envelope::Safety)) != 0);
+}
+
+void test_validity_precedes_speed() {
+    const auto slower_valid = valid_lap(1000);
+    auto invalid = valid_lap(10);
+    invalid.valid = false;
+    invalid.failed_envelopes = envelope_bit(Envelope::OutputValidity);
+    CHECK(slower_valid.better_than(invalid));
+
+    const auto faster_valid = valid_lap(10);
+    CHECK(faster_valid.better_than(slower_valid));
+}
+
+class CountingSink final : public Sink {
+public:
+    void emit(const Event&) noexcept override { ++count; }
+    uint64_t count{0};
+};
+
+uint64_t benchmark_recorder(Recorder& recorder, const Event& event, uint64_t iterations) {
+    const auto start = std::chrono::steady_clock::now();
+    for (uint64_t i = 0; i < iterations; ++i) recorder.record(event);
+    const auto end = std::chrono::steady_clock::now();
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count());
+}
+
+void test_counters_and_measured_overhead() {
+    constexpr uint64_t iterations = 200000;
+    auto event = passing_event(Phase::Decode, 1);
+    event.elapsed_us = 4;
+    event.work_units = 2;
+    event.kv_bytes = 4096;
+    event.peak_rss_bytes = 8192;
+
+    Recorder off(Mode::Off);
+    Recorder light(Mode::Light);
+    CountingSink sink;
+    Recorder deep(Mode::Deep, &sink);
+
+    const auto off_ns = benchmark_recorder(off, event, iterations);
+    const auto light_ns = benchmark_recorder(light, event, iterations);
+    const auto deep_ns = benchmark_recorder(deep, event, iterations);
+
+    const auto snapshot = light.snapshot();
+    const auto index = static_cast<size_t>(Phase::Decode);
+    CHECK(snapshot.events[index] == iterations);
+    CHECK(snapshot.elapsed_us[index] == iterations * 4);
+    CHECK(snapshot.work_units[index] == iterations * 2);
+    CHECK(snapshot.max_kv_bytes == 4096);
+    CHECK(snapshot.peak_rss_bytes == 8192);
+    CHECK(sink.count == iterations);
+
+    const double off_per_event = static_cast<double>(off_ns) / iterations;
+    const double light_per_event = static_cast<double>(light_ns) / iterations;
+    const double deep_per_event = static_cast<double>(deep_ns) / iterations;
+    std::cout << "xray overhead ns/event: off=" << off_per_event
+              << " light=" << light_per_event
+              << " deep=" << deep_per_event << '\n';
+
+    // Report only. Device-specific, statistically derived budgets are separate gates.
+}
+
+}  // namespace
+
+int main() {
+    test_valid_full_lap();
+    test_missing_phase_fails_closed();
+    test_unknown_active_envelope_fails_closed();
+    test_explicit_fail_cannot_be_masked();
+    test_unknown_validation_fails_closed();
+    test_throttling_fails_endurance();
+    test_recovery_residue_fails();
+    test_later_invalid_output_cannot_be_masked();
+    test_energy_requires_authoritative_measurement();
+    test_zero_energy_never_claims_efficiency();
+    test_identity_and_route_fields_are_mandatory();
+    test_validity_precedes_speed();
+    test_counters_and_measured_overhead();
+    if (failures != 0) {
+        std::cerr << failures << " xray contract test(s) failed\n";
+        return 1;
+    }
+    std::cout << "xray contract tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- serialize Android LLM/VLM handle operations and make stop/destroy lifecycle safe
- reject invalid native handles and release llama.cpp VLM sampler/model resources
- select GenieX QAIRT assets consistently in the model manager
- add a versioned, fail-closed Xray full-lap contract with focused regression tests

## Why

The Android demo needs deterministic cleanup, causal validation, and workload-level evidence instead of relying on short peak throughput measurements. These changes address native handle races and resource residue while establishing the initial lightweight/deep Xray measurement contract.

## Validation

- C++17 Xray contract tests passed in an NDEBUG build
- Xray contract tests passed with UBSan
- git diff --check passed
- focused Rust selector tests could not link in the current Android/Termux environment because host linker libraries liblog and libunwind were unavailable
- ASan could not reserve its shadow address space under Termux/proot; this occurred before test execution

## Scope

This is the reviewed Patch 1 and lifecycle correction set. It does not begin Patch 2 or claim production/device endurance completion.
