### PR TITLE
fix(sdk): accept both QAIRT runtime enums when selecting AI Hub assets

### DIFF
--- a/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
@@ -30,7 +30,9 @@ use self::dto::{
     ChipsetInfo, InfoJson, ManifestModelEntry, ModelReleaseAssets, PlatformInfo, ReleaseManifest,
 };
 use self::remote_zip::{fetch_central_directory, Method, ZipEntry};
-use self::selector::{match_asset, UnavailableChipset};
+// `is_qairt_runtime` is shared with the download selector so the listing
+// filter and the asset picker cannot drift apart.
+use self::selector::{is_qairt_runtime, match_asset, UnavailableChipset};
 
 use super::{basename, BytesSource, FileSpec, ModelSource, Plan};
 
@@ -162,9 +164,6 @@ pub async fn list_supported_chipsets(cfg: &AiHubConfig) -> Result<Vec<ChipsetInf
     Ok(chipsets)
 }
 
-/// Runtime string the public bucket uses for geniex's qairt (NPU) assets.
-const RUNTIME_GENIEX_QAIRT: &str = "RUNTIME_GENIEX_QAIRT";
-
 /// One AI Hub model geniex can run.
 #[derive(Debug, Clone)]
 pub struct HubModel {
@@ -174,7 +173,7 @@ pub struct HubModel {
     pub supported_chipsets: Vec<String>,
 }
 
-/// List AI Hub models with a `RUNTIME_GENIEX_QAIRT` asset, sorted by name.
+/// List AI Hub models with a QAIRT asset, sorted by name.
 /// `chipset` restricts to models compatible with it (any alias / display name
 /// from `platform.json`); `None` lists every one. Host detection is the
 /// caller's job — pass the chipset you want to match.
@@ -214,11 +213,7 @@ fn select_hub_models(manifest: ReleaseManifest, device_chipset: Option<&str>) ->
     let mut models: Vec<HubModel> = manifest
         .models
         .into_iter()
-        .filter(|m| {
-            m.supported_runtimes
-                .iter()
-                .any(|r| r == RUNTIME_GENIEX_QAIRT)
-        })
+        .filter(|m| m.supported_runtimes.iter().any(|r| is_qairt_runtime(r)))
         .filter(|m| match device_chipset {
             Some(chip) => m.supported_chipsets.iter().any(|c| c == chip),
             None => true,
@@ -757,6 +752,25 @@ mod tests {
         let out = select_hub_models(manifest, None);
         let ids: Vec<&str> = out.iter().map(|m| m.id.as_str()).collect();
         assert_eq!(ids, vec!["qairt_model"]);
+    }
+
+    /// `Phi-3.5-Mini-Instruct` (bucket v0.60.0) declares only the legacy
+    /// `RUNTIME_GENIE` enum, so filtering on `RUNTIME_GENIEX_QAIRT` alone
+    /// silently hid it from `list` even though its assets are installable.
+    #[test]
+    fn select_keeps_legacy_genie_only_models() {
+        let manifest = ReleaseManifest {
+            platform_url: String::new(),
+            models: vec![hub_entry(
+                "phi_3_5_mini_instruct",
+                &["RUNTIME_QNN_CONTEXT_BINARY", "RUNTIME_GENIE"],
+                &["qualcomm-snapdragon-x-elite"],
+                &[],
+            )],
+        };
+        let out = select_hub_models(manifest, None);
+        let ids: Vec<&str> = out.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["phi_3_5_mini_instruct"]);
     }
 
     #[test]

--- a/sdk/model-manager/crates/core/src/source/ai_hub/selector.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/selector.rs
@@ -7,22 +7,41 @@
 //! `cli/internal/model_hub/aihub/selector.go`:
 //!
 //! - Resolve the user-supplied chipset against `platform.json` aliases.
-//! - Filter to assets whose `runtime == RUNTIME_GENIE`. The CLI only
-//!   supports the Genie runtime (LLM / VLM domains); other assets are
-//!   rejected up front.
+//! - Filter to assets whose `runtime` is one of [`QAIRT_RUNTIMES`]. The
+//!   SDK only runs QAIRT (NPU) archives through this source; other assets
+//!   (ONNX, TFLite, QNN_DLC, llama.cpp GGUF) are rejected up front.
 //! - Filter to assets whose canonical chipset matches.
-//! - If multiple precisions survive, pick the lex-first precision string
-//!   for a deterministic default. The Go CLI sorts by enum value, which
-//!   produces the same order for the common precisions we see in practice
-//!   (`PRECISION_FP16` before `PRECISION_W4A16`, etc.). This is a
-//!   best-effort tiebreaker; precision selection is not exposed over FFI.
+//! - If multiple assets survive, prefer the newer `RUNTIME_GENIEX_QAIRT`
+//!   entry, then pick the lex-first precision string for a deterministic
+//!   default. Best-effort tiebreaker; precision is not exposed over FFI.
 
 use super::dto::{AssetDetails, ModelReleaseAssets, PlatformInfo};
 use crate::error::{Error, Result};
 
-/// Runtime string the public bucket uses for Genie-compatible assets.
-/// Matches `qaihm.Runtime_RUNTIME_GENIE`.
-const RUNTIME_GENIE: &str = "RUNTIME_GENIE";
+/// Runtime strings the public bucket uses for QAIRT (NPU) assets, in
+/// preference order.
+///
+/// AI Hub is mid-migration from the legacy `RUNTIME_GENIE` enum to the
+/// namespaced `RUNTIME_GENIEX_QAIRT`. Most models publish both, but neither
+/// alone is sufficient (bucket v0.60.0): `Gemma-4-E4B-it` ships only the
+/// new name, `Phi-3.5-Mini-Instruct` only the legacy one. Chipset coverage
+/// can also differ between the two for the same model, so both are kept as
+/// match candidates rather than picking one per model.
+const QAIRT_RUNTIMES: &[&str] = &["RUNTIME_GENIEX_QAIRT", "RUNTIME_GENIE"];
+
+/// Rank of `runtime` within [`QAIRT_RUNTIMES`] for the preference sort;
+/// non-QAIRT runtimes sort last (they're filtered out before this runs).
+fn runtime_rank(runtime: &str) -> usize {
+    QAIRT_RUNTIMES
+        .iter()
+        .position(|r| *r == runtime)
+        .unwrap_or(QAIRT_RUNTIMES.len())
+}
+
+/// Whether `runtime` names a QAIRT archive this source can install.
+pub fn is_qairt_runtime(runtime: &str) -> bool {
+    QAIRT_RUNTIMES.contains(&runtime)
+}
 
 /// Domains the SDK currently supports — same subset the Go CLI accepts
 /// in `RuntimeForDomain`.
@@ -80,7 +99,7 @@ pub fn resolve_chipset_display(plat: &PlatformInfo, chipset: &str) -> Option<Str
     None
 }
 
-/// Pick one asset matching `(chipset, RUNTIME_GENIE)`. Returns the list of
+/// Pick one asset matching `(chipset, QAIRT runtime)`. Returns the list of
 /// supported chipsets (for actionable error messages) when nothing matches.
 pub fn match_asset<'a>(
     ra: &'a ModelReleaseAssets,
@@ -107,7 +126,9 @@ pub fn match_asset<'a>(
     let mut candidates: Vec<&AssetDetails> = ra
         .assets
         .iter()
-        .filter(|a| a.runtime == RUNTIME_GENIE && a.chipset.as_deref() == Some(canonical.as_str()))
+        .filter(|a| {
+            is_qairt_runtime(&a.runtime) && a.chipset.as_deref() == Some(canonical.as_str())
+        })
         .collect();
 
     if candidates.is_empty() {
@@ -117,18 +138,28 @@ pub fn match_asset<'a>(
         });
     }
 
