### PR TITLE
Fix Gemma 4 required tool selection and native call normalization

### DIFF
--- a/bindings/go/llm.go
+++ b/bindings/go/llm.go
@@ -158,6 +158,7 @@ func freeLlmChatMessages(cPtr *C.geniex_LlmChatMessage, count C.int32_t) {
 type LlmApplyChatTemplateInput struct {
 	Messages            []LlmChatMessage
 	Tools               string
+	ToolChoice          string
 	EnableThink         bool
 	AddGenerationPrompt bool
 }
@@ -166,6 +167,7 @@ func (lati LlmApplyChatTemplateInput) toCPtr() *C.geniex_LlmApplyChatTemplateInp
 	cPtr := (*C.geniex_LlmApplyChatTemplateInput)(cMalloc(C.sizeof_geniex_LlmApplyChatTemplateInput))
 	*cPtr = C.geniex_LlmApplyChatTemplateInput{
 		tools:                 cStringIfSet(lati.Tools),
+		tool_choice:           cStringIfSet(lati.ToolChoice),
 		enable_thinking:       C.bool(lati.EnableThink),
 		add_generation_prompt: C.bool(lati.AddGenerationPrompt),
 	}
@@ -179,18 +181,23 @@ func freeLlmApplyChatTemplateInput(cPtr *C.geniex_LlmApplyChatTemplateInput) {
 	}
 	freeLlmChatMessages(cPtr.messages, cPtr.message_count)
 	cFreeIfSet(unsafe.Pointer(cPtr.tools))
+	cFreeIfSet(unsafe.Pointer(cPtr.tool_choice))
 	C.free(unsafe.Pointer(cPtr))
 }
 
 type LlmApplyChatTemplateOutput struct {
 	FormattedText string
+	Grammar       string
 }
 
 func newLlmApplyChatTemplateOutputFromCPtr(c *C.geniex_LlmApplyChatTemplateOutput) LlmApplyChatTemplateOutput {
 	if c == nil {
 		return LlmApplyChatTemplateOutput{}
 	}
-	return LlmApplyChatTemplateOutput{FormattedText: C.GoString(c.formatted_text)}
+	return LlmApplyChatTemplateOutput{
+		FormattedText: C.GoString(c.formatted_text),
+		Grammar:       C.GoString(c.grammar),
+	}
 }
 
 func freeLlmApplyChatTemplateOutput(cPtr *C.geniex_LlmApplyChatTemplateOutput) {
@@ -198,6 +205,7 @@ func freeLlmApplyChatTemplateOutput(cPtr *C.geniex_LlmApplyChatTemplateOutput) {
 		return
 	}
 	free(unsafe.Pointer(cPtr.formatted_text))
+	free(unsafe.Pointer(cPtr.grammar))
 }
 
 type LLM struct {

--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -38,4 +38,8 @@ go_cgo_test(
         "completion_test.go",
     ],
     embed = [":handler"],
+    deps = [
+        "//bindings/go:geniex_sdk_go",
+        "@com_github_gin_gonic_gin//:gin",
+    ],
 )

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -4,7 +4,9 @@
 package handler
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -30,6 +32,11 @@ type ChatCompletionRequest struct {
 	ChatCompletionNewParams
 	Stream bool `json:"stream"`
 
+	// openai-go can classify the standard named-function tool_choice object as
+	// its allowed_tools union variant. Retain the raw bounded field so the
+	// OpenAI-compatible named-function shape can be decoded strictly.
+	rawToolChoice json.RawMessage
+
 	EnableThink bool   `json:"enable_think"`
 	NCtx        int32  `json:"nctx"`
 	Ngl         int32  `json:"ngl"` // 0 = pure CPU, -1 = all layers, N = N layers; defaults to the server --ngl when omitted
@@ -50,6 +57,23 @@ type ChatCompletionRequest struct {
 	SpecNMax       int32   `json:"spec_n_max"`
 	SpecNMin       int32   `json:"spec_n_min"`
 	SpecPMin       float32 `json:"spec_p_min"`
+}
+
+func (r *ChatCompletionRequest) UnmarshalJSON(data []byte) error {
+	type requestAlias ChatCompletionRequest
+	decoded := requestAlias(*r)
+	if err := sonic.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var envelope struct {
+		ToolChoice json.RawMessage `json:"tool_choice"`
+	}
+	if err := sonic.Unmarshal(data, &envelope); err != nil {
+		return err
+	}
+	*r = ChatCompletionRequest(decoded)
+	r.rawToolChoice = append(r.rawToolChoice[:0], envelope.ToolChoice...)
+	return nil
 }
 
 func defaultChatCompletionRequest() ChatCompletionRequest {
@@ -168,17 +192,29 @@ type generateFn func(prompt string, onToken func(string) bool) (geniex_sdk.Profi
 
 // prepareFn holds the only LLM/VLM-specific work: apply the chat template, then
 // return the formatted prompt and a generateFn.
-type prepareFn[T, M any] func(p *T, messages M, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (prompt string, gen generateFn, err error)
+type prepareFn[T, M any] func(p *T, messages M, param ChatCompletionRequest, tools string, policy toolSelectionPolicy, sampler *geniex_sdk.SamplerConfig) (prompt string, gen generateFn, err error)
 
-func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
+func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param ChatCompletionRequest, tools string, policy toolSelectionPolicy, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
+	messages = applyLlmToolSelectionDirective(messages, policy)
 	formatted, err := p.ApplyChatTemplate(geniex_sdk.LlmApplyChatTemplateInput{
 		Messages:            messages,
 		Tools:               tools,
+		ToolChoice:          policy.templateToolChoice(),
 		EnableThink:         param.EnableThink,
 		AddGenerationPrompt: true,
 	})
 	if err != nil {
 		return "", nil, err
+	}
+	if policy.explicit() {
+		if formatted.Grammar == "" {
+			return "", nil, errors.New("active chat template did not provide a required-tool grammar")
+		}
+		requiredGrammar, err := strictRequiredToolGrammar(formatted.Grammar)
+		if err != nil {
+			return "", nil, err
+		}
+		sampler.GrammarString = requiredGrammar
 	}
 	gen := func(prompt string, onToken func(string) bool) (geniex_sdk.ProfileData, string, error) {
 		out, err := p.Generate(geniex_sdk.LlmGenerateInput{
@@ -197,7 +233,8 @@ func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param C
 	return formatted.FormattedText, gen, nil
 }
 
-func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
+func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param ChatCompletionRequest, tools string, policy toolSelectionPolicy, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
+	messages = applyVlmToolSelectionDirective(messages, policy)
 	formatted, err := p.ApplyChatTemplate(geniex_sdk.VlmApplyChatTemplateInput{
 		Messages:    messages,
 		Tools:       tools,
@@ -221,7 +258,7 @@ func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param C
 			PromptUTF8: prompt,
 			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
-				MaxTokens:      int32(param.MaxCompletionTokens.Value),
+				MaxTokens:     int32(param.MaxCompletionTokens.Value),
 				SamplerConfig: sampler,
 				ImagePaths:    images,
 				AudioPaths:    audios,
@@ -238,7 +275,7 @@ func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param C
 // runChat is the shared flow wrapping the type-specific prepareFn.
 func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam, messages M, prepare prepareFn[T, M]) {
 	// ---- prepare: parse tools, load the model, apply the chat template ----
-	parseTool, tools, err := parseTools(param)
+	toolPolicy, tools, err := parseTools(param)
 	if err != nil {
 		slog.Error("Failed to parse tools", "error", err)
 		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
@@ -268,7 +305,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		FrequencyPenalty:  float32(param.FrequencyPenalty.Value),
 		Seed:              int32(param.Seed.Value),
 	}
-	prompt, gen, err := prepare(p, messages, param, tools, sampler)
+	prompt, gen, err := prepare(p, messages, param, tools, toolPolicy, sampler)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 		return
@@ -301,8 +338,8 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 
 		wait := func() error { wg.Wait(); return genErr }
 		includeUsage := param.StreamOptions.IncludeUsage.Value
-		if parseTool {
-			streamToolCall(c, dataCh, wait, includeUsage, &profile)
+		if toolPolicy.parseResponse() {
+			streamToolCall(c, dataCh, wait, includeUsage, &profile, toolPolicy)
 		} else {
 			class := tokenClass(plainClass)
 			if reasoningSeparated(param.ReasoningFormat) {
@@ -318,7 +355,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		// blocking
 		var content, reasoning strings.Builder
 		class := tokenClass(plainClass)
-		if !parseTool && reasoningSeparated(param.ReasoningFormat) {
+		if !toolPolicy.parseResponse() && reasoningSeparated(param.ReasoningFormat) {
 			class = reasoningClass()
 		}
 		profile, fullText, err := gen(prompt, sink(class, &content, &reasoning))
@@ -330,14 +367,181 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return
 		}
-		writeBlockingResponse(c, content.String(), reasoning.String(), profile, parseTool)
+		writeBlockingResponse(c, content.String(), reasoning.String(), profile, toolPolicy)
 	}
 }
 
-func parseTools(param ChatCompletionRequest) (bool, string, error) {
-	if len(param.Tools) == 0 {
-		return false, "", nil
+type toolSelectionMode string
+
+const (
+	toolSelectionNone     toolSelectionMode = "none"
+	toolSelectionAuto     toolSelectionMode = "auto"
+	toolSelectionRequired toolSelectionMode = "required"
+	toolSelectionNamed    toolSelectionMode = "named"
+)
+
+const (
+	requiredToolCallParseFailedCode = "required_tool_call_parse_failed"
+	requiredToolCallParseFailedText = "the explicitly selected tool was not emitted or could not be parsed"
+)
+
+type toolSelectionPolicy struct {
+	mode         toolSelectionMode
+	namedTool    string
+	allowedTools []string
+}
+
+func (p toolSelectionPolicy) parseResponse() bool {
+	return p.mode == toolSelectionAuto || p.mode == toolSelectionRequired || p.mode == toolSelectionNamed
+}
+
+func (p toolSelectionPolicy) explicit() bool {
+	return p.mode == toolSelectionRequired || p.mode == toolSelectionNamed
+}
+
+func (p toolSelectionPolicy) templateToolChoice() string {
+	if p.explicit() {
+		// Named selection has already filtered the supplied list to exactly one
+		// function, so llama.cpp required mode enforces that selected name.
+		return string(toolSelectionRequired)
 	}
-	tools, err := sonic.MarshalString(param.Tools)
-	return true, tools, err
+	return string(p.mode)
+}
+
+func strictRequiredToolGrammar(grammar string) (string, error) {
+	const permissiveRoot = "root ::= start message* scan-to-toolcall tool-call"
+	const requiredRoot = "root ::= start tool-call"
+	if !strings.Contains(grammar, permissiveRoot) {
+		return "", errors.New("active chat template does not expose the expected required-tool grammar root")
+	}
+	return strings.Replace(grammar, permissiveRoot, requiredRoot, 1), nil
+}
+
+func (p toolSelectionPolicy) accepts(name string) bool {
+	for _, allowed := range p.allowedTools {
+		if name == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func (p toolSelectionPolicy) directive() string {
+	switch p.mode {
+	case toolSelectionRequired:
+		return "API tool selection requirement: call exactly one of the provided functions before answering. " +
+			"Emit only the tool call with its arguments; do not emit planning prose or a final answer."
+	case toolSelectionNamed:
+		return fmt.Sprintf(
+			"API tool selection requirement: call the function %q before answering. "+
+				"Emit only that tool call with its arguments; do not emit planning prose or a final answer.",
+			p.namedTool,
+		)
+	default:
+		return ""
+	}
+}
+
+func applyLlmToolSelectionDirective(messages []geniex_sdk.LlmChatMessage, policy toolSelectionPolicy) []geniex_sdk.LlmChatMessage {
+	directive := policy.directive()
+	if directive == "" {
+		return messages
+	}
+	result := make([]geniex_sdk.LlmChatMessage, 0, len(messages)+1)
+	result = append(result, geniex_sdk.LlmChatMessage{Role: "system", Content: directive})
+	return append(result, messages...)
+}
+
+func applyVlmToolSelectionDirective(messages []geniex_sdk.VlmChatMessage, policy toolSelectionPolicy) []geniex_sdk.VlmChatMessage {
+	directive := policy.directive()
+	if directive == "" {
+		return messages
+	}
+	result := make([]geniex_sdk.VlmChatMessage, 0, len(messages)+1)
+	result = append(result, geniex_sdk.VlmChatMessage{
+		Role:     "system",
+		Contents: []geniex_sdk.VlmContent{{Type: geniex_sdk.VlmContentTypeText, Text: directive}},
+	})
+	return append(result, messages...)
+}
+
+func parseTools(param ChatCompletionRequest) (toolSelectionPolicy, string, error) {
+	policy := toolSelectionPolicy{mode: toolSelectionAuto}
+	selectedTools := param.Tools
+
+	switch {
+	case len(param.rawToolChoice) > 0 && strings.HasPrefix(strings.TrimSpace(string(param.rawToolChoice)), "{"):
+		var named struct {
+			Type     string `json:"type"`
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		}
+		if err := sonic.Unmarshal(param.rawToolChoice, &named); err != nil {
+			return policy, "", fmt.Errorf("invalid named tool_choice: %w", err)
+		}
+		if named.Type != "function" || named.Function.Name == "" {
+			return policy, "", errors.New("only named function tool_choice is supported")
+		}
+		policy.mode = toolSelectionNamed
+		policy.namedTool = named.Function.Name
+		selectedTools = nil
+		for _, tool := range param.Tools {
+			function := tool.GetFunction()
+			if function != nil && function.Name == policy.namedTool {
+				selectedTools = append(selectedTools, tool)
+			}
+		}
+		if len(selectedTools) != 1 {
+			return policy, "", fmt.Errorf("named tool_choice references unknown function %q", policy.namedTool)
+		}
+	case param.ToolChoice.OfAuto.Valid():
+		switch param.ToolChoice.OfAuto.Value {
+		case "", "auto":
+			policy.mode = toolSelectionAuto
+		case "none":
+			policy.mode = toolSelectionNone
+		case "required":
+			policy.mode = toolSelectionRequired
+		default:
+			return policy, "", fmt.Errorf("unsupported tool_choice %q", param.ToolChoice.OfAuto.Value)
+		}
+	case param.ToolChoice.OfFunctionToolChoice != nil:
+		policy.mode = toolSelectionNamed
+		policy.namedTool = param.ToolChoice.OfFunctionToolChoice.Function.Name
+		if policy.namedTool == "" {
+			return policy, "", errors.New("named tool_choice requires a function name")
+		}
+		selectedTools = nil
+		for _, tool := range param.Tools {
+			function := tool.GetFunction()
+			if function != nil && function.Name == policy.namedTool {
+				selectedTools = append(selectedTools, tool)
+			}
+		}
+		if len(selectedTools) != 1 {
+			return policy, "", fmt.Errorf("named tool_choice references unknown function %q", policy.namedTool)
+		}
+	case param.ToolChoice.OfAllowedTools != nil || param.ToolChoice.OfCustomToolChoice != nil:
+		return policy, "", errors.New("only function tool_choice is supported")
+	}
+
+	if len(param.Tools) == 0 {
+		if policy.explicit() {
+			return policy, "", errors.New("explicit tool_choice requires at least one function tool")
+		}
+		return toolSelectionPolicy{mode: toolSelectionNone}, "", nil
+	}
+	if policy.mode == toolSelectionNone {
+		return policy, "", nil
+	}
+	for _, tool := range selectedTools {
+		function := tool.GetFunction()
+		if function == nil || function.Name == "" {
+			return policy, "", errors.New("only named function tools are supported")
+		}
+		policy.allowedTools = append(policy.allowedTools, function.Name)
+	}
+	tools, err := sonic.MarshalString(selectedTools)
+	return policy, tools, err
 }

--- a/cli/server/handler/chat_response.go
+++ b/cli/server/handler/chat_response.go
@@ -83,9 +83,30 @@ type blockingResponse struct {
 	Usage   openai.CompletionUsage `json:"usage"`
 }
 
-func writeBlockingResponse(c *gin.Context, content, reasoning string, profile geniex_sdk.ProfileData, parseTool bool) {
-	if parseTool {
-		toolCall, err := utils.ParseToolCalls(content)
+func parseSelectedToolCall(content string, policy toolSelectionPolicy) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	toolCall, err := utils.ParseToolCalls(content)
+	if err != nil {
+		return toolCall, err
+	}
+	if !policy.accepts(toolCall.Name) {
+		return openai.ChatCompletionMessageFunctionToolCallFunction{}, fmt.Errorf("model selected unavailable function %q", toolCall.Name)
+	}
+	return toolCall, nil
+}
+
+func requiredToolError() map[string]any {
+	return map[string]any{
+		"error": map[string]any{
+			"message": requiredToolCallParseFailedText,
+			"type":    "invalid_model_response",
+			"code":    requiredToolCallParseFailedCode,
+		},
+	}
+}
+
+func writeBlockingResponse(c *gin.Context, content, reasoning string, profile geniex_sdk.ProfileData, policy toolSelectionPolicy) {
+	if policy.parseResponse() {
+		toolCall, err := parseSelectedToolCall(content, policy)
 		if err == nil {
 			choice := openai.ChatCompletionChoice{
 				FinishReason: "tool_calls",
@@ -102,6 +123,11 @@ func writeBlockingResponse(c *gin.Context, content, reasoning string, profile ge
 				Choices: []openai.ChatCompletionChoice{choice},
 				Usage:   profile2Usage(profile),
 			})
+			return
+		}
+		if policy.explicit() {
+			slog.Warn("Required tool call parse failed", "error", err, "tool_choice", policy.mode)
+			c.JSON(http.StatusBadGateway, requiredToolError())
 			return
 		}
 		slog.Warn("Tool call parse error, fallback to text", "error", err)

--- a/cli/server/handler/chat_stream.go
+++ b/cli/server/handler/chat_stream.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openai/openai-go/v3"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
-	"github.com/qualcomm/GenieX/cli/server/utils"
 )
 
 // Local types so finish_reason serializes as null on intermediate chunks and a
@@ -113,7 +112,7 @@ func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, in
 
 // Buffers the whole stream, then emits one tool-call chunk (or a content chunk
 // on parse failure).
-func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData) {
+func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData, policy toolSelectionPolicy) {
 	buffer := strings.Builder{}
 	c.Stream(func(w io.Writer) bool {
 		r, ok := <-dataCh
@@ -127,8 +126,14 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			return false
 		}
 		finishReason := "tool_calls"
-		toolCall, err := utils.ParseToolCalls(buffer.String())
+		toolCall, err := parseSelectedToolCall(buffer.String(), policy)
 		if err != nil {
+			if policy.explicit() {
+				slog.Warn("Required tool call parse failed", "error", err, "tool_choice", policy.mode)
+				c.SSEvent("", requiredToolError())
+				c.SSEvent("", "[DONE]")
+				return false
+			}
 			slog.Warn("Tool call parse error, fallback to text", "error", err)
 			finishReason = mapFinishReason(profile.StopReason)
 			c.SSEvent("", contentChunk(buffer.String()))

--- a/cli/server/handler/chat_test.go
+++ b/cli/server/handler/chat_test.go
@@ -4,8 +4,16 @@
 package handler
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 )
 
 func TestReasoningSeparated(t *testing.T) {
@@ -52,4 +60,239 @@ func TestSinks(t *testing.T) {
 			t.Errorf("content = %q, want raw inline", got)
 		}
 	})
+}
+
+const testKnowledgeTool = `{
+  "type":"function",
+  "function":{
+    "name":"search_knowledge",
+    "description":"Search the local knowledge source.",
+    "parameters":{
+      "type":"object",
+      "properties":{"query":{"type":"string"}},
+      "required":["query"],
+      "additionalProperties":false
+    }
+  }
+}`
+
+func toolRequest(t *testing.T, choice string, withTools bool) ChatCompletionRequest {
+	t.Helper()
+	tools := "[]"
+	if withTools {
+		tools = "[" + testKnowledgeTool + "]"
+	}
+	input := `{"messages":[{"role":"user","content":"Search coffee."}],"tools":` + tools
+	if choice != "" {
+		input += `,"tool_choice":` + choice
+	}
+	input += `}`
+	var request ChatCompletionRequest
+	if err := json.Unmarshal([]byte(input), &request); err != nil {
+		t.Fatal(err)
+	}
+	return request
+}
+
+func namedToolRequest(t *testing.T, name string) ChatCompletionRequest {
+	t.Helper()
+	return toolRequest(t, `{"type":"function","function":{"name":"`+name+`"}}`, true)
+}
+
+func TestParseToolsTranslatesOpenAIToolChoice(t *testing.T) {
+	tests := []struct {
+		name       string
+		choice     string
+		named      string
+		withTools  bool
+		wantMode   toolSelectionMode
+		wantName   string
+		wantChoice string
+		wantError  bool
+	}{
+		{name: "omitted remains auto", withTools: true, wantMode: toolSelectionAuto, wantChoice: "auto"},
+		{name: "auto remains auto", choice: `"auto"`, withTools: true, wantMode: toolSelectionAuto, wantChoice: "auto"},
+		{name: "required", choice: `"required"`, withTools: true, wantMode: toolSelectionRequired, wantChoice: "required"},
+		{name: "none", choice: `"none"`, withTools: true, wantMode: toolSelectionNone, wantChoice: "none"},
+		{name: "named function", withTools: true, named: "search_knowledge", wantMode: toolSelectionNamed, wantName: "search_knowledge", wantChoice: "required"},
+		{name: "unknown named function", withTools: true, named: "unknown", wantError: true},
+		{name: "required without tools", choice: `"required"`, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := toolRequest(t, tt.choice, tt.withTools)
+			if tt.named != "" {
+				request = namedToolRequest(t, tt.named)
+			}
+			policy, tools, err := parseTools(request)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got policy=%+v tools=%s", policy, tools)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if policy.mode != tt.wantMode || policy.namedTool != tt.wantName {
+				t.Fatalf("policy=%+v, want mode=%s name=%q", policy, tt.wantMode, tt.wantName)
+			}
+			if got := policy.templateToolChoice(); got != tt.wantChoice {
+				t.Fatalf("template tool choice=%q, want %q", got, tt.wantChoice)
+			}
+			if tt.wantMode == toolSelectionNone && tools != "" {
+				t.Fatalf("none selection still rendered tools: %s", tools)
+			}
+			if tt.wantMode != toolSelectionNone && tt.withTools && !strings.Contains(tools, "search_knowledge") {
+				t.Fatalf("selected function missing from tools: %s", tools)
+			}
+		})
+	}
+}
+
+func TestExplicitToolSelectionAddsOneTemplateDirective(t *testing.T) {
+	for _, request := range []ChatCompletionRequest{
+		toolRequest(t, `"required"`, true),
+		namedToolRequest(t, "search_knowledge"),
+	} {
+		policy, _, err := parseTools(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		messages := applyLlmToolSelectionDirective([]geniex_sdk.LlmChatMessage{{Role: "user", Content: "Search coffee."}}, policy)
+		if len(messages) != 2 || messages[0].Role != "system" || !strings.Contains(messages[0].Content, "Emit only") || messages[1].Content != "Search coffee." {
+			t.Fatalf("unexpected translated messages: %+v", messages)
+		}
+	}
+
+	auto, _, err := parseTools(toolRequest(t, `"auto"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := []geniex_sdk.LlmChatMessage{{Role: "user", Content: "ordinary"}}
+	if got := applyLlmToolSelectionDirective(original, auto); len(got) != 1 || got[0].Content != "ordinary" {
+		t.Fatalf("auto request was modified: %+v", got)
+	}
+}
+
+func TestStrictRequiredToolGrammarRemovesProsePrefix(t *testing.T) {
+	grammar := "message ::= thought content\nroot ::= start message* scan-to-toolcall tool-call\ntool-call ::= \"call\"\n"
+	strict, err := strictRequiredToolGrammar(grammar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(strict, "root ::= start tool-call") || strings.Contains(strict, "message* scan-to-toolcall") {
+		t.Fatalf("required grammar still permits a prose prefix: %s", strict)
+	}
+	if _, err := strictRequiredToolGrammar("root ::= content"); err == nil {
+		t.Fatal("unexpected grammar shape did not fail closed")
+	}
+}
+
+type closeNotifyRecorder struct{ *httptest.ResponseRecorder }
+
+func (r closeNotifyRecorder) CloseNotify() <-chan bool { return make(chan bool) }
+
+func TestExplicitToolCallValidation(t *testing.T) {
+	policy, _, err := parseTools(toolRequest(t, `"required"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	call, err := parseSelectedToolCall(`<|tool_call>call:search_knowledge{query:<|"|>coffee<|"|>}<tool_call|>`, policy)
+	if err != nil || call.Name != "search_knowledge" || call.Arguments != `{"query":"coffee"}` {
+		t.Fatalf("unexpected selected call: call=%+v err=%v", call, err)
+	}
+	if _, err := parseSelectedToolCall(`{"name":"unknown","arguments":{}}`, policy); err == nil {
+		t.Fatal("unavailable model-selected tool was accepted")
+	}
+}
+
+func TestRequiredBlockingResponseNormalizesCall(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	policy, _, err := parseTools(toolRequest(t, `"required"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	writeBlockingResponse(context, `<|tool_call>call:search_knowledge{query:<|"|>coffee<|"|>}<tool_call|>`, "", geniex_sdk.ProfileData{}, policy)
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), `"finish_reason":"tool_calls"`) || !strings.Contains(recorder.Body.String(), "search_knowledge") {
+		t.Fatalf("required call not normalized: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRequiredBlockingResponseFailsClosed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	policy, _, err := parseTools(toolRequest(t, `"required"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := closeNotifyRecorder{httptest.NewRecorder()}
+	context, _ := gin.CreateTestContext(recorder)
+	writeBlockingResponse(context, "I need to search first.", "", geniex_sdk.ProfileData{}, policy)
+	if recorder.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), "I need to search") || !strings.Contains(recorder.Body.String(), requiredToolCallParseFailedCode) {
+		t.Fatalf("required failure leaked prose or omitted code: %s", recorder.Body.String())
+	}
+}
+
+func TestAutoBlockingResponseStillAllowsOrdinaryText(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	policy, _, err := parseTools(toolRequest(t, `"auto"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	writeBlockingResponse(context, "ordinary answer", "", geniex_sdk.ProfileData{}, policy)
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), "ordinary answer") {
+		t.Fatalf("auto text response changed: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestRequiredStreamingCallIsBufferedAndNormalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	policy, _, err := parseTools(toolRequest(t, `"required"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make(chan string, 5)
+	for _, piece := range []string{"<|tool_", "call>call:search_", "knowledge{query:<|\"|>", "coffee<|\"|>}<tool_", "call|>"} {
+		data <- piece
+	}
+	close(data)
+	recorder := closeNotifyRecorder{httptest.NewRecorder()}
+	context, _ := gin.CreateTestContext(recorder)
+	profile := geniex_sdk.ProfileData{}
+	streamToolCall(context, data, func() error { return nil }, false, &profile, policy)
+	body, err := io.ReadAll(recorder.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	if strings.Contains(text, "<|tool_call>") || !strings.Contains(text, "search_knowledge") || !strings.Contains(text, `"finish_reason":"tool_calls"`) {
+		t.Fatalf("stream did not normalize selected call: %s", text)
+	}
+}
+
+func TestRequiredStreamingFailureDoesNotFallbackToContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	policy, _, err := parseTools(toolRequest(t, `"required"`, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := make(chan string, 1)
+	data <- "I need to search first."
+	close(data)
+	recorder := closeNotifyRecorder{httptest.NewRecorder()}
+	context, _ := gin.CreateTestContext(recorder)
+	profile := geniex_sdk.ProfileData{}
+	streamToolCall(context, data, func() error { return nil }, false, &profile, policy)
+	text := recorder.Body.String()
+	if strings.Contains(text, "I need to search") || !strings.Contains(text, requiredToolCallParseFailedCode) || strings.Contains(text, `"finish_reason":"stop"`) {
+		t.Fatalf("stream required failure fell back to text: %s", text)
+	}
 }

--- a/cli/server/utils/toolcall.go
+++ b/cli/server/utils/toolcall.go
@@ -4,13 +4,247 @@
 package utils
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/bytedance/sonic/ast"
 	"github.com/openai/openai-go/v3"
 )
+
+const (
+	gemma4ToolCallStart = "<|tool_call>"
+	gemma4ToolCallEnd   = "<tool_call|>"
+	gemma4StringMarker  = "<|\"|>"
+)
+
+// gemma4ValueParser converts Gemma 4's native argument notation into JSON.
+// Gemma 4 uses unquoted object keys and <|"|> delimiters for string values:
+//
+//	{query:<|"|>coffee latte<|"|>}
+//
+// This parser is deliberately limited to JSON-equivalent values. It never
+// evaluates expressions or accepts executable syntax.
+type gemma4ValueParser struct {
+	value string
+	pos   int
+}
+
+func (p *gemma4ValueParser) skipSpace() {
+	for p.pos < len(p.value) {
+		switch p.value[p.pos] {
+		case ' ', '\t', '\r', '\n':
+			p.pos++
+		default:
+			return
+		}
+	}
+}
+
+func (p *gemma4ValueParser) parseValue() (string, error) {
+	p.skipSpace()
+	if p.pos >= len(p.value) {
+		return "", errors.New("missing Gemma 4 tool argument value")
+	}
+	switch {
+	case strings.HasPrefix(p.value[p.pos:], gemma4StringMarker):
+		return p.parseString()
+	case p.value[p.pos] == '{':
+		return p.parseObject()
+	case p.value[p.pos] == '[':
+		return p.parseArray()
+	default:
+		return p.parseLiteral()
+	}
+}
+
+func (p *gemma4ValueParser) parseString() (string, error) {
+	p.pos += len(gemma4StringMarker)
+	end := strings.Index(p.value[p.pos:], gemma4StringMarker)
+	if end < 0 {
+		return "", errors.New("unterminated Gemma 4 tool string")
+	}
+	raw := p.value[p.pos : p.pos+end]
+	p.pos += end + len(gemma4StringMarker)
+	encoded, err := json.Marshal(raw)
+	return string(encoded), err
+}
+
+func (p *gemma4ValueParser) parseKey() (string, error) {
+	p.skipSpace()
+	if strings.HasPrefix(p.value[p.pos:], gemma4StringMarker) {
+		encoded, err := p.parseString()
+		if err != nil {
+			return "", err
+		}
+		var key string
+		if err := json.Unmarshal([]byte(encoded), &key); err != nil {
+			return "", err
+		}
+		return key, nil
+	}
+	start := p.pos
+	for p.pos < len(p.value) && p.value[p.pos] != ':' {
+		switch p.value[p.pos] {
+		case '{', '}', '[', ']', ',':
+			return "", errors.New("invalid Gemma 4 tool argument key")
+		}
+		p.pos++
+	}
+	if p.pos >= len(p.value) {
+		return "", errors.New("missing Gemma 4 tool argument separator")
+	}
+	key := strings.TrimSpace(p.value[start:p.pos])
+	if key == "" {
+		return "", errors.New("empty Gemma 4 tool argument key")
+	}
+	return key, nil
+}
+
+func (p *gemma4ValueParser) parseObject() (string, error) {
+	p.pos++
+	var result strings.Builder
+	result.WriteByte('{')
+	p.skipSpace()
+	if p.pos < len(p.value) && p.value[p.pos] == '}' {
+		p.pos++
+		result.WriteByte('}')
+		return result.String(), nil
+	}
+	for count := 0; ; count++ {
+		if count > 0 {
+			result.WriteByte(',')
+		}
+		key, err := p.parseKey()
+		if err != nil {
+			return "", err
+		}
+		if p.pos >= len(p.value) || p.value[p.pos] != ':' {
+			return "", errors.New("missing Gemma 4 tool argument separator")
+		}
+		p.pos++
+		encodedKey, err := json.Marshal(key)
+		if err != nil {
+			return "", err
+		}
+		encodedValue, err := p.parseValue()
+		if err != nil {
+			return "", err
+		}
+		result.Write(encodedKey)
+		result.WriteByte(':')
+		result.WriteString(encodedValue)
+		p.skipSpace()
+		if p.pos >= len(p.value) {
+			return "", errors.New("unterminated Gemma 4 tool argument object")
+		}
+		switch p.value[p.pos] {
+		case ',':
+			p.pos++
+		case '}':
+			p.pos++
+			result.WriteByte('}')
+			return result.String(), nil
+		default:
+			return "", errors.New("invalid Gemma 4 tool argument object")
+		}
+	}
+}
+
+func (p *gemma4ValueParser) parseArray() (string, error) {
+	p.pos++
+	var result strings.Builder
+	result.WriteByte('[')
+	p.skipSpace()
+	if p.pos < len(p.value) && p.value[p.pos] == ']' {
+		p.pos++
+		result.WriteByte(']')
+		return result.String(), nil
+	}
+	for count := 0; ; count++ {
+		if count > 0 {
+			result.WriteByte(',')
+		}
+		encoded, err := p.parseValue()
+		if err != nil {
+			return "", err
+		}
+		result.WriteString(encoded)
+		p.skipSpace()
+		if p.pos >= len(p.value) {
+			return "", errors.New("unterminated Gemma 4 tool argument array")
+		}
+		switch p.value[p.pos] {
+		case ',':
+			p.pos++
+		case ']':
+			p.pos++
+			result.WriteByte(']')
+			return result.String(), nil
+		default:
+			return "", errors.New("invalid Gemma 4 tool argument array")
+		}
+	}
+}
+
+func (p *gemma4ValueParser) parseLiteral() (string, error) {
+	start := p.pos
+	for p.pos < len(p.value) && !strings.ContainsRune(",}] \t\r\n", rune(p.value[p.pos])) {
+		p.pos++
+	}
+	literal := p.value[start:p.pos]
+	var decoded any
+	if literal == "" || json.Unmarshal([]byte(literal), &decoded) != nil {
+		return "", fmt.Errorf("invalid Gemma 4 tool argument literal %q", literal)
+	}
+	return literal, nil
+}
+
+func parseGemma4ToolCall(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	toolCall := openai.ChatCompletionMessageFunctionToolCallFunction{}
+	searchFrom := 0
+	for searchFrom < len(resp) {
+		startOffset := strings.Index(resp[searchFrom:], gemma4ToolCallStart)
+		if startOffset < 0 {
+			break
+		}
+		start := searchFrom + startOffset + len(gemma4ToolCallStart)
+		endOffset := strings.Index(resp[start:], gemma4ToolCallEnd)
+		if endOffset < 0 {
+			break
+		}
+		payload := strings.TrimSpace(resp[start : start+endOffset])
+		searchFrom = start + endOffset + len(gemma4ToolCallEnd)
+		if !strings.HasPrefix(payload, "call:") {
+			continue
+		}
+		payload = strings.TrimSpace(strings.TrimPrefix(payload, "call:"))
+		objectStart := strings.IndexByte(payload, '{')
+		if objectStart <= 0 {
+			continue
+		}
+		name := strings.TrimSpace(payload[:objectStart])
+		if name == "" || strings.ContainsAny(name, "{}[],: \t\r\n") {
+			continue
+		}
+		parser := gemma4ValueParser{value: payload[objectStart:]}
+		arguments, err := parser.parseObject()
+		if err != nil {
+			continue
+		}
+		parser.skipSpace()
+		if parser.pos != len(parser.value) {
+			continue
+		}
+		toolCall.Name = name
+		toolCall.Arguments = arguments
+		return toolCall, nil
+	}
+	return toolCall, errors.New("Gemma 4 tool call not match")
+}
 
 // balancedObjectEnd returns the index just past the '}' matching the '{' at
 // start, skipping braces inside string literals. -1 if never closed.
@@ -99,6 +333,10 @@ func parseToolCallObject(obj string) (openai.ChatCompletionMessageFunctionToolCa
 // ParseToolCalls returns the first balanced {...} object in resp that decodes
 // into a valid tool call, skipping any malformed or non-tool-call objects.
 func ParseToolCalls(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	if toolCall, err := parseGemma4ToolCall(resp); err == nil {
+		slog.Debug("Parsed Gemma 4 native tool call", "tool_call", toolCall)
+		return toolCall, nil
+	}
 	for _, obj := range extractJSONObjects(resp) {
 		if toolCall, err := parseToolCallObject(obj); err == nil {
 			slog.Debug("Parsed tool call", "tool_call", toolCall)

--- a/cli/server/utils/toolcall_test.go
+++ b/cli/server/utils/toolcall_test.go
@@ -152,6 +152,41 @@ func TestParseToolCalls(t *testing.T) {
 			wantArgs: `{"q": "x"}`,
 		},
 		{
+			name:     "Gemma 4 native knowledge call",
+			resp:     `<|tool_call>call:search_knowledge{query:<|"|>低負擔白肉選擇<|"|>}<tool_call|>`,
+			wantName: "search_knowledge",
+			wantArgs: `{"query":"低負擔白肉選擇"}`,
+		},
+		{
+			name:     "Gemma 4 native call after reasoning",
+			resp:     "<|channel>thought\n需要查詢。<channel|><|tool_call>call:search_knowledge{query:<|\"|>香烤 雞肉<|\"|>}<tool_call|>",
+			wantName: "search_knowledge",
+			wantArgs: `{"query":"香烤 雞肉"}`,
+		},
+		{
+			name:     "Gemma 4 native empty arguments",
+			resp:     `<|tool_call>call:empty_args{}<tool_call|>`,
+			wantName: "empty_args",
+			wantArgs: `{}`,
+		},
+		{
+			name:     "Gemma 4 native nested JSON-equivalent arguments",
+			resp:     `<|tool_call>call:set_config{config:{theme:<|"|>dark<|"|>,count:3},enabled:true,todos:[<|"|>one<|"|>,<|"|>two<|"|>]}<tool_call|>`,
+			wantName: "set_config",
+			wantArgs: `{"config":{"theme":"dark","count":3},"enabled":true,"todos":["one","two"]}`,
+		},
+		{
+			name:     "malformed Gemma 4 call skips to later valid native call",
+			resp:     `<|tool_call>call:bad{query:<|"|>unterminated}<tool_call|><|tool_call>call:good{query:<|"|>valid<|"|>}<tool_call|>`,
+			wantName: "good",
+			wantArgs: `{"query":"valid"}`,
+		},
+		{
+			name:      "malformed Gemma 4 call fails closed",
+			resp:      `<|tool_call>call:bad{query:<|"|>unterminated}<tool_call|>`,
+			wantError: true,
+		},
+		{
 			name:      "no json object",
 			resp:      "just some plain text without any call",
 			wantError: true,

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -512,6 +512,7 @@ typedef struct {
     geniex_LlmChatMessage* messages;              /** Array of chat messages */
     int32_t                message_count;         /** Number of messages */
     const char*            tools;                 /** Tool JSON string (optional, can be NULL) */
+    const char*            tool_choice;           /** OpenAI tool choice: auto, required, or none */
     bool                   enable_thinking;       /** Enable thinking */
     bool                   add_generation_prompt; /** Add generation prompt */
 } geniex_LlmApplyChatTemplateInput;
@@ -519,6 +520,7 @@ typedef struct {
 /** Output structure for applying chat template */
 typedef struct {
     char* formatted_text; /** Formatted chat text (caller must free with geniex_free) */
+    char* grammar;        /** Generated grammar for required tool selection (optional) */
 } geniex_LlmApplyChatTemplateOutput;
 
 /**

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -208,6 +208,10 @@ int32_t LlamaLlm::apply_chat_template(
         inputs.tools = common_chat_tools_parse_oaicompat(nlohmann::ordered_json::parse(std::string(input->tools)));
     }
 
+    if (input->tool_choice && strlen(input->tool_choice) > 0) {
+        inputs.tool_choice = common_chat_tool_choice_parse_oaicompat(input->tool_choice);
+    }
+
     inputs.enable_thinking = input->enable_thinking;
 
     // Apply chat template
@@ -216,6 +220,14 @@ int32_t LlamaLlm::apply_chat_template(
     output->formatted_text = strdup(result.prompt.c_str());
     if (!output->formatted_text) {
         return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;  // error: memory allocation failed
+    }
+    if (!result.grammar.empty()) {
+        output->grammar = strdup(result.grammar.c_str());
+        if (!output->grammar) {
+            free(output->formatted_text);
+            output->formatted_text = nullptr;
+            return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;
+        }
     }
     return GENIEX_SUCCESS;
 }


### PR DESCRIPTION
## Problem

Gemma 4 emits a native non-JSON tool-call form that GenieX did not normalize consistently. OpenAI-compatible explicit `tool_choice` authority was also discarded before the llama.cpp chat-template path, while the generated grammar permitted ordinary prose before a required call. When parsing then failed, required/named requests silently fell back to successful assistant prose.

## Fix

- Parse and normalize Gemma 4 native tool calls while preserving the existing JSON parser.
- Propagate `tool_choice` through the Go binding, GenieX C ABI, and llama.cpp chat-template path.
- Apply the chat-template-generated grammar.
- Constrain required/named selections to the tool-call grammar instead of allowing prose first.
- Validate and filter named function selection and validate the function emitted by the model.
- Fail closed with a structured `required_tool_call_parse_failed` error when an explicit call is missing or malformed.
- Preserve ordinary `tool_choice=auto` behavior in streaming and non-streaming responses.

## Validation

- `utils_test`: PASS
- `handler_test_posix`: PASS
- GenieX Bazel build: PASS
- Native SDK build: PASS
- Accelerated SDK build: NOT RUN — the isolated worktree had no configured accelerated build, and the native build exercised the changed ABI/C++ path.
- `git diff --check`: PASS

Provider evidence:

```text
Required non-streaming:
finish_reason=tool_calls
search_knowledge
{"query":"咖啡"}

Required streaming:
one normalized call
no content leakage
finish_reason=tool_calls

Negative explicit mode:
HTTP 502
required_tool_call_parse_failed
no prose fallback
```

Downstream Local VRM evidence:

```text
Typed explicit coffee-list request: PASS
Typed explicit Americano-price request: PASS
Ordinary follow-up turn isolation: PASS
```

## Scope boundary

- No model changes
- No GenieX version upgrade
- No llama.cpp upgrade or submodule pointer change
- No Local VRM changes
- No ASR changes
- No microphone acceptance claim
- No model, local data, benchmark, or build artifacts

## Pending acceptance

Physical human-microphone validation remains pending in the downstream Local VRM application. A synthetic audio probe was mistranscribed by ASR before reaching GenieX; this does not block the provider correction.