### PR TITLE
fix(sdk): fix MTP failures caused by HTP session churn and VLM model leak

### DIFF
--- a/sdk/include/plugin/Plugin.h
+++ b/sdk/include/plugin/Plugin.h
@@ -26,6 +26,14 @@ class Plugin {
     }
     virtual ILlm* create_llm() { return nullptr; }
     virtual IVlm* create_vlm() { return nullptr; }
+
+    // Called by Registry just before it dispatches to a different plugin.
+    // Lets the yielding plugin (e.g. the llama.cpp plugin releasing its
+    // HTP FastRPC channels so QAIRT's HTP init isn't poisoned) tear down
+    // resources that would otherwise collide across plugin boundaries.
+    // Default no-op. Called on every already-instantiated Plugin whose id
+    // differs from the one being handed out.
+    virtual void on_foreign_plugin_load() {}
 };
 
 }  // namespace geniex

--- a/sdk/include/plugin/Plugin.h
+++ b/sdk/include/plugin/Plugin.h
@@ -27,12 +27,9 @@ class Plugin {
     virtual ILlm* create_llm() { return nullptr; }
     virtual IVlm* create_vlm() { return nullptr; }
 
-    // Called by Registry just before it dispatches to a different plugin.
-    // Lets the yielding plugin (e.g. the llama.cpp plugin releasing its
-    // HTP FastRPC channels so QAIRT's HTP init isn't poisoned) tear down
-    // resources that would otherwise collide across plugin boundaries.
-    // Default no-op. Called on every already-instantiated Plugin whose id
-    // differs from the one being handed out.
+    // Called on every already-cached plugin when Registry dispatches to a
+    // plugin with a different id, so the yielding side can release process-
+    // wide resources (e.g. HTP FastRPC channels) that would collide.
     virtual void on_foreign_plugin_load() {}
 };
 

--- a/sdk/include/registry.h
+++ b/sdk/include/registry.h
@@ -39,6 +39,11 @@ class PluginFactory {
 
     Plugin*         get_instance();  // return raw pointer, but internal manage lifecycle
     const PluginId& get_plugin_id() const { return plugin_id; }
+
+    // Returns the cached Plugin without constructing one. Used by Registry to
+    // notify already-instantiated foreign plugins of a handoff without
+    // eagerly spinning up plugins the caller hasn't asked for.
+    Plugin* peek_cached() const { return cached_plugin.get(); }
 };
 
 class PluginLoadException : public std::exception {};
@@ -50,9 +55,25 @@ class Registry {
     mutable std::unordered_map<PluginId, std::unique_ptr<PluginFactory>> plugins;
     mutable std::vector<std::string>                                     failed_plugins;
     mutable std::mutex                                                   mutex;
+    // Tracks the plugin_id from the last successful dispatch so we can fire
+    // Plugin::on_foreign_plugin_load on the yielding side of every handoff.
+    // Empty until the first dispatch.
+    PluginId last_dispatched_id;
 
     Registry()  = default;
     ~Registry() = default;
+
+    // Notifies every already-instantiated plugin whose id differs from
+    // `incoming_id` that a foreign plugin is about to run. Called under
+    // `mutex`; the callees must not re-enter Registry.
+    void notify_foreign_plugins_locked(const PluginId& incoming_id) {
+        for (auto& [id, factory] : plugins) {
+            if (id == incoming_id) continue;
+            if (Plugin* p = factory->peek_cached()) {
+                p->on_foreign_plugin_load();
+            }
+        }
+    }
 
    public:
     static Registry& instance();
@@ -80,6 +101,15 @@ class Registry {
             }
             throw PluginNotFoundException();
         }
