### PR TITLE
test(python): skip test_mtp_multi_turn[npu] on Windows arm64

### DIFF
--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import platform
 from pathlib import Path
 
 import geniex
@@ -180,8 +181,20 @@ def test_vlm_quality_keywords(llama_cpp_vlm_paths, quality_image, device_map):
         )
 
 
+_WINDOWS_ARM64 = platform.system() == 'Windows' and platform.machine().lower() == 'arm64'
+
+
 @pytest.mark.llm
 @pytest.mark.parametrize('device_map', ['npu'])
+@pytest.mark.skipif(
+    _WINDOWS_ARM64,
+    reason=(
+        'Windows-on-Snapdragon MTP aborts under sequenced pytest runs: '
+        'ggml-hexagon flush_pending -> dspqueue_read fails 0x0d after the '
+        'preceding LLM/VLM tests recycle HTP sessions. Standalone MTP runs '
+        'clean; investigation in the llama.cpp plugin HTP lifecycle.'
+    ),
+)
 def test_mtp_multi_turn(llama_cpp_mtp_paths, device_map):
     # Local paths route through model_name= so the model-manager sees the
     # catalogue id; positional-arg would push the path into resolved_name and


### PR DESCRIPTION
## Summary

- CI's QDC Windows leg (SC8480XP / Snapdragon X2 Elite) has been aborting `test_mtp_multi_turn[npu]` with `process aborted before test completed` (see run 31646248037). Present on 2026-08-11 main too — not tied to any recent change.
- Root-caused on the same SC8480XP CRD with head-SDK bits: standalone MTP passes; `pytest -m llama_cpp` (20 tests, MTP last) aborts inside `third-party/llama.cpp/ggml/src/ggml-hexagon/ggml-hexagon.cpp:1583` (`flush_pending`) with `dspqueue_read failed: 0x0000000d` after the 19 preceding LLM/VLM tests recycle HTP sessions. Native trace captured with `pytest --log-cli-level=DEBUG -s` shows the abort right after the first MTP prefill push. Upstream ggml-hexagon behaves correctly — the trigger is inside GenieX's llama.cpp plugin HTP session lifecycle (`sdk/plugins/llama_cpp/src/htp_session.cpp`).
- This PR is a stopgap: `skipif Windows arm64` on the MTP test so the QDC Windows leg reports a real signal again. The plugin-side lifecycle fix is scoped separately; when it lands, drop the `skipif`.

## Test plan

- [ ] Windows arm64 QDC leg: `test_mtp_multi_turn[npu]` shows `SKIPPED` (was `FAILED`).
- [ ] Linux QDC leg (QCS9075M) and Android QDC leg (SM8850) unchanged (the Linux `-100201` MTP fastrpc-budget failure is a separate issue and is not touched by this PR).