### PR TITLE
docs(docs): document audio input across CLI, server, and Python

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -96,7 +96,8 @@
             "group": "Tutorials",
             "icon": "graduation-cap",
             "pages": [
-              "en/tutorials/speculative-decoding-mtp"
+              "en/tutorials/speculative-decoding-mtp",
+              "en/tutorials/audio-input"
             ]
           },
           {

--- a/docs/en/models/supported.mdx
+++ b/docs/en/models/supported.mdx
@@ -10,6 +10,16 @@ There are two places to get models, matching GenieX's two [runtimes](/en/get-sta
 - **[Qualcomm AI Hub](https://aihub.qualcomm.com/models/)** — pre-compiled bundles for Qualcomm AI Engine Direct, plus curated GGUF models for llama.cpp.
 - **[Hugging Face](https://huggingface.co/models?library=gguf)** — any GGUF model for llama.cpp. See [Run a GGUF model from Hugging Face](#run-a-gguf-model-from-hugging-face).
 
+## **Input modalities**
+
+| Modality | Supported by | Notes |
+|---|---|---|
+| Text | LLM, VLM | Every model. |
+| Image | VLM | Any VLM (QAIRT bundle or GGUF with an image mmproj). |
+| Audio | VLM (llama.cpp only) | A GGUF VLM whose mmproj carries a conformer encoder — e.g. `google/gemma-4-E2B-it-qat-q4_0-gguf`. QAIRT bundles do not support audio. See the [audio input tutorial](/en/tutorials/audio-input). |
+
+A single VLM turn can mix text, image, and audio. See the [audio input tutorial](/en/tutorials/audio-input) for verified CLI, server, and Python examples.
+
 ## **Run a Qualcomm AI Hub Model**
 
 For a model in the `ai-hub-models/*` namespace, just `geniex infer` it:

--- a/docs/en/run/cli/local-server.mdx
+++ b/docs/en/run/cli/local-server.mdx
@@ -31,7 +31,7 @@ The server runs on `http://127.0.0.1:18181` by default. Keep this terminal open 
 
 ## **POST /v1/chat/completions**
 
-Creates a model response for a conversation. Supports LLM (text-only) and VLM (image + text).
+Creates a model response for a conversation. Supports LLM (text-only) and VLM (text + image or audio).
 
 ### **LLM request**
 
@@ -65,34 +65,77 @@ Open `http://127.0.0.1:18181` in your browser to access the built-in Swagger UI.
 
 ### **VLM request**
 
-`image_url.url` accepts three formats:
+A VLM accepts multimodal content parts alongside text. Use `image_url` for images, and `input_audio` for audio on a model whose mmproj carries a conformer encoder (e.g. `google/gemma-4-E2B-it-qat-q4_0-gguf`). Both `image_url.url` and `input_audio.data` accept the same three formats:
 
-| Format | Example |
-|---|---|
-| Local file path (the `file://` prefix is optional) | `C:/Users/Username/Pictures/photo.jpg`, `file:///tmp/photo.jpg` |
-| HTTP / HTTPS URL — fetched by the server | `https://example.com/image.jpg` |
-| Base64 data URL — inline image bytes | `data:image/png;base64,iVBORw0KGgo...` |
+| Format | Image example | Audio example |
+|---|---|---|
+| Local file path (the `file://` prefix is optional) | `C:/Users/Username/Pictures/photo.jpg` | `/data/jfk.wav`, `file:///tmp/jfk.wav` |
+| HTTP / HTTPS URL — fetched by the server | `https://example.com/image.jpg` | `https://example.com/clip.mp3` |
+| Base64 data URL — inline bytes | `data:image/png;base64,iVBORw0KGgo...` | `data:audio/wav;base64,UklGR...` |
 
 <Note>
-**Running in Docker?** Local paths are resolved **inside the container**, not on your host. The install command already mounts `$PWD/data` to `/data` — drop your images there and pass `/data/cat.jpg`. Alternatively, use an HTTP URL or base64 data URL to skip the filesystem entirely.
+**Running in Docker?** Local paths are resolved **inside the container**, not on your host. The install command already mounts `$PWD/data` to `/data` — drop your images and audio files there and pass `/data/cat.jpg` / `/data/jfk.wav`. Alternatively, use an HTTP URL or base64 data URL to skip the filesystem entirely.
 </Note>
 
-```json Example Value
-{
-  "model": "ai-hub-models/Qwen2.5-VL-7B-Instruct",
-  "messages": [
-    {
-      "role": "user",
-      "content": [
-        {"type": "text", "text": "Describe this image succinctly."},
-        {"type": "image_url", "image_url": {"url": "</path/to/image>"}}
-      ]
-    }
-  ]
-}
+<Warning>Audio input runs on the **llama.cpp** backend only. QAIRT models report `audio: false` and a QAIRT model given audio fails with `GenieXError(-201201): Multimodal generation failed`.</Warning>
+
+A single message can mix `image_url` and `input_audio` parts. Pull an audio-capable model and grab a sample clip:
+
+```bash
+geniex pull google/gemma-4-E2B-it-qat-q4_0-gguf
+curl -L -o jfk.wav https://github.com/ggml-org/whisper.cpp/raw/master/samples/jfk.wav
+curl -L -o landmark.jpg "https://images.pexels.com/photos/402028/pexels-photo-402028.jpeg?w=1024"
 ```
 
-In Swagger UI, replace the request body with this VLM payload, point `image_url.url` to a local image, then click **Execute**.
+```bash
+curl http://127.0.0.1:18181/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-4-E2B-it-qat-q4_0-gguf",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "text", "text": "Describe the image, then transcribe the audio."},
+          {"type": "image_url", "image_url": {"url": "/full/path/to/landmark.jpg"}},
+          {"type": "input_audio", "input_audio": {"data": "/full/path/to/jfk.wav"}}
+        ]
+      }
+    ],
+    "max_tokens": 256
+  }'
+```
+
+The same request from the Python `openai` client:
+
+```python
+resp = client.chat.completions.create(
+    model="google/gemma-4-E2B-it-qat-q4_0-gguf",
+    messages=[
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe the image, then transcribe the audio."},
+                {"type": "image_url", "image_url": {"url": "/full/path/to/landmark.jpg"}},
+                {"type": "input_audio", "input_audio": {"data": "/full/path/to/jfk.wav"}},
+            ],
+        }
+    ],
+    max_tokens=256,
+)
+print(resp.choices[0].message.content)
+```
+
+Output (verified on `--compute npu`, Snapdragon X Elite):
+
+```text
+This is a photograph featuring a traditional Japanese temple ... In the background, there are softer, blue-toned mountains and a distant urban skyline.
+
+**Transcription:**
+And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.
+```
+
+In Swagger UI, replace the request body with a VLM payload like the one above, point the paths at local files, then click **Execute**.
 
 ![Editing the VLM request body in Try-it-out mode before executing](/Images/server/curl-4.png)
 

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -75,17 +75,37 @@ geniex infer ai-hub-models/Qwen3-4B --compute npu
 
 ### **`geniex infer` — VLM**
 
-Run vision-language inference with text-only or image input:
+Run vision-language inference with text-only, image, or audio input:
 
 ```bash
