### PR TITLE
fix(sdk): only last MTP-prefill token needs logits

### DIFF
--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -335,7 +335,13 @@ int32_t LlamaLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
         if (spec_prefill) {
             llama_batch batch = llama_batch_init(n_tokens, /*embd=*/0, /*n_seq_max=*/1);
             for (int i = 0; i < n_tokens; ++i) {
-                common_batch_add(batch, tokens[i], this->n_past + i, {0}, /*logits=*/true);
+                // Only the last prompt token needs vocab logits for first-token sampling.
+                // MTP consumes h_nextn embeddings, which llama_set_embeddings_nextn() emits
+                // per position regardless of this flag; leaving logits=true on interior
+                // tokens re-runs the vocab-wide output_head MUL_MAT at every position and
+                // roughly halves prefill throughput on large-vocab models.
+                const bool need_logits = (i == n_tokens - 1);
+                common_batch_add(batch, tokens[i], this->n_past + i, {0}, need_logits);
             }
             rc = llama_decode(this->ctx, batch);
             while (rc == 1 && can_shift && slide_window(n_tokens) > 0) {


### PR DESCRIPTION
## Summary

- Under `--spec-type draft-mtp`, `LlamaLlm::generate` was setting `logits=true` on every prompt token, forcing the target model's vocab-wide `output_head` MUL_MAT (large-vocab: 2816 → 262144) at every prompt position. Only the last prompt token actually needs logits (for first-token sampling); MTP consumes `h_nextn` embeddings which `llama_set_embeddings_nextn(ctx_tgt, true, false)` emits per position regardless of this flag.
- One-line semantic change in `sdk/plugins/llama_cpp/src/llm.cpp` prefill loop: `logits = (i == n_tokens - 1)`.
- Aligns MTP prefill with the upstream `llama-server` pattern (`output = need_embd()` for interior tokens, `set_output(last, true)`).

## Test plan

- [x] `geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:q4_0 --compute NPU --input prompt_1k.txt --nctx 2048 --max-tokens 128 --top-k 1 --think=false --spec-type draft-mtp --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0` on X2 Elite: **MTP prefill 217 → 479 t/s (2.21×), decode 21.1 → 22.2 t/s, accept 62.2 % → 64.4 %** (no correctness regression).
- [x] Plain-decode path (`--spec-type` unset, `spec_prefill == false`) untouched — the change is inside the `if (spec_prefill)` branch only.
- [x] Draft acceptance stability across 3 runs at same prompt: 62 % / 64 % / 63 % (∆ ≤ 2 %, matches pre-patch variance).