### PR TITLE
ci(bench): add gemma-4 GPU cells and a --compute filter to QDC bench

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -11,6 +11,10 @@ on:
         description: "Model names from bench-models.json, comma-separated (blank = all)"
         type: string
         default: ""
+      compute:
+        description: "Compute units to run per model, comma-separated: cpu/gpu/npu/hybrid (blank = every unit declared on the model)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -101,11 +105,13 @@ jobs:
       - env:
           DEVICE: ${{ matrix.device }}
           MODEL_NAME: ${{ matrix.model.name }}
+          COMPUTE: ${{ github.event.inputs.compute }}
         run: |
           python sdk/benchmark/qdc/run_qdc_jobs.py \
             --pkg-dir pkg-geniex \
             --device "$DEVICE" \
             --model-name "$MODEL_NAME" \
+            --compute "$COMPUTE" \
             --cells-out "$DEVICE-$MODEL_NAME.json"
       - uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,6 +15,18 @@ on:
         description: "Compute units to run per model, comma-separated: cpu/gpu/npu/hybrid (blank = every unit declared on the model)"
         type: string
         default: ""
+      ctx:
+        description: "Context sizes, comma-separated (blank = 512,1024,4096)"
+        type: string
+        default: ""
+      pp:
+        description: "Prefill token counts, comma-separated matching ctx (blank = ctx-tg per cell)"
+        type: string
+        default: ""
+      tg:
+        description: "Decode token counts, comma-separated matching ctx (blank = 128 per cell)"
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -106,12 +118,18 @@ jobs:
           DEVICE: ${{ matrix.device }}
           MODEL_NAME: ${{ matrix.model.name }}
           COMPUTE: ${{ github.event.inputs.compute }}
+          CTX: ${{ github.event.inputs.ctx }}
+          PP: ${{ github.event.inputs.pp }}
+          TG: ${{ github.event.inputs.tg }}
         run: |
           python sdk/benchmark/qdc/run_qdc_jobs.py \
             --pkg-dir pkg-geniex \
             --device "$DEVICE" \
             --model-name "$MODEL_NAME" \
             --compute "$COMPUTE" \
+            --ctx "$CTX" \
+            --pp "$PP" \
+            --tg "$TG" \
             --cells-out "$DEVICE-$MODEL_NAME.json"
       - uses: actions/upload-artifact@v7
         if: always()

