### PR TITLE
sdk(model-manager): bump DEFAULT_AI_HUB_VERSION to v0.60.0

### DIFF
--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -80,7 +80,7 @@ const DEFAULT_AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
 
 /// Mirrors `cli/internal/config/config.go:DefaultAIHubVersion`.
-const DEFAULT_AI_HUB_VERSION: &str = "v0.58.0";
+const DEFAULT_AI_HUB_VERSION: &str = "v0.60.0";
 
 fn default_data_dir() -> PathBuf {
     let home = std::env::var("HOME")

--- a/sdk/model-manager/crates/core/tests/ai_hub_live.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_live.rs
@@ -28,7 +28,7 @@ use model_manager_core::transport::ReqwestTransport;
 
 const AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
-const AI_HUB_VERSION: &str = "v0.58.0";
+const AI_HUB_VERSION: &str = "v0.60.0";
 
 const PHI_DISPLAY_NAME: &str = "Phi-3.5-Mini-Instruct";
 const PHI_CHIPSET: &str = "qualcomm-snapdragon-x-elite";


### PR DESCRIPTION
Bump the pinned `qai-hub-models` release from `v0.58.0` to `v0.60.0`.

### Changes
- `sdk/model-manager/crates/core/src/config.rs`: update `DEFAULT_AI_HUB_VERSION`
- `sdk/model-manager/crates/core/tests/ai_hub_live.rs`: update `AI_HUB_VERSION` (live test constant kept in sync)

### Why
`DEFAULT_AI_HUB_VERSION` controls the S3 URL used to fetch `manifest.json`, `platform.json`, and `release-assets.json` for AI Hub model pulls, chipset listing, and model listing. Bumping it picks up new models and chipsets published in the `v0.60.0` release.
