### PR TITLE
fix(server): report speculative-decoding stats in OpenAI usage

### DIFF
--- a/cli/cmd/geniex/run.go
+++ b/cli/cmd/geniex/run.go
@@ -228,6 +228,9 @@ func runCompletions(ctx context.Context, name string, modelType geniex_sdk.Model
 				if chunk.Usage.PromptTokens > 0 {
 					profileData.PromptTokens = chunk.Usage.PromptTokens
 					profileData.GeneratedTokens = chunk.Usage.CompletionTokens
+					det := chunk.Usage.CompletionTokensDetails
+					profileData.DraftNAccepted = det.AcceptedPredictionTokens
+					profileData.DraftNTotal = det.AcceptedPredictionTokens + det.RejectedPredictionTokens
 				}
 			}
 

--- a/cli/server/handler/chat_response.go
+++ b/cli/server/handler/chat_response.go
@@ -141,6 +141,10 @@ func profile2Usage(p geniex_sdk.ProfileData) openai.CompletionUsage {
 		CompletionTokens: p.GeneratedTokens,
 		PromptTokens:     p.PromptTokens,
 		TotalTokens:      p.TotalTokens(),
+		CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{
+			AcceptedPredictionTokens: p.DraftNAccepted,
+			RejectedPredictionTokens: p.DraftNTotal - p.DraftNAccepted,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Speculative-decoding stats collected by the SDK (`ProfileData.DraftNAccepted` / `DraftNTotal`) never reached HTTP callers of `geniex serve`: `profile2Usage` in `cli/server/handler/chat_response.go` filled only `completion_tokens` / `prompt_tokens` / `total_tokens`, so `/v1/chat/completions` and `/v1/completions` (blocking + streaming) responses always came back with `accepted_prediction_tokens: 0` and `rejected_prediction_tokens: 0` — the openai-go zero defaults — with no way to tell whether MTP actually ran.

`geniex run` inherited the gap: it reads usage back from the stream (`cli/cmd/geniex/run.go`) but only picked up `PromptTokens` / `CompletionTokens`, so its verbose profile never printed `draft accept X/Y (Z%)` even against a server that did run MTP.

Fix: reuse OpenAI's Predicted-Outputs fields (`completion_tokens_details.accepted_prediction_tokens` / `rejected_prediction_tokens`) — same semantics as speculative decoding — to carry the draft-accept counters end-to-end, and fold them back into `ProfileData` in `geniex run` so its output matches `geniex infer`.

## Test plan

- [x] `geniex serve` + `curl /v1/chat/completions` with `spec_type=draft-mtp` returns non-zero `completion_tokens_details.accepted_prediction_tokens` and `rejected_prediction_tokens` matching the SDK log's draft-accept ratio — pending, needs device with MTP-capable pair
- [x] `geniex run --verbose` against the same server prints `draft accept X/Y (Z%)` on the profile line — pending, needs device