### PR TITLE
feat(sdk): add a CPU-only linux build variant for baseline armv8.0 boards

### DIFF
--- a/.github/workflows/_build-cli.yml
+++ b/.github/workflows/_build-cli.yml
@@ -33,6 +33,8 @@ jobs:
             runner: windows-11-arm
           - platform: linux-arm64
             runner: ubuntu-24.04-arm
+          - platform: linux-arm64-cpu
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
 
@@ -84,7 +86,7 @@ jobs:
         run: bazelisk build //cli:artifact --//sdk:sdk_type=local "--define=VERSION=%RAW_VERSION%"
 
       - name: Build CLI (Linux)
-        if: matrix.platform == 'linux-arm64'
+        if: startsWith(matrix.platform, 'linux-arm64')
         shell: bash
         env:
           RAW_VERSION: ${{ steps.version.outputs.version }}
@@ -110,9 +112,9 @@ jobs:
           retention-days: 1
 
       - name: Upload Linux CLI artifact
-        if: inputs.upload_artifact && matrix.platform == 'linux-arm64'
+        if: inputs.upload_artifact && startsWith(matrix.platform, 'linux-arm64')
         uses: actions/upload-artifact@v7
         with:
-          name: cli-linux-arm64
+          name: cli-${{ matrix.platform }}
           path: bazel-bin/cli/artifact.zip
           retention-days: 1

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -23,7 +23,7 @@ on:
         type: string
         default: ""
       is_prerelease:
-        description: "When true, skip moving the :latest tag."
+        description: "When true, skip moving the floating :latest / :latest-cpu tag."
         required: false
         type: boolean
         default: true
@@ -33,8 +33,20 @@ permissions:
 
 jobs:
   build:
+    name: ${{ matrix.variant }}
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            sdk_artifact: sdk-linux-arm64
+            tag_suffix: ""
+          # OCI has no micro-arch discriminator, so this needs its own tag. #1217
+          - variant: cpu
+            sdk_artifact: sdk-linux-arm64-cpu
+            tag_suffix: "-cpu"
 
     steps:
       - name: Checkout source
@@ -52,16 +64,16 @@ jobs:
       - name: Download linux-arm64 SDK artifact
         uses: actions/download-artifact@v8
         with:
-          name: sdk-linux-arm64
+          name: ${{ matrix.sdk_artifact }}
           path: sdk/pkg-geniex/
 
       - name: Restore Bazel disk cache
         uses: actions/cache@v6
         with:
           path: ~/.cache/bazel-disk
-          key: bazel-cli-${{ runner.os }}-${{ hashFiles('MODULE.bazel.lock', 'cli/**/BUILD.bazel', 'cli/**/*.bzl') }}
+          key: bazel-cli-${{ runner.os }}-${{ matrix.variant }}-${{ hashFiles('MODULE.bazel.lock', 'cli/**/BUILD.bazel', 'cli/**/*.bzl') }}
           restore-keys: |
-            bazel-cli-${{ runner.os }}-
+            bazel-cli-${{ runner.os }}-${{ matrix.variant }}-
 
       - name: Build docker tarball (//cli/release/linux)
         shell: bash
@@ -94,11 +106,13 @@ jobs:
         env:
           RAW_VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ inputs.tag }}
+          TAG_SUFFIX: ${{ matrix.tag_suffix }}
         run: |
           set -euo pipefail
           bare="${RAW_VERSION#v}"
-          dest_tag="${TAG:-$bare}"
+          dest_tag="${TAG:-$bare}${TAG_SUFFIX}"
           echo "DOCKERHUB_REF=docker.io/qualcomm/geniex:${dest_tag}" >> "$GITHUB_ENV"
+          echo "DOCKERHUB_LATEST=latest${TAG_SUFFIX}" >> "$GITHUB_ENV"
 
       - name: Validate tarball (PR path)
         if: ${{ !inputs.push }}
@@ -125,11 +139,12 @@ jobs:
         shell: bash
         env:
           IMAGE_REF: ${{ env.DOCKERHUB_REF }}