+
+        // Fire the foreign-plugin-load hook on every other cached plugin so
+        // they can yield process-wide resources (e.g. llama.cpp releasing HTP
+        // FastRPC channels for QAIRT). Skip when the dispatch id is unchanged
+        // — sequential loads of the same plugin must not churn.
+        if (!last_dispatched_id.empty() && last_dispatched_id != plugin_id) {
+            notify_foreign_plugins_locked(plugin_id);
+        }
+        last_dispatched_id = plugin_id;
 
         Plugin* plugin = it->second->get_instance();
         if constexpr (std::is_same_v<M, Plugin>) {

--- a/sdk/include/registry.h
+++ b/sdk/include/registry.h
@@ -40,9 +40,7 @@ class PluginFactory {
     Plugin*         get_instance();  // return raw pointer, but internal manage lifecycle
     const PluginId& get_plugin_id() const { return plugin_id; }
 
-    // Returns the cached Plugin without constructing one. Used by Registry to
-    // notify already-instantiated foreign plugins of a handoff without
-    // eagerly spinning up plugins the caller hasn't asked for.
+    // Cached instance without constructing one; nullptr if never instantiated.
     Plugin* peek_cached() const { return cached_plugin.get(); }
 };
 
@@ -55,17 +53,12 @@ class Registry {
     mutable std::unordered_map<PluginId, std::unique_ptr<PluginFactory>> plugins;
     mutable std::vector<std::string>                                     failed_plugins;
     mutable std::mutex                                                   mutex;
-    // Tracks the plugin_id from the last successful dispatch so we can fire
-    // Plugin::on_foreign_plugin_load on the yielding side of every handoff.
-    // Empty until the first dispatch.
-    PluginId last_dispatched_id;
+    PluginId                                                             last_dispatched_id;
 
     Registry()  = default;
     ~Registry() = default;
 
-    // Notifies every already-instantiated plugin whose id differs from
-    // `incoming_id` that a foreign plugin is about to run. Called under
-    // `mutex`; the callees must not re-enter Registry.
+    // Callees must not re-enter Registry — mutex is held.
     void notify_foreign_plugins_locked(const PluginId& incoming_id) {
         for (auto& [id, factory] : plugins) {
             if (id == incoming_id) continue;
@@ -102,10 +95,6 @@ class Registry {
             throw PluginNotFoundException();
         }
 
-        // Fire the foreign-plugin-load hook on every other cached plugin so
-        // they can yield process-wide resources (e.g. llama.cpp releasing HTP
-        // FastRPC channels for QAIRT). Skip when the dispatch id is unchanged
-        // — sequential loads of the same plugin must not churn.
         if (!last_dispatched_id.empty() && last_dispatched_id != plugin_id) {
             notify_foreign_plugins_locked(plugin_id);
         }

--- a/sdk/plugins/llama_cpp/include/htp_session.h
+++ b/sdk/plugins/llama_cpp/include/htp_session.h
@@ -14,19 +14,16 @@ namespace geniex {
 // llama.cpp's still-open libggml-htp-vN.so / libdspqueue_rpc_skel.so handles —
 // QAIRT reports "Failed to create device: 1002" or 1007.
 //
-// Workaround: when the last HTP-bound llama.cpp object is destroyed, call
-// ggml_backend_hexagon_release_sessions (exposed by our llama.cpp patch) to
-// close those handles. Before the next llama.cpp load we call
-// ggml_backend_hexagon_reacquire_sessions so the cached device pointers in
-// ggml-backend-reg have live sessions again.
+// Handoff to another plugin closes those channels via
+// ggml_backend_hexagon_release_sessions (exposed by our llama.cpp patch).
+// Before the next llama.cpp load we call ggml_backend_hexagon_reacquire_sessions
+// so the cached device pointers in ggml-backend-reg have live sessions again.
 //
-// Classes that may load on HTP (LlamaLlm / LlamaVlm / LlamaCppEmbedding /
-// LlamaCppReranker) own an htp::SessionGuard with RAII semantics: call
-// reacquire_before_load() before llama_model_load_from_file, mark_htp() when
-// the HTP backend is registered, and the destructor releases when it was the
-// last live user. Tracking is registry-scoped (not device-scoped) because
-// llama.cpp opens HTP FastRPC channels at ggml_hexagon_registry construction
-// time regardless of per-load device_id/n_gpu_layers.
+// SessionGuard tracks live HTP users with a shared refcount but no longer
+// releases on destruction — each release/reacquire cycle leaves the DSP-side
+// dspqueue in a state that fails `dspqueue_read` (0x0d) after enough churn,
+// so the actual release is deferred to release_sessions_if_idle(), invoked
+// by the SDK only when a foreign plugin is about to load (Plugin::on_foreign_plugin_load).
 namespace htp {
 
 // Recreate any HTP sessions that were released by a prior handoff. No-op if
@@ -39,10 +36,18 @@ void reacquire_before_load();
 // torn down before a QAIRT plugin can take over.
 bool htp_backend_present();
 
+// Close all HTP sessions iff no SessionGuard is currently holding a
+// reference. Called from LlamaPlugin::on_foreign_plugin_load when another
+// plugin (QAIRT) is about to run, so its own HTP init isn't poisoned. No-op
+// if the HTP backend is absent, sessions are already released, or any
+// llama.cpp handle is still using HTP (the foreign plugin will collide, but
+// that's caller error).
+void release_sessions_if_idle();
+
 class SessionGuard {
    public:
     SessionGuard() = default;
-    ~SessionGuard() { release_if_last(); }
+    ~SessionGuard() { release_ref(); }
 
     SessionGuard(const SessionGuard&)            = delete;
     SessionGuard& operator=(const SessionGuard&) = delete;
@@ -55,7 +60,10 @@ class SessionGuard {
     bool uses_htp() const { return uses_htp_; }
 
    private:
-    void release_if_last();
+    // Decrement the shared refcount. Does NOT close sessions — release is
+    // driven by release_sessions_if_idle() so sequential llama.cpp loads
+    // keep the same HTP sessions warm.
+    void release_ref();
 
     bool uses_htp_ = false;
 };

--- a/sdk/plugins/llama_cpp/include/htp_session.h
+++ b/sdk/plugins/llama_cpp/include/htp_session.h
@@ -5,43 +5,18 @@
 
 namespace geniex {
 
-// HTP session lifecycle helpers shared by all llama.cpp plugin classes.
-//
-// llama.cpp's Hexagon backend opens FastRPC channels to the CDSP at registry
-// construction time (ggml_hexagon_registry). Those channels persist for the
-// life of the process, which means a QAIRT plugin spun up after llama.cpp
-// tries to open its own dspqueue on the same CDSP domain and collides with
-// llama.cpp's still-open libggml-htp-vN.so / libdspqueue_rpc_skel.so handles —
-// QAIRT reports "Failed to create device: 1002" or 1007.
-//
-// Handoff to another plugin closes those channels via
-// ggml_backend_hexagon_release_sessions (exposed by our llama.cpp patch).
-// Before the next llama.cpp load we call ggml_backend_hexagon_reacquire_sessions
-// so the cached device pointers in ggml-backend-reg have live sessions again.
-//
-// SessionGuard tracks live HTP users with a shared refcount but no longer
-// releases on destruction — each release/reacquire cycle leaves the DSP-side
-// dspqueue in a state that fails `dspqueue_read` (0x0d) after enough churn,
-// so the actual release is deferred to release_sessions_if_idle(), invoked
-// by the SDK only when a foreign plugin is about to load (Plugin::on_foreign_plugin_load).
+// A QAIRT plugin spun up after llama.cpp collides on the same CDSP domain
+// with llama.cpp's still-open FastRPC handles ("Failed to create device:
+// 1002"/1007). Release only on plugin handoff — cycling release/reacquire
+// per llama.cpp load accumulates DSP-side state that fails dspqueue_read
+// with 0x0d after ~20 handoffs.
 namespace htp {
 
-// Recreate any HTP sessions that were released by a prior handoff. No-op if
-// the HTP backend is absent or sessions are already live. Safe to call on
-// every llama.cpp load.
 void reacquire_before_load();
 
-// Returns true iff the ggml backend registry has a backend named "HTP".
-// When true, llama.cpp has live FastRPC channels to CDSP that need to be
-// torn down before a QAIRT plugin can take over.
 bool htp_backend_present();
 
-// Close all HTP sessions iff no SessionGuard is currently holding a
-// reference. Called from LlamaPlugin::on_foreign_plugin_load when another
-// plugin (QAIRT) is about to run, so its own HTP init isn't poisoned. No-op
-// if the HTP backend is absent, sessions are already released, or any
-// llama.cpp handle is still using HTP (the foreign plugin will collide, but
-// that's caller error).
+// Close all HTP sessions iff no SessionGuard is holding a reference.
 void release_sessions_if_idle();
 
 class SessionGuard {
@@ -52,17 +27,11 @@ class SessionGuard {
     SessionGuard(const SessionGuard&)            = delete;
     SessionGuard& operator=(const SessionGuard&) = delete;
 
-    // Call after deciding uses_htp (post model-load so we know the real
-    // device selection). Safe to call multiple times — only the first flip
-    // from false→true increments the shared refcount.
     void mark_htp();
 
     bool uses_htp() const { return uses_htp_; }
 
    private:
-    // Decrement the shared refcount. Does NOT close sessions — release is
-    // driven by release_sessions_if_idle() so sequential llama.cpp loads
-    // keep the same HTP sessions warm.
     void release_ref();
 
     bool uses_htp_ = false;

--- a/sdk/plugins/llama_cpp/src/htp_session.cpp
+++ b/sdk/plugins/llama_cpp/src/htp_session.cpp
@@ -31,17 +31,20 @@ void reacquire_before_load() {
 
 bool htp_backend_present() { return ggml_backend_reg_by_name("HTP") != nullptr; }
 
+void release_sessions_if_idle() {
+    if (g_htp_refcount.load(std::memory_order_acquire) != 0) return;
+    call_htp_proc("ggml_backend_hexagon_release_sessions", "Releasing HTP sessions for foreign-plugin handoff");
+}
+
 void SessionGuard::mark_htp() {
     if (uses_htp_) return;
     uses_htp_ = true;
     g_htp_refcount.fetch_add(1, std::memory_order_acq_rel);
 }
 
-void SessionGuard::release_if_last() {
+void SessionGuard::release_ref() {
     if (!uses_htp_) return;
-    if (g_htp_refcount.fetch_sub(1, std::memory_order_acq_rel) != 1) return;
-    call_htp_proc(
-        "ggml_backend_hexagon_release_sessions", "Releasing HTP sessions on last llama.cpp HTP handle destroy");
+    g_htp_refcount.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 }  // namespace geniex::htp

--- a/sdk/plugins/llama_cpp/src/plugin.cpp
+++ b/sdk/plugins/llama_cpp/src/plugin.cpp
@@ -144,10 +144,6 @@ class LlamaPlugin : public Plugin {
 
     IVlm* create_vlm() override { return new geniex::LlamaVlm; }
 
-    // Yield the HTP FastRPC channels so the incoming plugin (typically QAIRT)
-    // can bring up its own dspqueue on the same CDSP domain without colliding
-    // with the still-open libggml-htp-vN.so / libdspqueue_rpc_skel.so handles.
-    // See htp_session.h for the collision symptom this avoids.
     void on_foreign_plugin_load() override { htp::release_sessions_if_idle(); }
 };
 

--- a/sdk/plugins/llama_cpp/src/plugin.cpp
+++ b/sdk/plugins/llama_cpp/src/plugin.cpp
@@ -18,6 +18,7 @@
 #include "build_config.h"
 #include "common.h"
 #include "ggml-backend.h"
+#include "htp_session.h"
 #include "llama.h"
 #include "llm.h"
 #include "logging.h"
@@ -142,6 +143,12 @@ class LlamaPlugin : public Plugin {
     ILlm* create_llm() override { return new geniex::LlamaLlm; }
 
     IVlm* create_vlm() override { return new geniex::LlamaVlm; }
+
+    // Yield the HTP FastRPC channels so the incoming plugin (typically QAIRT)
+    // can bring up its own dspqueue on the same CDSP domain without colliding
+    // with the still-open libggml-htp-vN.so / libdspqueue_rpc_skel.so handles.
+    // See htp_session.h for the collision symptom this avoids.
+    void on_foreign_plugin_load() override { htp::release_sessions_if_idle(); }
 };
 
 }  // namespace geniex

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -20,13 +20,21 @@
 namespace geniex {
 
 LlamaVlm::~LlamaVlm() {
+    // mtmd_context holds tensor pointers into `model`, so tear it down first.
+    if (this->ctx_vision) {
+        mtmd_free(this->ctx_vision);
+        this->ctx_vision = nullptr;
+    }
     if (this->ctx) {
         llama_free(this->ctx);
         this->ctx = nullptr;
     }
-    if (this->ctx_vision) {
-        mtmd_free(this->ctx_vision);
-        this->ctx_vision = nullptr;
+    // Missing model release leaked the whole llama_model on every VLM
+    // destroy, including its HTP-mapped tensors — enough to exhaust the
+    // CDSP fastrpc mmap budget after a single VLM npu load.
+    if (this->model) {
+        llama_model_free(this->model);
+        this->model = nullptr;
     }
 }
 

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -20,7 +20,7 @@
 namespace geniex {
 
 LlamaVlm::~LlamaVlm() {
-    // mtmd_context holds tensor pointers into `model`, so tear it down first.
+    // ctx_vision and ctx hold pointers into model; free them first.
     if (this->ctx_vision) {
         mtmd_free(this->ctx_vision);
         this->ctx_vision = nullptr;
@@ -29,9 +29,6 @@ LlamaVlm::~LlamaVlm() {
         llama_free(this->ctx);
         this->ctx = nullptr;
     }
-    // Missing model release leaked the whole llama_model on every VLM
-    // destroy, including its HTP-mapped tensors — enough to exhaust the
-    // CDSP fastrpc mmap budget after a single VLM npu load.
     if (this->model) {
         llama_model_free(this->model);
         this->model = nullptr;


### PR DESCRIPTION
## Summary

Two independent bugs in the llama.cpp plugin combine to break `test_mtp_multi_turn[npu]` on the QDC Windows (SC8480XP / Snapdragon X2 Elite) leg. Bisected on-device with the head SDK against `pytest -m llama_cpp`:

- **HTP session lifecycle churn** — `SessionGuard::~SessionGuard` called `ggml_backend_hexagon_release_sessions` on every model destroy so a subsequent QAIRT plugin would not collide with llama.cpp's open dspqueue. Cycling release/reacquire on every load accumulates DSP-side state; after enough churn the next `flush_pending()` sees `dspqueue_read` return `0x0d` at `third-party/llama.cpp/ggml/src/ggml-hexagon/ggml-hexagon.cpp:1583` and calls `GGML_ABORT`. Moved the release to a plugin-boundary hook: `Plugin` gains `on_foreign_plugin_load`, `Registry::get` fires it on every already-cached plugin whose id differs from the incoming one, and `LlamaPlugin` overrides it to call `htp::release_sessions_if_idle`. Sequential llama.cpp loads keep the same HTP sessions warm; QAIRT still gets clean sessions when it steps in.
- **VLM model leak** — `LlamaVlm::~LlamaVlm` released `llama_context` and `mtmd_context` but never called `llama_model_free`, leaking the model — and every HTP-mapped tensor tied to it — on each destroy. A single `test_vlm_*[npu]` run consumes enough of the CDSP fastrpc mmap budget that the next MTP load's compute buffer or KV cache allocation fails with `fastrpc_mmap failed`. Free the model after `ctx` and `ctx_vision` (which hold pointers into it).

## Test plan

- [x] SC8480XP on-device, head SDK from `sdk-windows-arm64` artifact of run 31646248037 + these two fixes: `pytest -m llama_cpp` → **20 passed** in 3m38s (was: abort at MTP mid-run before the fix; `1 failed, 19 passed` with the lifecycle fix alone).
- [x] Bisection on the same box narrowed the second failure to a single predecessor: 12× LLM predecessors + MTP all pass; **1× VLM-npu predecessor + MTP fails** on `fastrpc_mmap` for a 138 MB compute buffer. Confirms VLM destroy path was the leak site.
- [x] Standalone MTP `AutoModelForCausalLM.from_pretrained(..., spec_type='draft-mtp', spec_n_max=3)` still passes after each fix (regression check that neither change breaks MTP itself).