-geniex infer ai-hub-models/Qwen2.5-VL-7B-Instruct-GGUF
+geniex infer google/gemma-4-E2B-it-qat-q4_0-gguf
 ```
 
-For text-only, just launch and chat. For image input, provide the **absolute path** or drag the file into your terminal:
+For text-only, just launch and chat. For image or audio input, provide the **absolute path** or drag the file into your terminal — image (`.jpg`, `.jpeg`, `.png`, `.webp`) and audio (`.wav`, `.mp3`) paths are auto-detected, and a single prompt can carry both. `google/gemma-4-E2B-it-qat-q4_0-gguf` ships an audio-capable mmproj (~4.0 GiB total: `Q4_0` weights + conformer mmproj, pulled together):
 
 ```bash
-Describe this picture </full/path/to/image.png>
+geniex pull google/gemma-4-E2B-it-qat-q4_0-gguf
+
+curl -L -o jfk.wav https://github.com/ggml-org/whisper.cpp/raw/master/samples/jfk.wav
+curl -L -o landmark.jpg "https://images.pexels.com/photos/402028/pexels-photo-402028.jpeg?w=1024"
+
+geniex infer google/gemma-4-E2B-it-qat-q4_0-gguf \
+  -p "Describe the image and transcribe the audio. Image: /full/path/to/landmark.jpg Audio: /full/path/to/jfk.wav"
 ```
+
+Output (verified on `--compute npu`, Snapdragon X Elite):
+
+```text
+**Image Description:**
+This is a scenic, panoramic photograph that features a traditional Japanese temple ... The overall mood of the image is serene and beautiful.
+
+**Audio Transcription:**
+"And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country."
+```
+
+<Warning>Audio input runs on the **llama.cpp** backend only and needs an audio-capable model (mmproj with a conformer encoder). Audio also runs on `--compute cpu` / `gpu`, but QAIRT models report `audio: false` and a QAIRT model given audio fails with `GenieXError(-201201): Multimodal generation failed`.</Warning>
+
+In an interactive session with an audio-capable model, `/mic` records a clip instead of loading one from disk — `Ctrl-C` stops the recording and transcribes it. This needs **SoX** on your `PATH` (`sudo apt install sox`, or `winget install --id=ChrisBagwell.SoX -e` on Windows); without it GenieX warns `SoX is not installed` at startup. See the [audio input tutorial](/en/tutorials/audio-input) for the full walkthrough.
 
 ## **`geniex serve`**
 

--- a/docs/en/run/python/quickstart.mdx
+++ b/docs/en/run/python/quickstart.mdx
@@ -114,6 +114,62 @@ for chunk in streamer:
 model.close()
 ```
 