-    // Deterministic tiebreak when multiple precisions match.
-    candidates.sort_by(|a, b| a.precision.cmp(&b.precision));
+    // Prefer the newer runtime, then tiebreak on precision so the pick is
+    // deterministic when a model publishes the same chipset under both.
+    candidates.sort_by(|a, b| {
+        runtime_rank(&a.runtime)
+            .cmp(&runtime_rank(&b.runtime))
+            .then_with(|| a.precision.cmp(&b.precision))
+    });
     Ok(candidates[0])
 }
 
-/// Collect the chipsets a model ships assets for, rendered as the
-/// reference device names callers see in `list_supported_chipsets` (so
-/// error messages match the picker). Falls back to the canonical id when
-/// `platform.json` has no reference device for it.
+/// Collect the chipsets a model ships *installable* (QAIRT) assets for,
+/// rendered as the reference device names callers see in
+/// `list_supported_chipsets` (so error messages match the picker). Falls
+/// back to the canonical id when `platform.json` has no reference device
+/// for it.
+///
+/// Only accepted runtimes are counted: listing every chipset in
+/// `release-assets.json` regardless of runtime produced self-contradictory
+/// errors that named the very chipset the caller had just requested.
 fn collect_chipsets(ra: &ModelReleaseAssets, plat: &PlatformInfo) -> Vec<String> {
     let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for a in &ra.assets {
+    for a in ra.assets.iter().filter(|a| is_qairt_runtime(&a.runtime)) {
         if let Some(cs) = a.chipset.as_deref() {
             let display = plat
                 .chipsets
@@ -260,13 +291,80 @@ mod tests {
             model_id: "m".into(),
             assets: vec![
                 asset("SD8G3", "RUNTIME_TFLITE", "PRECISION_FP16"),
-                asset("SD8G3", "RUNTIME_GENIE", "PRECISION_W4A16"),
-                asset("Other", "RUNTIME_GENIE", "PRECISION_FP16"),
+                asset("SD8G3", "RUNTIME_GENIEX_QAIRT", "PRECISION_W4A16"),
+                asset("Other", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
             ],
         };
         let got = match_asset(&ra, &plat, "sm8650").unwrap();
         assert_eq!(got.chipset.as_deref(), Some("SD8G3"));
+        assert_eq!(got.runtime, "RUNTIME_GENIEX_QAIRT");
+    }
+
+    /// `Gemma-4-E4B-it` (bucket v0.60.0) publishes only
+    /// `RUNTIME_GENIEX_QAIRT`; matching the legacy name alone made it
+    /// undownloadable on every supported chipset.
+    #[test]
+    fn matches_geniex_qairt_only_model() {
+        let plat = platform(&[("qualcomm-snapdragon-x-elite", &["x1e80100"])]);
+        let ra = ModelReleaseAssets {
+            model_id: "gemma_4_e4b_it".into(),
+            assets: vec![asset(
+                "qualcomm-snapdragon-x-elite",
+                "RUNTIME_GENIEX_QAIRT",
+                "PRECISION_W4A16",
+            )],
+        };
+        let got = match_asset(&ra, &plat, "x1e80100").unwrap();
+        assert_eq!(got.runtime, "RUNTIME_GENIEX_QAIRT");
+    }
+
+    /// `Phi-3.5-Mini-Instruct` (bucket v0.60.0) still ships only the legacy
+    /// `RUNTIME_GENIE` enum, so dropping it would regress that model.
+    #[test]
+    fn matches_legacy_genie_only_model() {
+        let plat = platform(&[("qualcomm-snapdragon-x-elite", &["x1e80100"])]);
+        let ra = ModelReleaseAssets {
+            model_id: "phi_3_5_mini_instruct".into(),
+            assets: vec![asset(
+                "qualcomm-snapdragon-x-elite",
+                "RUNTIME_GENIE",
+                "PRECISION_W4A16",
+            )],
+        };
+        let got = match_asset(&ra, &plat, "x1e80100").unwrap();
         assert_eq!(got.runtime, "RUNTIME_GENIE");
+    }
+
+    /// When a model dual-publishes the same chipset the newer runtime wins,
+    /// even though `RUNTIME_GENIE` sorts first alphabetically.
+    #[test]
+    fn prefers_geniex_qairt_over_legacy_genie() {
+        let plat = platform(&[("A", &[])]);
+        let ra = ModelReleaseAssets {
+            model_id: "m".into(),
+            assets: vec![
+                asset("A", "RUNTIME_GENIE", "PRECISION_W4A16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_W4A16"),
+            ],
+        };
+        let got = match_asset(&ra, &plat, "A").unwrap();
+        assert_eq!(got.runtime, "RUNTIME_GENIEX_QAIRT");
+    }
+
+    /// Non-QAIRT assets must not leak into the "supported chipsets" hint,
+    /// or the error can name a chipset with no installable QAIRT archive.
+    #[test]
+    fn available_excludes_non_qairt_runtimes() {
+        let plat = platform(&[("A", &[]), ("B", &[])]);
+        let ra = ModelReleaseAssets {
+            model_id: "m".into(),
+            assets: vec![
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_W4A16"),
+                asset("B", "RUNTIME_TFLITE", "PRECISION_FP16"),
+            ],
+        };
+        let err = match_asset(&ra, &plat, "C").unwrap_err();
+        assert_eq!(err.available, vec!["A".to_string()]);
     }
 
     #[test]
@@ -275,7 +373,7 @@ mod tests {
         let ra = ModelReleaseAssets {
             model_id: "m".into(),
             assets: vec![
-                asset("A", "RUNTIME_GENIE", "PRECISION_FP16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
                 asset("B", "RUNTIME_GENIE", "PRECISION_FP16"),
             ],
         };
@@ -297,7 +395,7 @@ mod tests {
             model_id: "m".into(),
             assets: vec![asset(
                 "qualcomm-snapdragon-x-elite",
-                "RUNTIME_GENIE",
+                "RUNTIME_GENIEX_QAIRT",
                 "PRECISION_FP16",
             )],
         };
@@ -311,8 +409,8 @@ mod tests {
         let ra = ModelReleaseAssets {
             model_id: "m".into(),
             assets: vec![
-                asset("A", "RUNTIME_GENIE", "PRECISION_W4A16"),
-                asset("A", "RUNTIME_GENIE", "PRECISION_FP16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_W4A16"),
+                asset("A", "RUNTIME_GENIEX_QAIRT", "PRECISION_FP16"),
             ],
         };
         let picked = match_asset(&ra, &plat, "A").unwrap();

--- a/sdk/model-manager/crates/core/tests/ai_hub_pull.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_pull.rs
@@ -131,7 +131,7 @@ async fn ai_hub_pull_writes_manifest_and_extracts_flat() {
           "assets": [
             {{
               "chipset": "SM8650",
-              "runtime": "RUNTIME_GENIE",
+              "runtime": "RUNTIME_GENIEX_QAIRT",
               "precision": "PRECISION_W4A16",
               "download_url": "{asset_url}",
               "uncompressed_size": {}
@@ -244,6 +244,8 @@ async fn ai_hub_pull_errors_when_chipset_unknown() {
         }}"#
     );
     let platform_json = r#"{ "chipsets": [ { "name": "SM8650", "aliases": [] } ] }"#;
+    // Legacy runtime enum on purpose: AI Hub still publishes `RUNTIME_GENIE`
+    // for some models, so the selector must keep accepting it.
     let release_assets_json = format!(
         r#"{{
           "model_id": "testnet",

--- a/sdk/src/error.cpp
+++ b/sdk/src/error.cpp
@@ -33,8 +33,14 @@ const char* geniex_get_error_message(const geniex_ErrorCode error_code) {
             return "Memory allocation failed";
         case GENIEX_ERROR_COMMON_FILE_NOT_FOUND:
             return "File not found or inaccessible";
+        case GENIEX_ERROR_COMMON_NETWORK:
+            return "Network failure (timeout, bad status, DNS, proxy, ...)";
+        case GENIEX_ERROR_COMMON_CANCELLED:
+            return "Operation cancelled by caller";
         case GENIEX_ERROR_COMMON_NOT_INITIALIZED:
             return "Library not initialized";
+        case GENIEX_ERROR_COMMON_ALREADY_INITIALIZED:
+            return "Library already initialized; deinit first";
         case GENIEX_ERROR_COMMON_AUTH:
             return "Hub rejected request; authentication required";
         case GENIEX_ERROR_COMMON_HUB_MODEL_NOT_FOUND:
@@ -45,6 +51,10 @@ const char* geniex_get_error_message(const geniex_ErrorCode error_code) {
             return "Hub server error";
         case GENIEX_ERROR_COMMON_NOT_SUPPORTED:
             return "Operation not supported";
+        case GENIEX_ERROR_COMMON_MANIFEST_PARSE:
+            return "Failed to parse a manifest / index document";
+        case GENIEX_ERROR_COMMON_CHIPSET_UNAVAILABLE:
+            return "Requested chipset not available for this model";
         case GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED:
             return "Parameter not supported by this plugin";
         case GENIEX_ERROR_COMMON_MODEL_LOAD:


### PR DESCRIPTION
## Problem

`geniex pull` / `geniex infer` fail for `ai-hub-models/Gemma-4-E4B-it` on **every** chipset, with an error that contradicts itself:

```
Error: download model failed: SDKError(Unknown error code), chipset "Snapdragon X Elite CRD" not available
for this model; supported: Arduino VENTUNO Q, Dragonwing IQ-9075 EVK, SA8775P ADP,
Snapdragon 8 Elite Gen 5 QRD, Snapdragon 8 Elite QRD, Snapdragon X Elite CRD, Snapdragon X2 Elite CRD
```

The requested chipset (`Snapdragon X Elite CRD`) is listed as supported, yet rejected. Reported against release `v0.20.0`.

## Root cause

AI Hub is mid-migration from the legacy `RUNTIME_GENIE` enum to the namespaced `RUNTIME_GENIEX_QAIRT`. The two AI Hub code paths each hardcoded a *different* one:

| File | Path | Matched only |
|---|---|---|
| `selector.rs` | download | `RUNTIME_GENIE` |
| `mod.rs` | `geniex list` | `RUNTIME_GENIEX_QAIRT` |

Most models publish both enums — but not all, so each path had a blind spot, and the blind spots were **complementary**. Verified against bucket release `v0.60.0`:

- `Gemma-4-E4B-it` publishes **only** `RUNTIME_GENIEX_QAIRT` → visible in `list`, but the selector found zero candidates and failed the pull.
- `Phi-3.5-Mini-Instruct` publishes **only** `RUNTIME_GENIE` → so standardising on the new name alone would have regressed it.

Chipset coverage can also differ between the two runtimes for the *same* model (`Qwen3-VL-8B-Instruct` lists `qualcomm-qcs8275` under `RUNTIME_GENIEX_QAIRT` but not under `RUNTIME_GENIE`), so neither enum can be dropped, and it can't be decided per-model either.

## Fix

Collapse both call sites onto a single shared predicate in `selector.rs`, so the listing filter and the asset picker cannot drift apart:

```rust
const QAIRT_RUNTIMES: &[&str] = &["RUNTIME_GENIEX_QAIRT", "RUNTIME_GENIE"];

pub fn is_qairt_runtime(runtime: &str) -> bool {
    QAIRT_RUNTIMES.contains(&runtime)
}
```

`mod.rs` no longer defines a runtime constant at all — it imports the predicate. The list stays preference-ordered so `runtime_rank` prefers the newer enum when a model publishes both, keeping asset selection deterministic.

Two diagnosability fixes that made this bug much harder to track down than it needed to be:

- **Self-contradicting error.** `collect_chipsets()` built the "supported:" hint *without* the runtime filter `match_asset()` applies, so it advertised chipsets it would then reject. It now uses the same `is_qairt_runtime` predicate.
- **`SDKError(Unknown error code)`.** `error.cpp` had no case for `GENIEX_ERROR_COMMON_CHIPSET_UNAVAILABLE`. Added, along with four other codes that were silently falling through to `default`: `NETWORK`, `CANCELLED`, `ALREADY_INITIALIZED`, `MANIFEST_PARSE`.

## Testing

New unit tests, each pinned to a real model that would regress without it:

| Test | Guards |
|---|---|
| `matches_geniex_qairt_only_model` | `Gemma-4-E4B-it` (the reported bug) |
| `matches_legacy_genie_only_model` | `Phi-3.5-Mini-Instruct` |
| `prefers_geniex_qairt_over_legacy_genie` | deterministic pick when both exist |
| `available_excludes_non_qairt_runtimes` | the self-contradicting hint |
| `select_keeps_legacy_genie_only_models` | the `mod.rs` listing blind spot |

Full suite green: **168** unit tests + all integration suites (`ai_hub_pull`, `compat`, `executor`, `local_aihub_pull`, `proxy_smoke`, `pull_resume`). `cargo fmt --check` clean; clippy shows no new warnings (the 3 remaining were confirmed pre-existing via `git stash`).

**Verified end-to-end on a Snapdragon X Elite CRD** with a locally built SDK + CLI:

```
downloading 100% |█████████████████████████| (9.9/9.9 GB, 44 MB/s)
   Detected model type: vlm
✔  Download success
   Precision: W4A16

> In one short sentence, what chipset are you running on?
— 14.2 tok/s • 11 tok • 0.2 s first token —
```

The generated manifest is correct (`PluginId: qairt`, `ModelType: vlm`, `W4A16`) — note the `--local-path` workaround would *not* produce a correct precision label.

## Note on a separate bug found while verifying

The first pull silently wrote a **truncated** `tokenizer.json` (17,170,432 bytes instead of 32,169,626 — exactly 262 × 64 KiB), which crashed inference with `Error("EOF while parsing a string")`. I confirmed the archive is fine (those exact compressed bytes inflate to the full size with a valid JSON tail) and it was **not reproducible** — re-pulling that one file produced the correct output.

This is **unrelated to this PR** and not addressed here. It looks like `download_http_deflate` validates using `dec.total_out()` (the decoder's counter, read *before* `finish()`) rather than the actual on-disk length, so a short write can pass validation and still be marked complete. Filing separately.

## Follow-ups

- Consider deriving these runtime strings from one typed source rather than a `&[&str]`, so a fourth call site can't reintroduce a hardcoded enum.
- Once AI Hub finishes migrating off `RUNTIME_GENIE`, the legacy entry can be dropped from `QAIRT_RUNTIMES` — the list is the single place to do it.