+          LATEST_TAG: ${{ env.DOCKERHUB_LATEST }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
         run: |
           set -euo pipefail
           crane push bazel-bin/cli/release/linux/geniex-cli-docker.tar "${IMAGE_REF}"
-          # Prereleases must not clobber the floating :latest tag.
+          # Prereleases must not clobber the floating tag.
           if [[ "${IS_PRERELEASE}" != "true" ]]; then
-            crane tag "${IMAGE_REF}" latest
+            crane tag "${IMAGE_REF}" "${LATEST_TAG}"
           fi

--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -41,6 +41,11 @@ jobs:
             runner: ubuntu-latest
             preset: arm64-linux-snapdragon-release
             container_image: docker.io/qualcomm/geniex-toolchain-linux:v0.1.0
+          # NPU-less Dragonwing IoT boards (unoq) can't run armv8.2. See #1217.
+          - platform: linux-arm64-cpu
+            runner: ubuntu-latest
+            preset: arm64-linux-cpu-release
+            container_image: docker.io/qualcomm/geniex-toolchain-linux:v0.1.0
           - platform: android-arm64
             runner: ubuntu-latest
             preset: arm64-android-snapdragon-release
@@ -150,7 +155,7 @@ jobs:
       # Linux/Android ccache lives in the toolchain container; host just
       # owns the dir so actions/cache can persist it.
       - name: Prepare ccache dir (Linux/Android)
-        if: matrix.platform == 'linux-arm64' || matrix.platform == 'android-arm64'
+        if: matrix.platform != 'windows-arm64'
         shell: bash
         run: mkdir -p "${{ github.workspace }}/.ccache"
 
@@ -278,7 +283,7 @@ jobs:
       # On Linux/Android ccache runs inside the container; only the on-disk
       # size is visible from the host. Never fail the job on a stats read.
       - name: ccache stats (Linux/Android)
-        if: matrix.platform == 'linux-arm64' || matrix.platform == 'android-arm64'
+        if: matrix.platform != 'windows-arm64'
         shell: bash
         run: du -sh "${{ github.workspace }}/.ccache" 2>/dev/null || true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,11 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
+          name: sdk-linux-arm64-cpu
+          path: sdk-linux-arm64-cpu
+
+      - uses: actions/download-artifact@v8
+        with:
           name: sdk-android-arm64
           path: sdk-android-arm64
 
@@ -240,6 +245,11 @@ jobs:
         with:
           name: cli-linux-arm64
           path: cli-linux-arm64/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cli-linux-arm64-cpu
+          path: cli-linux-arm64-cpu/
 
       - uses: actions/download-artifact@v8
         with:
@@ -263,12 +273,14 @@ jobs:
           mv geniex_llama_cpp-*.tar.gz "geniex-pysdist-llama_cpp-${RELEASE_TAG}.tar.gz"
           mv geniex_qairt-*.tar.gz "geniex-pysdist-qairt-${RELEASE_TAG}.tar.gz"
 
-          staged="geniex-cli-linux-arm64-${RELEASE_TAG}"
-          mkdir -p "${staged}"
-          unzip -q cli-linux-arm64/artifact.zip -d "${staged}"
-          chmod +x "${staged}/geniex"
-          tar -czf "${staged}.tar.gz" "${staged}"
-          rm -rf "${staged}"
+          for plat in linux-arm64 linux-arm64-cpu; do
+            staged="geniex-cli-${plat}-${RELEASE_TAG}"
+            mkdir -p "${staged}"
+            unzip -q "cli-${plat}/artifact.zip" -d "${staged}"
+            chmod +x "${staged}/geniex"
+            tar -czf "${staged}.tar.gz" "${staged}"
+            rm -rf "${staged}"
+          done
 
           # Stage the install script as a versioned release asset so users can
           # pin to a specific tag's script — the mutable install.sh pointer is
@@ -288,6 +300,7 @@ jobs:
           fi
           zip -r "geniex-sdk-windows-arm64-${RELEASE_TAG}${sdk_suffix}.zip" sdk-windows-arm64
           zip -r "geniex-sdk-linux-arm64-${RELEASE_TAG}.zip" sdk-linux-arm64
+          zip -r "geniex-sdk-linux-arm64-cpu-${RELEASE_TAG}.zip" sdk-linux-arm64-cpu
 
           # Package standalone geniex-bench archives (bin + runtime libs).
           for plat in linux-arm64 windows-arm64 android-arm64; do
@@ -313,7 +326,7 @@ jobs:
             rm -rf "${bench_dir}"
           done
 
-          rm -rf sdk-windows-arm64 sdk-linux-arm64 sdk-android-arm64 cli-linux-arm64 to-sign
+          rm -rf sdk-windows-arm64 sdk-linux-arm64 sdk-linux-arm64-cpu sdk-android-arm64 cli-linux-arm64 cli-linux-arm64-cpu to-sign
 
           shopt -s nullglob
           files=(*.zip *.exe *.tar.gz *.cer *.aar install-*.sh)

--- a/bindings/python/_sdk_fetch.py
+++ b/bindings/python/_sdk_fetch.py
@@ -33,6 +33,11 @@ PLATFORM_MAP = {
     ('linux', 'arm64'): 'linux-arm64',
 }
 
+# Baseline armv8.0 boards (unoq) can't run the default linux-arm64 SDK, so CI
+# publishes a CPU-only one. Picking it is explicit. See GenieX #1217.
+_CPU_SUFFIX = '-cpu'
+_VARIANT_ENV = 'GENIEX_SDK_VARIANT'
+
 _CORE_LIB_NAMES = ('geniex.dll', 'libgeniex.so', 'libgeniex.dylib')
 _BACKEND_DIRS = {'llama-cpp': 'llama_cpp', 'qairt': 'qairt'}
 
@@ -57,6 +62,12 @@ class _ZIP64NotSupported(Exception):
 def _detect_platform() -> str:
     key = (sys.platform, platform.machine().lower())
     plat = PLATFORM_MAP.get(key)
+    if plat == 'linux-arm64':
+        variant = os.environ.get(_VARIANT_ENV, '').strip().lower()
+        if variant == 'cpu':
+            plat += _CPU_SUFFIX
+        elif variant not in ('', 'default'):
+            raise RuntimeError(f'{_VARIANT_ENV}={variant!r} is not one of: default, cpu')
     if plat is None:
         raise RuntimeError(
             f'Unsupported platform {key} for prebuilt geniex SDK.\n'
@@ -362,6 +373,19 @@ def fetch(
         raise ValueError(f'unknown backends: {sorted(unknown)}; expected subset of {sorted(_BACKEND_DIRS)}')
 
     plat = _detect_platform()
+    if plat.endswith(_CPU_SUFFIX) and 'qairt' in backend_set:
+        # Better to drop the backend than stage an empty qairt/ that fails later.
+        if backend_set == {'qairt'}:
+            raise RuntimeError(
+                f'{_VARIANT_ENV}=cpu selects the CPU-only SDK, which has no QAIRT\n'
+                'backend — those boards have no NPU. Install llama.cpp instead:\n'
+                '  pip install geniex-llama-cpp'
+            )
+        backend_set -= {'qairt'}
+        print(
+            '[geniex] the CPU-only SDK has no QAIRT backend; installing llama.cpp only.',
+            file=_tty(),
+        )
     asset = f'geniex-sdk-{plat}-{release_tag}.zip'
 
     override = os.environ.get('GENIEX_SDK_DOWNLOAD_URL')

--- a/bindings/python/tests/unit/test_sdk_variant.py
+++ b/bindings/python/tests/unit/test_sdk_variant.py
@@ -1,0 +1,89 @@
+# Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Unit coverage for CPU-only SDK asset selection (#1217)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture
+def fetcher(monkeypatch):
+    """A fresh ``_sdk_fetch``, imported by path the way ``setup.py`` does."""
+    spec = importlib.util.spec_from_file_location('_sdk_fetch_under_test', _ROOT / '_sdk_fetch.py')
+    mod = importlib.util.module_from_spec(spec)
+    # @dataclass looks its own module up in sys.modules while the class is built.
+    monkeypatch.setitem(sys.modules, spec.name, mod)
+    spec.loader.exec_module(mod)
+    # Pretend we're on linux/aarch64. Swap the module's `sys` rather than the real
+    # one: a global sys.platform='linux' would send pytest's tmp_path down the
+    # POSIX path on Windows and into os.getuid().
+    monkeypatch.setattr(mod, 'sys', types.SimpleNamespace(platform='linux', stderr=sys.stderr))
+    monkeypatch.setattr(mod, 'platform', types.SimpleNamespace(machine=lambda: 'aarch64'))
+    monkeypatch.delenv(mod._VARIANT_ENV, raising=False)
+    return mod
+
+
+@pytest.fixture
+def staged(fetcher, monkeypatch):
+    """Capture the asset and backend set fetch() would have downloaded."""
+    seen: dict = {}
+
+    def _capture(name, zip_url, lib_dir, backends, errors):
+        seen['asset'] = zip_url.rsplit('/', 1)[-1]
+        seen['backends'] = set(backends)
+        return True
+
+    monkeypatch.setattr(fetcher, '_try_one_source', _capture)
+    return seen
+
+
+@pytest.mark.parametrize(
+    ('variant', 'expected'),
+    [(None, 'linux-arm64'), ('default', 'linux-arm64'), ('cpu', 'linux-arm64-cpu')],
+)
+def test_variant_picks_the_asset(fetcher, monkeypatch, variant, expected):
+    if variant is not None:
+        monkeypatch.setenv(fetcher._VARIANT_ENV, variant)
+    assert fetcher._detect_platform() == expected
+
+
+def test_unknown_variant_is_rejected(fetcher, monkeypatch):
+    monkeypatch.setenv(fetcher._VARIANT_ENV, 'armv9')
+    with pytest.raises(RuntimeError, match='default, cpu'):
+        fetcher._detect_platform()
+
+
+def test_the_variant_is_linux_arm64_only(fetcher, monkeypatch):
+    fetcher.sys.platform = 'win32'
+    monkeypatch.setattr(fetcher, 'platform', types.SimpleNamespace(machine=lambda: 'ARM64'))
+    monkeypatch.setenv(fetcher._VARIANT_ENV, 'cpu')
+    assert fetcher._detect_platform() == 'windows-arm64'
+
+
+def test_meta_sdist_drops_qairt(fetcher, monkeypatch, staged, tmp_path):
+    monkeypatch.setenv(fetcher._VARIANT_ENV, 'cpu')
+    fetcher.fetch(tmp_path, 'v1.2.3', backends=('llama-cpp', 'qairt'))
+    assert staged['asset'] == 'geniex-sdk-linux-arm64-cpu-v1.2.3.zip'
+    assert staged['backends'] == {'llama-cpp'}
+
+
+def test_qairt_only_sdist_is_rejected(fetcher, monkeypatch, staged, tmp_path):
+    monkeypatch.setenv(fetcher._VARIANT_ENV, 'cpu')
+    with pytest.raises(RuntimeError, match='no QAIRT'):
+        fetcher.fetch(tmp_path, 'v1.2.3', backends=('qairt',))
+    assert staged == {}
+
+
+def test_default_variant_keeps_qairt(fetcher, staged, tmp_path):
+    fetcher.fetch(tmp_path, 'v1.2.3', backends=('llama-cpp', 'qairt'))
+    assert staged['asset'] == 'geniex-sdk-linux-arm64-v1.2.3.zip'
+    assert staged['backends'] == {'llama-cpp', 'qairt'}

--- a/cli/cmd/geniex/common/error.go
+++ b/cli/cmd/geniex/common/error.go
@@ -107,7 +107,9 @@ Possible causes: network timeout, corporate proxy, or firewall.
 	hintCPUUnsupported = `⚠️ This device is missing CPU features that geniex requires, so it cannot run here.
 
 👉 Try these:
-- Run geniex on a newer device that meets the CPU requirements.
+- On a baseline ARMv8.0 board, install the CPU-only build instead: re-run the
+  installer with '--cpu-only'.
+- Otherwise run geniex on a newer device that meets the CPU requirements.
 - If you believe this device should be supported, report it in our discord or slack with the output of 'uname -m' and 'cat /proc/cpuinfo'.`
 )
 

--- a/cli/release/linux/entrypoint.sh
+++ b/cli/release/linux/entrypoint.sh
@@ -32,25 +32,30 @@ link_lib() {
     MISSING_LIBS="$MISSING_LIBS $bare"
 }
 
-# fastrpc: bare-name links required by libQnnHtp*Stub.so's $ORIGIN rpath.
-link_lib libcdsprpc.so
-link_lib libadsprpc.so
+# Only warn about drivers a plugin in this image actually needs. See #1217.
+if [ -d "$LIB_DIR/qairt" ] || [ -e "$LIB_DIR/llama_cpp/libggml-hexagon.so" ]; then
+    # fastrpc: bare-name links required by libQnnHtp*Stub.so's $ORIGIN rpath.
+    link_lib libcdsprpc.so
+    link_lib libadsprpc.so
+fi
 
-# Other QCOM user-space libs (GPU/CL/llvm).
-for lib in \
-    libOpenCL.so.1 \
-    libOpenCL_adreno.so.1 \
-    libCB.so.1 \
-    libadreno_utils.so.1 \
-    libgsl.so.1 \
-    libllvm-qcom.so.1 \
-    libllvm-qgl.so.1 \
-    libllvm-glnext.so.1 \
-    libpropertyvault.so.0 \
-    libdmabufheap.so.0 \
-; do
-    link_lib "$lib"
-done
+if [ -e "$LIB_DIR/llama_cpp/libggml-opencl.so" ]; then
+    # QCOM user-space libs the Adreno OpenCL backend pulls in.
+    for lib in \
+        libOpenCL.so.1 \
+        libOpenCL_adreno.so.1 \
+        libCB.so.1 \
+        libadreno_utils.so.1 \
+        libgsl.so.1 \
+        libllvm-qcom.so.1 \
+        libllvm-qgl.so.1 \
+        libllvm-glnext.so.1 \
+        libpropertyvault.so.0 \
+        libdmabufheap.so.0 \
+    ; do
+        link_lib "$lib"
+    done
+fi
 
 if [ -n "$MISSING_LIBS" ]; then
     warn "the following libraries were not found under /opt/qcom-lib; NPU/GPU may fail:"

--- a/cli/release/linux/install.sh
+++ b/cli/release/linux/install.sh
@@ -22,6 +22,7 @@ ISSUE_URL="https://github.com/qualcomm/GenieX/issues"
 VERSION=""
 PREFIX=""
 QUIET=0
+CPU_ONLY=0
 
 usage() {
     cat <<EOF
@@ -33,6 +34,8 @@ Options:
   --version vX.Y.Z   Install a specific release (default: latest stable)
   --prefix DIR       Install to DIR (default: /usr/local/lib/geniex when root,
                      \${XDG_DATA_HOME:-\$HOME/.local/share}/geniex otherwise)
+  --cpu-only         Install the CPU-only armv8.0-a build, for baseline ARMv8.0
+                     boards that cannot run the default armv8.2 build
   -q, --quiet        Suppress non-error output
   -h, --help         Show this help
 
@@ -112,6 +115,10 @@ while [ $# -gt 0 ]; do
             PREFIX="${1#*=}"
             shift
             ;;
+        --cpu-only)
+            CPU_ONLY=1
+            shift
+            ;;
         -q|--quiet)
             QUIET=1
             shift
@@ -146,6 +153,13 @@ case "$arch" in
         exit 1
         ;;
 esac
+
+# Baseline armv8.0 boards (unoq) can't run the default armv8.2-a build; opting
+# into the CPU-only one is explicit. See GenieX issue #1217.
+if [ "$CPU_ONLY" -eq 1 ]; then
+    ASSET_STEM="${ASSET_STEM}-cpu"
+    say "Installing the CPU-only build. NPU and GPU inference are not available."
+fi
 
 # Snapdragon EVKs and most Linux container images log in as root, so installing
 # under $HOME/.local would leave geniex hidden under /root/.local/bin. Default
@@ -267,10 +281,13 @@ fi
 rm -rf "${PREFIX}.old"
 
 # Symlink bare-name fastrpc libs into the prefix so the bundled QNN HTP stub
-# can find them via the LD_LIBRARY_PATH the launcher sets
-say "Linking host NPU libraries"
-resolve_host_lib libcdsprpc.so
-resolve_host_lib libadsprpc.so
+# can find them via the LD_LIBRARY_PATH the launcher sets. The CPU-only build
+# ships no QAIRT/HTP plugin.
+if [ "$CPU_ONLY" -eq 0 ]; then
+    say "Linking host NPU libraries"
+    resolve_host_lib libcdsprpc.so
+    resolve_host_lib libadsprpc.so
+fi
 
 # Launcher wrapper instead of a bare symlink: the binary is built without
 # an $ORIGIN rpath, so it can't find sibling libgeniex.so / plugins unless

--- a/docs/cn/resources/troubleshooting.mdx
+++ b/docs/cn/resources/troubleshooting.mdx
@@ -99,7 +99,21 @@ import Feedback from "/snippets/page-feedback.mdx";
     cat /proc/cpuinfo | grep Features          # 相同特性，内核使用的名称
     ```
 
-    若缺少这些特性，该设备无法运行当前版本。请带上以上输出到 [GitHub Issues](https://github.com/qualcomm/GenieX/issues) 或 Slack 反馈。
+    若缺少这些特性，请改用 **CPU-only（仅 CPU）** 版本：它以纯 `armv8.0-a`（不带任何 ISA 扩展）编译，只包含 CPU 推理（不含 QAIRT/NPU、OpenCL/GPU、Hexagon），速度也相应更慢——缺少 `dotprod`/`fp16` 时 ggml 会退回 fp32 量化内核。所有渠道都需要显式指定，不做自动探测：
+
+    ```bash bash
+    curl -fsSL https://raw.githubusercontent.com/qualcomm/GenieX/main/cli/release/linux/install.sh | sh -s -- --cpu-only
+    ```
+
+    | 渠道 | 如何选中 CPU-only 版本 |
+    | --- | --- |
+    | `install.sh` | `--cpu-only` |
+    | `pip install geniex` | `GENIEX_SDK_VARIANT=cpu` |
+    | Docker | `-cpu` tag —— `docker.io/qualcomm/geniex:latest-cpu` |
+
+    `geniex-qairt` 没有 CPU-only 版本：QAIRT 需要 NPU，而这类板子并没有。请改用 `geniex-llama-cpp`（或 `geniex` 元包，它会在这类板子上自动去掉 QAIRT 后端）。
+
+    若 CPU-only 版本仍然失败，请带上以上输出到 [GitHub Issues](https://github.com/qualcomm/GenieX/issues) 或 Slack 反馈。
   </Accordion>
 </AccordionGroup>
 

--- a/docs/cn/run/linux/install.mdx
+++ b/docs/cn/run/linux/install.mdx
@@ -40,6 +40,10 @@ docker pull "$IMAGE"
   若 `docker login` 失败或 `docker pull` 返回 `permission denied ... /var/run/docker.sock`，参见[故障排查 → Linux](/cn/resources/troubleshooting#linux) 了解凭据与 `docker` 组的修复方法。
 </Note>
 
+<Note>
+  **基线 ARMv8.0 板子** —— 部分无 NPU 的 Dragonwing IoT SoC 跑不了默认的 ARMv8.2 镜像，这类板子请在 tag 后加上 `-cpu`：`docker.io/qualcomm/geniex:latest-cpu`。该镜像仅支持 CPU 推理，既不需要 `--privileged`，也不需要下面的 `/usr/lib` 挂载。
+</Note>
+
 ### **交互式运行**
 
 进入容器内交互式 shell：

--- a/docs/en/resources/troubleshooting.mdx
+++ b/docs/en/resources/troubleshooting.mdx
@@ -113,7 +113,21 @@ import Feedback from "/snippets/page-feedback.mdx";
     cat /proc/cpuinfo | grep Features          # same features, under the kernel's names
     ```
 
-    If those features are absent, the device can't run the current build. Report it in [GitHub Issues](https://github.com/qualcomm/GenieX/issues) or Slack with the output above.
+    If those features are absent, install the **CPU-only** build instead. It is compiled for plain `armv8.0-a` with no ISA extensions, ships CPU inference only (no QAIRT/NPU, no OpenCL/GPU, no Hexagon), and is correspondingly slower — ggml falls back to its fp32 quant kernels without `dotprod`/`fp16`. Every channel asks for it explicitly; nothing is auto-detected:
+
+    ```bash bash
+    curl -fsSL https://raw.githubusercontent.com/qualcomm/GenieX/main/cli/release/linux/install.sh | sh -s -- --cpu-only
+    ```
+
+    | Channel | How to select the CPU-only build |
+    | --- | --- |
+    | `install.sh` | `--cpu-only` |
+    | `pip install geniex` | `GENIEX_SDK_VARIANT=cpu` |
+    | Docker | the `-cpu` tag — `docker.io/qualcomm/geniex:latest-cpu` |
+
+    `geniex-qairt` has no CPU-only build at all: QAIRT needs an NPU, and these boards have none. Use `geniex-llama-cpp` (or the `geniex` meta package, which drops the QAIRT backend automatically on such a board).
+
+    If the CPU-only build still fails, report it in [GitHub Issues](https://github.com/qualcomm/GenieX/issues) or Slack with the output above.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/en/run/linux/install.mdx
+++ b/docs/en/run/linux/install.mdx
@@ -40,6 +40,10 @@ docker pull "$IMAGE"
   If `docker login` fails or `docker pull` returns `permission denied ... /var/run/docker.sock`, see [Troubleshooting → Linux](/en/resources/troubleshooting#linux) for the credential and `docker` group fixes.
 </Note>
 
+<Note>
+  **Baseline ARMv8.0 boards** — some NPU-less Dragonwing IoT SoCs cannot run the default ARMv8.2 image; append `-cpu` to the tag for those: `docker.io/qualcomm/geniex:latest-cpu`. That image is CPU-only and needs neither `--privileged` nor the `/usr/lib` mount below.
+</Note>
+
 ### **Run interactively**
 
 Drop into an interactive shell inside the container:

--- a/notes/build.md
+++ b/notes/build.md
@@ -80,6 +80,20 @@ cmake --build build-linux -j
 cmake --install build-linux --prefix pkg-geniex
 ```
 
+#### CPU-only variant (baseline armv8.0-a)
+
+NPU-less Dragonwing IoT boards (unoq) are baseline ARMv8.0 and trap on the LSE
+atomics the `snapdragon` presets inline (see
+[#1217](https://github.com/qualcomm/GenieX/issues/1217)). Swap the preset for
+`arm64-linux-cpu-{debug,release}` — same container, plain `-march=armv8-a`, and
+CPU-only (no QAIRT, Hexagon, or OpenCL):
+
+```bash
+cmake --preset arm64-linux-cpu-debug -B build-linux-cpu .
+cmake --build build-linux-cpu -j
+cmake --install build-linux-cpu --prefix pkg-geniex
+```
+
 ### Android (cross-compile from Linux)
 
 Build the SDK inside the derived Snapdragon Android toolchain container — it extends [ghcr.io/snapdragon-toolchain/arm64-android](https://github.com/ggml-org/llama.cpp/blob/master/docs/backend/snapdragon/README.md#android) with `build-essential`, `ccache`, `rustup`, and the `aarch64-linux-android` Rust target baked in (see [`.github/docker/toolchain-android.Dockerfile`](../.github/docker/toolchain-android.Dockerfile)). Run from the repo root.

--- a/notes/release.md
+++ b/notes/release.md
@@ -9,6 +9,7 @@ git tag v1.2.3 && git push origin v1.2.3
 - Tags containing `-` are drafts (and push the sdist to TestPyPI).
 - Bare `vX.Y.Z` tags publish immediately (and push the sdist to production PyPI).
 - Assets: `geniex-sdk-{linux,windows}-arm64-<tag>.zip`, `geniex-cli-linux-arm64-<tag>.tar.gz`, `geniex-cli-setup-windows-arm64-<tag>.exe`, `geniex-android-aar-<tag>.aar`, `geniex-bench-{linux,windows,android}-arm64-<tag>.{tar.gz,zip}`, `geniex-pysdist{,-llama_cpp,-qairt}-<tag>.tar.gz`, and per-file `.sha256` sidecars.
+- The CPU-only variant ([#1217](https://github.com/qualcomm/GenieX/issues/1217)) adds a `-cpu` infix on the Linux assets: `geniex-{sdk,cli}-linux-arm64-cpu-<tag>.*`. Docker mirrors it as the `-cpu` tag. No `geniex-bench` archive — the SDK zip already ships `bin/geniex-bench`.
 - Re-running the same tag via **Actions → Release → Run workflow** is safe **as long as you set "Use workflow from" to the tag** (Tags tab in the dropdown). Dispatching from `main` is rejected by `resolve-tag` so the workflow never builds a tag against the wrong commit.
 - S3 mirror at `s3://qaihub-public-assets/qai-hub-geniex/` — see [§ S3 mirror & manifest](#s3-mirror--manifest) below.
 
@@ -91,11 +92,14 @@ All objects live directly under the prefix — no `<tag>/` subdirectories. The `
 | --------------------------------------------------- | ----------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `geniex-sdk-windows-arm64-<tag>.zip(.sha256)`       | every tag   | default     | Windows SDK                                                                                                                  |
 | `geniex-sdk-linux-arm64-<tag>.zip(.sha256)`         | every tag   | default     | Linux SDK                                                                                                                    |
+| `geniex-sdk-linux-arm64-cpu-<tag>.zip(.sha256)`     | every tag   | default     | CPU-only Linux SDK, fetched by `GENIEX_SDK_VARIANT=cpu`                                                                      |
 | `geniex-cli-setup-windows-arm64-<tag>.exe(.sha256)` | every tag   | default     | Windows CLI installer (versioned)                                                                                            |
 | `geniex-cli-linux-arm64-<tag>.tar.gz(.sha256)`      | every tag   | default     | Linux CLI archive (versioned)                                                                                                |
+| `geniex-cli-linux-arm64-cpu-<tag>.tar.gz(.sha256)`  | every tag   | default     | CPU-only Linux CLI archive (versioned)                                                                                       |
 | `install-<tag>.sh(.sha256)`                         | every tag   | default     | Linux install script (versioned, pinned via `--version`)                                                                     |
 | `geniex-cli.exe`                                    | stable only | `no-cache`  | Mutable pointer to latest stable Windows installer                                                                           |
 | `geniex-cli-linux-arm64.tar.gz(.sha256)`            | stable only | `no-cache`  | Mutable pointer consumed by `install.sh`                                                                                     |
+| `geniex-cli-linux-arm64-cpu.tar.gz(.sha256)`        | stable only | `no-cache`  | Mutable pointer consumed by `install.sh --cpu-only`                                                                          |
 | `install.sh`                                        | stable only | `no-cache`  | Mutable install script — `curl ... \| sh` entrypoint                                                                         |
 | `manifest-<tag>.json`                               | every tag   | `immutable` | Per-tag asset listing                                                                                                        |
 | `index.json`                                        | every tag   | `no-cache`  | Full version catalogue                                                                                                       |
@@ -162,6 +166,8 @@ S3 publishing runs in the geniex repo (the IAM role's OIDC trust only allows `qc
   `assets[].url` always points at the versioned object (never at the mutable `geniex-cli.exe` / `geniex-cli-linux-arm64.tar.gz` / `install.sh`), so the referenced bytes are immutable and the listed `sha256` is authoritative. `kind` is one of `sdk` / `cli-installer` / `cli-archive` / `install-script` / `sha256`.
 
 The per-tag manifest is byte-stable across workflow re-runs of the same tag — `released_at` is preserved from the first publish, so clients can cache it forever.
+
+The CPU-only objects are on S3 but deliberately **absent from the manifest**: their metadata would be identical to the default build's, so a `kind`/`platform`/`arch` lookup could hand a normal Snapdragon device the slow artifact. Nothing discovers them that way anyway — `install.sh --cpu-only` and `GENIEX_SDK_VARIANT=cpu` both build the URL from the naming convention.
 
 ## Hexagon HTP signing
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -30,12 +30,14 @@ set(GENIEX_VERSION "v0.0.0" CACHE STRING "GenieX library version")
 option(GENIEX_PLUGIN_LLAMA_CPP  "Enable llama.cpp backend"       ON)
 option(GENIEX_PLUGIN_QAIRT      "Enable QAIRT backend"           ON)
 option(GENIEX_BENCHMARK         "Build benchmark example"        OFF)
+option(GENIEX_CPU_ONLY          "CPU inference only, baseline ISA" OFF)
 
 message(STATUS "=============== Options ===============")
 message(STATUS "GENIEX_VERSION:          ${GENIEX_VERSION}")
 message(STATUS "GENIEX_PLUGIN_LLAMA_CPP: ${GENIEX_PLUGIN_LLAMA_CPP}")
 message(STATUS "GENIEX_PLUGIN_QAIRT:     ${GENIEX_PLUGIN_QAIRT}")
 message(STATUS "GENIEX_BENCHMARK:        ${GENIEX_BENCHMARK}")
+message(STATUS "GENIEX_CPU_ONLY:         ${GENIEX_CPU_ONLY}")
 message(STATUS "=======================================")
 
 # ===============================================================================
@@ -177,6 +179,9 @@ set(COMMON_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # compile definitions
 
 add_compile_definitions(PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+if(GENIEX_CPU_ONLY)
+    add_compile_definitions(GENIEX_CPU_ONLY)
+endif()
 
 # subdirectories
 

--- a/sdk/CMakePresets.json
+++ b/sdk/CMakePresets.json
@@ -38,6 +38,18 @@
       }
     },
     {
+      "name": "cpu-only",
+      "hidden": true,
+      "cacheVariables": {
+        "GENIEX_PLUGIN_LLAMA_CPP": "ON",
+        "GENIEX_PLUGIN_QAIRT": "OFF",
+        "GGML_HEXAGON": "OFF",
+        "GGML_OPENCL": "OFF",
+        "GENIEX_BENCHMARK": "ON",
+        "GENIEX_CPU_ONLY": "ON"
+      }
+    },
+    {
       "name": "arm64-windows-snapdragon",
       "hidden": true,
       "generator": "Ninja",
@@ -89,6 +101,22 @@
       }
     },
     {
+      "name": "arm64-linux-cpu",
+      "hidden": true,
+      "architecture": {
+        "value": "arm64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x86_64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/arm64-linux-gnu-cpu.cmake",
+        "PREBUILT_LIB_DIR": "linux_aarch64"
+      }
+    },
+    {
       "name": "default",
       "displayName": "Default (SDK Release)",
       "description": "Build SDK in Release mode with standard options",
@@ -117,6 +145,14 @@
     {
       "name": "arm64-linux-snapdragon-release",
       "inherits": ["arm64-linux-snapdragon", "snapdragon", "release", "base"]
+    },
+    {
+      "name": "arm64-linux-cpu-debug",
+      "inherits": ["arm64-linux-cpu", "cpu-only", "debug", "base"]
+    },
+    {
+      "name": "arm64-linux-cpu-release",
+      "inherits": ["arm64-linux-cpu", "cpu-only", "release", "base"]
     }
   ],
   "buildPresets": [
@@ -153,6 +189,16 @@
     {
       "name": "arm64-linux-snapdragon-release",
       "configurePreset": "arm64-linux-snapdragon-release",
+      "jobs": 0
+    },
+    {
+      "name": "arm64-linux-cpu-debug",
+      "configurePreset": "arm64-linux-cpu-debug",
+      "jobs": 0
+    },
+    {
+      "name": "arm64-linux-cpu-release",
+      "configurePreset": "arm64-linux-cpu-release",
       "jobs": 0
     }
   ]

--- a/sdk/cmake/arm64-linux-gnu-cpu.cmake
+++ b/sdk/cmake/arm64-linux-gnu-cpu.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+# gcc-13: default gcc-14 emits CXXABI_1.3.15, missing on Qualcomm Linux. See #458.
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc-13)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++-13)
+
+# CPU-only variant for NPU-less Dragonwing IoT SoCs (unoq). No ISA extensions:
+# without LSE, gcc stops inlining the LDADDAL that trapped in std::mutex. #1217
+set(CMAKE_C_FLAGS "-march=armv8-a -ftree-vectorize -fno-finite-math-only -flto -D_GNU_SOURCE")
+set(CMAKE_CXX_FLAGS "-march=armv8-a -ftree-vectorize -fno-finite-math-only -flto -D_GNU_SOURCE")
+
+message(STATUS "Using baseline armv8.0-a cross compile toolchain for ARM64 Linux (gcc-13)")

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -24,8 +24,9 @@
 #endif
 
 // Baseline armv8.0 boards (e.g. unoq) lack the armv8.2 features this build bakes
-// in, so bail cleanly instead of SIGILL. Keep in sync with -march. See #1217.
-#if defined(__linux__) && defined(__aarch64__)
+// in, so bail cleanly instead of SIGILL. Keep in sync with -march; the CPU-only
+// build has nothing to check. See #1217.
+#if defined(__linux__) && defined(__aarch64__) && !defined(GENIEX_CPU_ONLY)
 #include <asm/hwcap.h>
 #include <sys/auxv.h>
 


### PR DESCRIPTION
## Problem

`geniex` cannot run on baseline ARMv8.0 boards — NPU-less Dragonwing IoT SoCs such as the Arduino UNO Q. #1180 made the failure *graceful* (a clear "missing CPU features" error instead of a raw `SIGILL`), but the board still can't do inference at all:

```
$ geniex infer unsloth/Qwen3-0.6B-GGUF --compute cpu --ngl 0
⚠️ This device is missing CPU features that geniex requires, so it cannot run here.
exit=1
```

That remaining half is what #1217 stayed open for.

## Root cause (recap of #1217)

The aarch64-Linux toolchain compiles everything with `-march=armv8.2-a+fp16+dotprod` (`sdk/cmake/arm64-linux-gnu.cmake:8`). `armv8.2-a` implies `FEAT_LSE`, so GCC inlines LSE atomics with **no runtime fallback** — every `std::mutex` and thread-safe static-local guard lowers to `LDADDAL`/`CAS`. UNO Q is ARMv8.0 and implements none of it, so the first atomic in the process traps.

## Why a separate build variant, not runtime dispatch

The alternative was `GGML_CPU_ALL_VARIANTS` (runtime-dispatched ggml kernels). It is the *larger* change, not the smaller one:

- The dispatch machinery exists upstream — there is even an `armv8.0_1` variant (`ggml/src/CMakeLists.txt:408`) — but it **requires `GGML_BACKEND_DL=ON`**, which we set `OFF` (`sdk/plugins/llama_cpp/CMakeLists.txt:5`). Turning it on makes ggml-cpu / hexagon / opencl `dlopen`'d backends, changing packaging and backend discovery for the *shipping Snapdragon* artifact.
- It also wouldn't be sufficient alone. The `LDADDAL` that trapped comes from the **global** `-march` applied to the SDK's own C++ and to ggml-base — not from ggml-cpu kernels. So that route = this PR's flag change **plus** a risky refactor of the NPU path.

`GGML_CPU_ALL_VARIANTS` stays on the table as a later unification, once `GGML_BACKEND_DL` is de-risked on Snapdragon — at which point the two Linux artifacts could collapse back into one.

## Design decision: opt-in, never auto-detected

Every channel requires an explicit request for the CPU-only build; nothing probes the CPU to choose for you. A mis-detection would silently cost several-fold throughput on a perfectly capable device, whereas the failure it would have prevented is already a clear, actionable error (#1180's guard). Explicit selection trades a little friction for no risk of a silent slowdown.

## Fix

- **`sdk/cmake/arm64-linux-gnu-cpu.cmake`** — `-march=armv8-a`, no ISA extensions. Without `armv8.2-a` GCC no longer inlines LSE, so the `LDADDAL` that trapped in `std::mutex` is gone. (Distro GCC defaults to `-moutline-atomics`, so the `__aarch64_*` helpers are still linked in and dispatch on `HWCAP_ATOMICS` at runtime — LSE when present, LL/SC otherwise.) Dropping `+fp16`/`+dotprod` means ggml falls back to its fp32 quant kernels: slower, but it runs.
- **`GENIEX_CPU_ONLY` CMake option** (`sdk/CMakeLists.txt`) — `add_compile_definitions(GENIEX_CPU_ONLY)`, which compiles out the startup HWCAP guard in `sdk/src/ml.cpp`. The guard exists to describe the armv8.2 build's requirements; for this build there is nothing left to check.
- **`arm64-linux-cpu-{debug,release}` presets** — compose a new hidden `cpu-only` preset (`GENIEX_PLUGIN_QAIRT=OFF`, `GGML_HEXAGON=OFF`, `GGML_OPENCL=OFF`, `GENIEX_CPU_ONLY=ON`). An ARMv8.0 Dragonwing board has no NPU and no Adreno, so those plugins would be dead weight.
- **CI / release** — a `linux-arm64-cpu` leg in both `_build-sdk.yml` and `_build-cli.yml`, shipping `geniex-sdk-linux-arm64-cpu-<tag>.zip` and `geniex-cli-linux-arm64-cpu-<tag>.tar.gz`. **No CPU-only `geniex-bench` archive** — the SDK zip already ships `bin/geniex-bench`.
- **`install.sh`** — `--cpu-only` appends `-cpu` to the asset stem and prints a notice. It also skips the fastrpc symlink step, since this build ships no QAIRT/HTP plugin to resolve host libraries for.
- **`_sdk_fetch.py`** — `GENIEX_SDK_VARIANT=cpu` selects the `-cpu` SDK zip at pip-install time (an sdist builds on the target, so install-time selection is the right hook). Only `default` and `cpu` are accepted, and only on `linux-arm64`. Because the CPU-only SDK has no QAIRT: `geniex-qairt` fails with an actionable message, while the `geniex` meta sdist degrades to llama.cpp only rather than staging an empty `qairt/` that would fail at first inference.
- **`error.go`** — the CPU-unsupported hint now points at `--cpu-only` instead of only saying "use a newer device".
- **Docker** — OCI carries no micro-architecture discriminator (`platform.variant` is `v8`, not `v8.2`), so one manifest can't auto-select. The CPU-only image ships as `:<tag>-cpu` with its own floating `:latest-cpu`; `:latest` stays the armv8.2 image. `entrypoint.sh` now gates each host-library group on the plugin that needs it, so the CPU-only image no longer prints driver warnings for hardware these boards don't have.
- **Docs** — EN + CN troubleshooting entries (with a per-channel selection table), the Linux install page, `notes/build.md`, and `notes/release.md`.

| Channel | How to select the CPU-only build |
| --- | --- |
| `install.sh` | `--cpu-only` |
| `pip install geniex` | `GENIEX_SDK_VARIANT=cpu` |
| Docker | the `-cpu` tag — `docker.io/qualcomm/geniex:latest-cpu` |

## Test plan

- [x] Release CI green end to end on `v0.4.1-alpha.3` — run [32356785568](https://github.com/qualcomm/GenieX/actions/runs/32356785568), 22/22 jobs, including `build-sdk / linux-arm64-cpu`, `build-cli / linux-arm64-cpu` and `publish-docker / cpu`
- [x] `geniex-sdk-linux-arm64-cpu-<tag>.zip` and `geniex-cli-linux-arm64-cpu-<tag>.tar.gz` (+ `.sha256`) reach S3 and the release
- [x] `docker.io/qualcomm/geniex:v0.4.1-alpha.3-cpu` pushed; `:latest-cpu` correctly **not** moved for a prerelease
- [x] `GENIEX_CPU_ONLY` verified to reach the compiler and remove the `getauxval` guard (`nm -uC ml.cpp.o | grep -c getauxval` = 0)
- [x] `bindings/python/tests/unit/test_sdk_variant.py` — 8 passed
- [x] Device run on **`WADTestBoard01`** (the UNO Q from #1217: `crc32`, no `atomics`/`asimddp`/`fphp`) — see [pr-check 31768117636](https://github.com/qualcomm/GenieX/actions/runs/31768117636). Note this ran against the earlier `-baseline`-named iteration of this branch; the flags were `-march=armv8-a+crc -moutline-atomics` then and are plain `-march=armv8-a` now, so a re-run on the current artifacts is worth doing before merge.
- [x] S3 mutable pointer `geniex-cli-linux-arm64-cpu.tar.gz` (+ `.sha256`) — implemented and landed (see Companion changes). Verified statically only: the step is gated on `is_prerelease != 'true'`, so no alpha tag can reach it. The filename it references matches `package-release`'s output byte for byte, and `package-release` fails outright if the `cli-linux-arm64-cpu` artifact is missing, so the file is guaranteed present whenever the step runs.

## Companion changes (other repo)

S3 publishing runs in `qcom-ai-hub/geniex` — this repo's `publish-s3` job only dispatches it — so these are **not** visible in this diff. All three are on `chore/publish-s3` and already landed:

| Commit | What | Why it matters here |
| --- | --- | --- |
| `553d5b3` | match release assets by family (`--include 'geniex-cli-linux-arm64-*.tar.gz'`) instead of by exact tag | **Prerequisite.** The tag-pinned `--include` silently dropped variant suffixes, so `geniex-cli-linux-arm64-cpu-<tag>.tar.gz` never reached S3 and `install.sh --cpu-only` would 404 even with `--version`. |
| `a6fff3d` | refresh the mutable `geniex-cli-linux-arm64-cpu.tar.gz(.sha256)` pointer | `install.sh --cpu-only` without `--version` resolves the unversioned object. |
| `a3c2736` | keep the CPU-only build out of `manifest-<tag>.json` | The old patterns' `.+` spanned the `cpu-` infix, so the CPU-only assets landed in the manifest with metadata identical to the default build's — a `kind`/`platform`/`arch` lookup could hand a normal Snapdragon device the slow artifact. |

Tracked in qcom-ai-hub/geniex#1473.

Closes #1217