+## **Audio inference (GGUF)**
+
+Audio input runs on the **llama.cpp** backend with an audio-capable model — its mmproj must carry a conformer encoder. `google/gemma-4-E2B-it-qat-q4_0-gguf` is one such model. Load it with `AutoModelForVision2Seq`, then pass file paths to `generate(images=[...], audios=[...])` — a single call can carry both.
+
+<Warning>Audio input runs on the **llama.cpp** backend only. QAIRT bundles report `capabilities()['audio'] == False` and raise `GenieXError(-201201): Multimodal generation failed` if given audio.</Warning>
+
+Download a sample clip and photo:
+
+```bash
+curl -L -o jfk.wav https://github.com/ggml-org/whisper.cpp/raw/master/samples/jfk.wav
+curl -L -o landmark.jpg "https://images.pexels.com/photos/402028/pexels-photo-402028.jpeg?w=1024"
+```
+
+Then run inference:
+
+```python
+import os
+from geniex import AutoModelForVision2Seq
+
+image_path = os.path.abspath("landmark.jpg")
+audio_path = os.path.abspath("jfk.wav")
+
+model = AutoModelForVision2Seq.from_pretrained(
+    "google/gemma-4-E2B-it-qat-q4_0-gguf",  # GGUF VLM with an audio mmproj
+    device_map="npu",                       # audio runs on npu / gpu / cpu, not qairt
+)
+# capabilities() confirms the loaded mmproj handles audio.
+print(model.capabilities())  # -> {'vision': True, 'audio': True}
+
+messages = [{
+    "role": "user",
+    "content": [
+        {"type": "image", "image": image_path},
+        {"type": "audio", "audio": audio_path},
+        {"type": "text", "text": "Describe the image, then transcribe the audio."},
+    ],
+}]
+prompt = model.tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True,
+)
+
+output = model.generate(prompt, images=[image_path], audios=[audio_path], max_new_tokens=256)
+print(output.text)
+
+model.close()
+```
+
+Output (verified on `device_map="npu"`, Snapdragon X Elite):
+
+```text
+A photograph captures a stunning landscape featuring a traditional Japanese temple ... framed by softer, muted blue and green mountains under a clear, pale sky.
+
+**Audio Transcription:**
+"And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country."
+```
+
 ## **Jupyter notebook walkthrough**
 
 For laptop users, follow the step-by-step Jupyter notebook at [examples/python/windows.ipynb](https://github.com/qualcomm/GenieX/blob/main/examples/python/windows.ipynb) — it covers environment setup and inference end-to-end.

--- a/docs/en/tutorials/audio-input.mdx
+++ b/docs/en/tutorials/audio-input.mdx
@@ -1,0 +1,166 @@
+---
+title: "Audio input"
+description: "Transcribe and reason over audio on-device with an audio-capable VLM, in the GenieX CLI, local server, and Python SDK."
+---
+
+import Feedback from "/snippets/page-feedback.mdx";
+
+A vision-language model whose multimodal projector carries a **conformer audio encoder** can take audio alongside text and images. GenieX feeds the clip through llama.cpp's mtmd (multimodal) path — the same mechanism that handles images — so a single turn can mix text, image, and audio.
+
+<Note>Audio is the **`llama_cpp`** path only. QAIRT bundles report `audio: false` and a QAIRT model given audio fails with `GenieXError(-201201): Multimodal generation failed`. Audio runs on `--compute npu` / `gpu` / `cpu`; the NPU is the default and fast path on Snapdragon.</Note>
+
+## **Step 1: Pull an audio-capable model**
+
+Audio support is not a metadata flag — it means the mmproj GGUF actually contains an audio encoder. `google/gemma-4-E2B-it-qat-q4_0-gguf` ships one: the `Q4_0` weights (≈3.1 GiB) and the conformer mmproj (≈0.9 GiB) are pulled together, ~4.0 GiB total.
+
+```bash
+geniex pull google/gemma-4-E2B-it-qat-q4_0-gguf
+```
+
+Grab a sample clip and photo to use in the examples below:
+
+```bash
+curl -L -o jfk.wav https://github.com/ggml-org/whisper.cpp/raw/master/samples/jfk.wav
+curl -L -o landmark.jpg "https://images.pexels.com/photos/402028/pexels-photo-402028.jpeg?w=1024"
+```
+
+## **Step 2: Run it with `geniex infer`**
+
+Drop an **absolute** `.wav` / `.mp3` path into the prompt (or drag the file into your terminal). Audio and image paths are auto-detected, and one prompt can carry both:
+
+```bash
+geniex infer google/gemma-4-E2B-it-qat-q4_0-gguf \
+  -p "Describe the image and transcribe the audio. Image: /full/path/to/landmark.jpg Audio: /full/path/to/jfk.wav"
+```
+
+Output (verified on `--compute npu`, Snapdragon X Elite):
+
+```text
+**Image Description:**
+This is a scenic, panoramic photograph that features a traditional Japanese temple ... The overall mood of the image is serene and beautiful.
+
+**Audio Transcription:**
+"And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country."
+```
+
+### Record from the microphone with `/mic`
+
+In an interactive session (launch `geniex infer <model>` with no `-p`), the `/mic` command records a clip and feeds it straight in — handy when you don't have a file on disk. It only appears when the loaded model supports audio.
+
+```text
+> /mic
+Recording is going on, press Ctrl-C to stop
+```
+
+`Ctrl-C` stops the recording; GenieX saves it to a temp `.wav` and transcribes it.
+
+<Warning>
+`/mic` needs **SoX** on your `PATH`. Without it, GenieX prints `SoX is not installed, some features may not work` at startup. Install it:
+
+```bash
+sudo apt install sox       # Debian/Ubuntu
+sudo yum install sox       # RHEL/CentOS/Fedora
+sudo pacman -S sox         # Arch Linux
+```
+
+```powershell
+winget install --id=ChrisBagwell.SoX -e
+# then restart your terminal so sox is on PATH
+```
+</Warning>
+
+## **Step 3: Use it on the local server**
+
+Start the server and send an OpenAI-compatible `input_audio` content part. `input_audio.data` takes the same three formats as an image URL — a local path, an HTTP/HTTPS URL, or a base64 data URL. A single message can mix `image_url` and `input_audio`:
+
+```bash
+geniex serve
+```
+
+```bash
+curl http://127.0.0.1:18181/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-4-E2B-it-qat-q4_0-gguf",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "text", "text": "Describe the image, then transcribe the audio."},
+          {"type": "image_url", "image_url": {"url": "/full/path/to/landmark.jpg"}},
+          {"type": "input_audio", "input_audio": {"data": "/full/path/to/jfk.wav"}}
+        ]
+      }
+    ],
+    "max_tokens": 256
+  }'
+```
+
+<Warning>**Running in Docker?** Local paths are resolved **inside the container**. The install command mounts `$PWD/data` to `/data` — drop your files there and pass `/data/jfk.wav`, or use an HTTP URL / base64 data URL to skip the filesystem entirely.</Warning>
+
+See [Local server](/en/run/cli/local-server#vlm-request) for the full request shape and the Python `openai`-client equivalent.
+
+## **Step 4: Use it from the Python SDK**
+
+Load with `AutoModelForVision2Seq` and pass paths to `generate(images=[...], audios=[...])` — a single call can carry both. `capabilities()` confirms the mmproj handles audio before you send anything:
+
+```python
+import os
+from geniex import AutoModelForVision2Seq
+
+image_path = os.path.abspath("landmark.jpg")
+audio_path = os.path.abspath("jfk.wav")
+
+model = AutoModelForVision2Seq.from_pretrained(
+    "google/gemma-4-E2B-it-qat-q4_0-gguf",
+    device_map="npu",                       # audio runs on npu / gpu / cpu, not qairt
+)
+print(model.capabilities())  # -> {'vision': True, 'audio': True}
+
+messages = [{
+    "role": "user",
+    "content": [
+        {"type": "image", "image": image_path},
+        {"type": "audio", "audio": audio_path},
+        {"type": "text", "text": "Describe the image, then transcribe the audio."},
+    ],
+}]
+prompt = model.tokenizer.apply_chat_template(
+    messages, tokenize=False, add_generation_prompt=True,
+)
+
+output = model.generate(prompt, images=[image_path], audios=[audio_path], max_new_tokens=256)
+print(output.text)
+
+model.close()
+```
+
+## **Supported formats and preprocessing**
+
+| | Details |
+|---|---|
+| **CLI / prompt auto-detection** | `.wav` and `.mp3` extensions only. Any other path in the prompt is treated as an image. |
+| **Server** | No extension allowlist — `input_audio.data` bytes are decoded by content, so anything llama.cpp can decode works. |
+| **Decoder (llama.cpp)** | Recognizes WAV, MP3, and FLAC by magic bytes. Note the mismatch: a `.flac` **path** in a CLI prompt is misrouted to images even though the decoder itself handles FLAC — pass FLAC via the server or a `.wav`/`.mp3` on the CLI. |
+| **Channels / sample rate** | Audio is always down-mixed to **mono** and resampled to the encoder's target rate (typically **16 kHz**; some architectures use 24 kHz). Handled automatically — no need to pre-convert. |
+| **Duration** | No maximum. Clips shorter than the encoder's chunk length are zero-padded; longer clips are chunked automatically. |
+
+<Note>Channel/sample-rate/duration handling lives in the bundled llama.cpp mtmd audio path (third-party), not in GenieX — behavior may shift with the pinned llama.cpp version.</Note>
+
+## **Failure modes**
+
+| Situation | What happens |
+|---|---|
+| **Audio sent to a QAIRT model** | `capabilities()` reports `audio: false`; generation fails with `GenieXError(-201201): Multimodal generation failed`. QAIRT has no audio decode path. |
+| **Audio sent to a vision-only VLM** (mmproj without an audio encoder) | The audio is **silently skipped** with a `model does not support audio input; skipping N audio file(s)` warning, and generation continues text-only. Check `capabilities()['audio']` first. |
+| **Unreadable / unsupported audio file** | The file is dropped with a debug log. If that leaves fewer media than the chat template expects, generation fails later with `-201201`. |
+
+## **Next steps**
+
+- [CLI reference](/en/run/cli/reference#geniex-infer-vlm) — every `geniex infer` flag.
+- [Local server](/en/run/cli/local-server#vlm-request) — the full OpenAI-compatible API.
+- [Python quickstart](/en/run/python/quickstart) — VLM and audio inference from Python.
+
+<br />
+
+<Feedback />


### PR DESCRIPTION
## What

Audio input shipped in the llama.cpp mtmd path but was undocumented, and two pages wrongly claimed image-only VLM input. This documents it across every surface and adds a dedicated tutorial.

- **Fix the wrong wording** in `run/cli/reference.mdx` and `run/cli/local-server.mdx` (they claimed image-only).
- **Verified image+audio example per surface** — CLI (`/mic` + prompt paths), server (`input_audio`), Python (`generate(audios=)`), all on `google/gemma-4-E2B-it-qat-q4_0-gguf`.
- **New `en/tutorials/audio-input.mdx`** — CLI/server/Python walkthrough plus supported-format and failure-mode tables; added to the nav.
- **Input-modalities table** on the models page.
- QAIRT/NPU non-support called out (`audio: false`, error `-201201`).

## Verification

All examples run on real hardware — Snapdragon X Elite (Windows ARM), CLI + server curl + `openai` client + Python SDK — and the real output is pasted in, not written from source. Format/sample-rate/failure-mode details are sourced from the SDK plugin and the pinned llama.cpp mtmd code.

`/mic` interaction, and the format/duration/failure-mode tables, are documented from the code (not hardware-exercised — `/mic` needs a live microphone).

Docs-only; MDX compile-checked locally.

Addresses qcom-ai-hub/geniex#1412.