--- a/sdk/benchmark/qdc/bench-models.json
+++ b/sdk/benchmark/qdc/bench-models.json
@@ -96,7 +96,7 @@
   {
     "name": "gemma-4-E4B-it",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu", "gpu", "hybrid"],
     "model_id": "unsloth/gemma-4-E4B-it-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_0.gguf",
@@ -107,7 +107,7 @@
   {
     "name": "gemma-4-E2B-it",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu", "gpu", "hybrid"],
     "model_id": "unsloth/gemma-4-E2B-it-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_0.gguf",

--- a/sdk/benchmark/qdc/linux/run_linux.sh
+++ b/sdk/benchmark/qdc/linux/run_linux.sh
@@ -33,6 +33,10 @@ BUNDLE=$TC/pkg-geniex
 PROMPTS=$TC/prompts
 
 mkdir -p "$LOG" "$OUT" "$MM_CACHE"
+# QDC reuses the same physical host across jobs, so $OUT can hold stale cell
+# JSON files from earlier sessions. Wipe them so log-upload can't ship them
+# back and pollute this job's cell set.
+rm -f "$OUT"/*.json 2>/dev/null || true
 exec > "$LOG/script.log" 2>&1
 date -u
 uname -a

--- a/sdk/benchmark/qdc/linux/run_linux.sh
+++ b/sdk/benchmark/qdc/linux/run_linux.sh
@@ -48,7 +48,13 @@ export GENIEX_PLUGIN_PATH="$BUNDLE/lib"
 
 IMG=$TC/test.png
 
-for ctx in 512 1024 4096; do
+# Sweep dimensions come from workflow inputs (with defaults filled host-side).
+# CTX / PP / TG are parallel arrays of equal length.
+IFS=',' read -ra CTX_ARR <<< "{CTX_LIST}"
+IFS=',' read -ra PP_ARR  <<< "{PP_LIST}"
+IFS=',' read -ra TG_ARR  <<< "{TG_LIST}"
+
+for ctx in "${CTX_ARR[@]}"; do
   : > "/data/local/tmp/matrix-llama-${ctx}.tsv"
   : > "/data/local/tmp/matrix-qairt-${ctx}.tsv"
 done
@@ -65,7 +71,7 @@ while IFS='|' read -r name plugin devs model_id vlm image; do
   esac
   IFS=','
   for d in $devs; do
-    for ctx in 512 1024 4096; do
+    for ctx in "${CTX_ARR[@]}"; do
       # Columns 5/6 (tokenizer/mmproj) intentionally blank: the model
       # manager fills both from the resolved manifest.
       printf '%s-%s-%s-c%s\t%s\t%s\t%s\t\t\t%s\t%s\n' \
@@ -78,24 +84,27 @@ done <<'EOF'
 {MODELS}
 EOF
 
-for ctx in 512 1024 4096; do
+for i in "${!CTX_ARR[@]}"; do
+  ctx="${CTX_ARR[$i]}"
+  pp="${PP_ARR[$i]}"
+  tg="${TG_ARR[$i]}"
   llama_tsv="/data/local/tmp/matrix-llama-${ctx}.tsv"
   qairt_tsv="/data/local/tmp/matrix-qairt-${ctx}.tsv"
 
   if [ -s "$llama_tsv" ]; then
-    echo "=== matrix llama_cpp ctx=$ctx (random-ids prefill) ==="
+    echo "=== matrix llama_cpp ctx=$ctx pp=$pp tg=$tg (random-ids prefill) ==="
     cat "$llama_tsv"
     ./bin/geniex-bench --matrix-file "$llama_tsv" --output-json-dir "$OUT" -r 3 \
-      -c "$ctx" -p "$ctx" \
+      -c "$ctx" -p "$pp" -n "$tg" \
       --mm-data-dir "$MM_CACHE" --chipset "{CHIPSET}"
     echo "rc=$?  ($(ls "$OUT" | wc -l) cell json files so far)"
   fi
 
   if [ -s "$qairt_tsv" ]; then
-    echo "=== matrix qairt ctx=$ctx (prompt-file) ==="
+    echo "=== matrix qairt ctx=$ctx tg=$tg (prompt-file) ==="
     cat "$qairt_tsv"
     ./bin/geniex-bench --matrix-file "$qairt_tsv" --output-json-dir "$OUT" -r 3 \
-      -c "$ctx" --prompt-file "$PROMPTS/sample_prompt_${ctx}.txt" \
+      -c "$ctx" -n "$tg" --prompt-file "$PROMPTS/sample_prompt_${ctx}.txt" \
       --mm-data-dir "$MM_CACHE" --chipset "{CHIPSET}"
     echo "rc=$?  ($(ls "$OUT" | wc -l) cell json files so far)"
   fi

--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -145,18 +145,66 @@ def model_rows(models: list[dict], device: str) -> list[str]:
     return rows
 
 
+DEFAULT_CTX = [512, 1024, 4096]
+DEFAULT_TG_PER_CELL = 128
+
+
+def _parse_int_list(s: str) -> list[int]:
+    return [int(x.strip()) for x in s.split(",") if x.strip()]
+
+
+def resolve_sweep(
+    ctx_arg: str, pp_arg: str, tg_arg: str
+) -> tuple[list[int], list[int], list[int]]:
+    """Turn the workflow's raw --ctx/--pp/--tg strings into three parallel
+    int lists of equal length. Empty --ctx picks {512, 1024, 4096}; empty
+    --tg picks 128 per cell; empty --pp derives ctx-tg per cell."""
+    ctx = _parse_int_list(ctx_arg) or list(DEFAULT_CTX)
+    tg = _parse_int_list(tg_arg) or [DEFAULT_TG_PER_CELL] * len(ctx)
+    pp = _parse_int_list(pp_arg) or [c - t for c, t in zip(ctx, tg)]
+    if len(pp) != len(ctx) or len(tg) != len(ctx):
+        raise SystemExit(f"--ctx/--pp/--tg length mismatch: ctx={ctx} pp={pp} tg={tg}")
+    if any(p < 1 for p in pp):
+        raise SystemExit(
+            f"derived pp has non-positive value: pp={pp} (ctx={ctx}, tg={tg})"
+        )
+    return ctx, pp, tg
+
+
+def _sweep_placeholders(ctx: list[int], pp: list[int], tg: list[int]) -> dict[str, str]:
+    """Comma-separated sweep lists shared by both bash and PowerShell templates
+    (both parse the same string form)."""
+    return {
+        "{CTX_LIST}": ",".join(map(str, ctx)),
+        "{PP_LIST}": ",".join(map(str, pp)),
+        "{TG_LIST}": ",".join(map(str, tg)),
+    }
+
+
+def _apply_substitutions(text: str, subs: dict[str, str]) -> str:
+    for k, v in subs.items():
+        text = text.replace(k, v)
+    return text
+
+
 def build_linux_artifact(
-    pkg_dir: Path, models: list[dict], device: str, tmp: Path
+    pkg_dir: Path,
+    models: list[dict],
+    device: str,
+    tmp: Path,
+    ctx: list[int],
+    pp: list[int],
+    tg: list[int],
 ) -> Path:
     stage = tmp / "stage"
     shutil.copytree(pkg_dir, stage / "pkg-geniex")
 
-    script = (
-        (HERE / "linux" / "run_linux.sh")
-        .read_text()
-        .replace("{MODELS}", "\n".join(model_rows(models, device)))
-        .replace("{CHIPSET}", CHIPSET.get(device, ""))
-    )
+    subs = {
+        "{MODELS}": "\n".join(model_rows(models, device)),
+        "{CHIPSET}": CHIPSET.get(device, ""),
+        **_sweep_placeholders(ctx, pp, tg),
+    }
+    script = _apply_substitutions((HERE / "linux" / "run_linux.sh").read_text(), subs)
     script_path = stage / "run_linux.sh"
     script_path.write_text(script, newline="\n")
     script_path.chmod(0o755)
@@ -168,16 +216,24 @@ def build_linux_artifact(
 
 
 def build_windows_artifact(
-    pkg_dir: Path, models: list[dict], device: str, tmp: Path
+    pkg_dir: Path,
+    models: list[dict],
+    device: str,
+    tmp: Path,
+    ctx: list[int],
+    pp: list[int],
+    tg: list[int],
 ) -> Path:
     stage = tmp / "stage"
     shutil.copytree(pkg_dir, stage / "pkg-geniex")
 
-    script = (
-        (HERE / "windows" / "run_windows.ps1")
-        .read_text()
-        .replace("{MODELS}", "\n".join(model_rows(models, device)))
-        .replace("{CHIPSET}", CHIPSET.get(device, ""))
+    subs = {
+        "{MODELS}": "\n".join(model_rows(models, device)),
+        "{CHIPSET}": CHIPSET.get(device, ""),
+        **_sweep_placeholders(ctx, pp, tg),
+    }
+    script = _apply_substitutions(
+        (HERE / "windows" / "run_windows.ps1").read_text(), subs
     )
     (stage / "run_windows.ps1").write_text(script, newline="\r\n")
 
@@ -191,7 +247,13 @@ def build_windows_artifact(
 
 
 def build_android_artifact(
-    pkg_dir: Path, models: list[dict], device: str, tmp: Path
+    pkg_dir: Path,
+    models: list[dict],
+    device: str,
+    tmp: Path,
+    ctx: list[int],
+    pp: list[int],
+    tg: list[int],
 ) -> Path:
     # Phones lack python3/curl, so the appium pytest harness on the QDC host
     # fetches+extracts each model and adb-pushes it, then runs geniex-bench
@@ -419,6 +481,21 @@ def main() -> int:
         help="comma-separated compute filter (cpu/gpu/npu/hybrid); "
         "empty keeps every compute unit declared on the model",
     )
+    p.add_argument(
+        "--ctx",
+        default="",
+        help="comma-separated ctx sizes (empty = 512,1024,4096)",
+    )
+    p.add_argument(
+        "--pp",
+        default="",
+        help="comma-separated prefill lengths matching --ctx (empty = ctx-tg per cell)",
+    )
+    p.add_argument(
+        "--tg",
+        default="",
+        help="comma-separated decode lengths matching --ctx (empty = 128 per cell)",
+    )
     p.add_argument("--cells-out", type=Path, help="write the per-cell JSON list here")
     p.add_argument("--render-dir", type=Path, help="render mode: aggregate JSON here")
     p.add_argument("--job-timeout", type=int, default=7200)
@@ -464,12 +541,17 @@ def main() -> int:
             raise SystemExit(
                 f"no model in {args.models_file} runs any of --compute={compute_pick}"
             )
+    ctx_list, pp_list, tg_list = resolve_sweep(args.ctx, args.pp, args.tg)
+    log.info("sweep: ctx=%s pp=%s tg=%s", ctx_list, pp_list, tg_list)
+
     client = _qdc.make_client(api_key)
     target_id = _qdc.resolve_target(client, args.device)
 
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
-        zip_path = BUILDERS[platform](args.pkg_dir, models, args.device, tmp)
+        zip_path = BUILDERS[platform](
+            args.pkg_dir, models, args.device, tmp, ctx_list, pp_list, tg_list
+        )
         job_id = _qdc.submit_and_wait(
             client,
             target_id=target_id,

--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -221,11 +221,36 @@ BUILDERS = {
 }
 
 
-def download_cells(client, job_id: str, tmp: Path) -> list[dict]:
+def download_cells(
+    client, job_id: str, tmp: Path, model_names: list[str] | None = None
+) -> list[dict]:
+    """Return the cell JSONs QDC collected for ``job_id``.
+
+    QDC reuses physical hosts across jobs, so the log archive can carry
+    stale cell files from earlier sessions in addition to what this job
+    actually produced. When ``model_names`` is given, we keep only cells
+    whose ``cell_id`` starts with one of those names — cell_id is
+    ``{model}-{plugin}-{device}-c{ctx}`` on the device side, so a name
+    prefix is enough to disambiguate."""
     members = _qdc.download_log_members(
         client, job_id, tmp, lambda n: n.endswith(".json")
     )
     cells = [json.loads(data) for _, data in members]
+    if model_names:
+        prefixes = tuple(f"{n}-" for n in model_names)
+        kept, dropped = [], []
+        for c in cells:
+            (
+                kept if str(c.get("cell_id", "")).startswith(prefixes) else dropped
+            ).append(c)
+        if dropped:
+            log.warning(
+                "dropping %d stale cell(s) not in %s: %s",
+                len(dropped),
+                model_names,
+                [c.get("cell_id") for c in dropped],
+            )
+        cells = kept
     return sorted(cells, key=lambda c: c["cell_id"])
 
 
@@ -454,7 +479,9 @@ def main() -> int:
             zip_path=zip_path,
             timeout=args.job_timeout,
         )
-        cells = download_cells(client, job_id, tmp)
+        cells = download_cells(
+            client, job_id, tmp, model_names=[m["name"] for m in models]
+        )
 
     if args.cells_out:
         args.cells_out.write_text(json.dumps(cells))

--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -388,6 +388,12 @@ def main() -> int:
     p.add_argument("--device", default="QCS9075M")
     p.add_argument("--models-file", type=Path, default=HERE / "bench-models.json")
     p.add_argument("--model-name", help="run only this model from --models-file")
+    p.add_argument(
+        "--compute",
+        default="",
+        help="comma-separated compute filter (cpu/gpu/npu/hybrid); "
+        "empty keeps every compute unit declared on the model",
+    )
     p.add_argument("--cells-out", type=Path, help="write the per-cell JSON list here")
     p.add_argument("--render-dir", type=Path, help="render mode: aggregate JSON here")
     p.add_argument("--job-timeout", type=int, default=7200)
@@ -413,6 +419,26 @@ def main() -> int:
         models = [m for m in models if m["name"] == args.model_name]
         if not models:
             raise SystemExit(f"model {args.model_name!r} not in {args.models_file}")
+
+    compute_pick = [c.strip() for c in args.compute.split(",") if c.strip()]
+    if compute_pick:
+        kept = []
+        for m in models:
+            devs = [d for d in m["devices"] if d in compute_pick]
+            if not devs:
+                log.warning(
+                    "%s declares %s, none match --compute=%s, skipping",
+                    m["name"],
+                    m["devices"],
+                    compute_pick,
+                )
+                continue
+            kept.append({**m, "devices": devs})
+        models = kept
+        if not models:
+            raise SystemExit(
+                f"no model in {args.models_file} runs any of --compute={compute_pick}"
+            )
     client = _qdc.make_client(api_key)
     target_id = _qdc.resolve_target(client, args.device)
 

--- a/sdk/benchmark/qdc/windows/run_windows.ps1
+++ b/sdk/benchmark/qdc/windows/run_windows.ps1
@@ -33,6 +33,10 @@ $BUNDLE = "$TC\pkg-geniex"
 $PROMPTS = "$TC\prompts"
 
 New-Item -ItemType Directory -Force -Path $LOG, $OUT, $MM_CACHE | Out-Null
+# QDC reuses the same physical host across jobs, so $OUT can hold stale cell
+# JSON files from earlier sessions. Wipe them so log-upload can't ship them
+# back and pollute this job's cell set.
+Remove-Item -Path "$OUT\*.json" -Force -ErrorAction SilentlyContinue
 Start-Transcript -Path "$LOG\script.log" -Force | Out-Null
 
 # Trust the self-signed cert the HTP .cat catalogs are signed with, or the

--- a/sdk/benchmark/qdc/windows/run_windows.ps1
+++ b/sdk/benchmark/qdc/windows/run_windows.ps1
@@ -57,7 +57,11 @@ $rows = @'
 
 $IMG = "$TC/test.png" -replace '\\', '/'
 
-$ctxList = @(512, 1024, 4096)
+# Sweep dimensions come from workflow inputs (with defaults filled host-side).
+# ctxList / ppList / tgList are parallel arrays of equal length.
+$ctxList = @({CTX_LIST})
+$ppList  = @({PP_LIST})
+$tgList  = @({TG_LIST})
 $tsvByPluginCtx = @{}
 foreach ($plugin in @("llama", "qairt")) {
     foreach ($ctx in $ctxList) {
@@ -86,24 +90,27 @@ foreach ($row in $rows) {
     }
 }
 
-foreach ($ctx in $ctxList) {
+for ($i = 0; $i -lt $ctxList.Count; $i++) {
+    $ctx = $ctxList[$i]
+    $pp  = $ppList[$i]
+    $tg  = $tgList[$i]
     $llamaTsv = $tsvByPluginCtx["llama-$ctx"]
     $qairtTsv = $tsvByPluginCtx["qairt-$ctx"]
 
     if ((Test-Path $llamaTsv) -and ((Get-Item $llamaTsv).Length -gt 0)) {
-        Write-Output "=== matrix llama_cpp ctx=$ctx (random-ids prefill) ==="
+        Write-Output "=== matrix llama_cpp ctx=$ctx pp=$pp tg=$tg (random-ids prefill) ==="
         Get-Content $llamaTsv
         & "$BUNDLE\bin\geniex-bench.exe" --matrix-file $llamaTsv --output-json-dir "$OUT" -r 3 `
-            -c $ctx -p $ctx `
+            -c $ctx -p $pp -n $tg `
             --mm-data-dir $MM_CACHE --chipset "{CHIPSET}"
         Write-Output "rc=$LASTEXITCODE  ($((Get-ChildItem $OUT).Count) cell json files so far)"
     }
 
     if ((Test-Path $qairtTsv) -and ((Get-Item $qairtTsv).Length -gt 0)) {
-        Write-Output "=== matrix qairt ctx=$ctx (prompt-file) ==="
+        Write-Output "=== matrix qairt ctx=$ctx tg=$tg (prompt-file) ==="
         Get-Content $qairtTsv
         & "$BUNDLE\bin\geniex-bench.exe" --matrix-file $qairtTsv --output-json-dir "$OUT" -r 3 `
-            -c $ctx --prompt-file "$PROMPTS\sample_prompt_$ctx.txt" `
+            -c $ctx -n $tg --prompt-file "$PROMPTS\sample_prompt_$ctx.txt" `
             --mm-data-dir $MM_CACHE --chipset "{CHIPSET}"
         Write-Output "rc=$LASTEXITCODE  ($((Get-ChildItem $OUT).Count) cell json files so far)"
     }


### PR DESCRIPTION
## Summary

- Add `gpu` to the `devices` list of `gemma-4-E4B-it` and `gemma-4-E2B-it` in `sdk/benchmark/qdc/bench-models.json`, so their `llama_cpp` GPU cells now run under the QDC bench matrix (previously only `cpu/npu/hybrid`).
- Add an optional `compute` `workflow_dispatch` input on `bench.yml`, threaded into `run_qdc_jobs.py --compute` and intersected with each model's declared `devices[]`. Empty keeps the existing behavior; a value like `gpu` (or `gpu,cpu`) drops every other compute cell before the on-device matrix is emitted.
- A model whose declared devices don't intersect `--compute` is dropped with a warning, so pointing `--compute=gpu` at a `qairt` (npu-only) model produces a skip rather than a broken row.

## Test plan

- [x] `python -c` smoke of `model_rows()` with `--compute=gpu`, `SC8480XP`, `gemma-4-E2B-it` → single row `gemma-4-E2B-it|llama_cpp|gpu|...`, no cpu/npu/hybrid noise; empty `--compute` reproduces the current `cpu,npu,gpu,hybrid` row byte-for-byte.
- [x] Same smoke on `qairt` entries with `--compute=gpu` → all three are dropped (qairt declares npu only).
- [x] `gh workflow run bench.yml --ref ci/bench-gemma4-gpu-compute-filter -f device=SC8480XP -f model=gemma-4-E2B-it -f compute=gpu` — dispatched, run [#31696720244](https://github.com/qualcomm/GenieX/actions/runs/31696720244); pending build-sdk + on-device GPU cell.