### PR TITLE
fix(bench): run VLM llama_cpp cells as text LLM in ctx/pp/tg sweep

### DIFF
--- a/sdk/benchmark/qdc/linux/run_linux.sh
+++ b/sdk/benchmark/qdc/linux/run_linux.sh
@@ -62,13 +62,14 @@ done
 while IFS='|' read -r name plugin devs model_id vlm image; do
   [ -z "$name" ] && continue
   echo "=== plan $name id=$model_id ==="
-  imgpath=""
-  [ "$image" = "1" ] && imgpath="$IMG"
   case "$plugin" in
     qairt)     bucket=qairt ;;
     llama_cpp) bucket=llama ;;
     *) echo "WARN: unknown plugin $plugin in $name, skipping"; continue ;;
   esac
+  [ "$bucket" != "qairt" ] && { vlm=""; image=""; }
+  imgpath=""
+  [ "$image" = "1" ] && imgpath="$IMG"
   IFS=','
   for d in $devs; do
     for ctx in "${CTX_ARR[@]}"; do

--- a/sdk/benchmark/qdc/tests/test_bench.py
+++ b/sdk/benchmark/qdc/tests/test_bench.py
@@ -52,6 +52,8 @@ def test_bench():
         name, plugin, devs, model_id, vlm, image = row.split("|")
         if plugin not in ("llama_cpp", "qairt"):
             continue
+        if plugin != "qairt":
+            vlm = image = ""
         imgpath = IMAGE_PATH if image == "1" else ""
         for d in devs.split(","):
             for ctx in CTXS:

--- a/sdk/benchmark/qdc/windows/run_windows.ps1
+++ b/sdk/benchmark/qdc/windows/run_windows.ps1
@@ -73,12 +73,13 @@ foreach ($plugin in @("llama", "qairt")) {
 foreach ($row in $rows) {
     $name, $plugin, $devs, $model_id, $vlm, $image = $row -split '\|'
     Write-Output "=== plan $name id=$model_id ==="
-    $imgpath = if ($image -eq "1") { $IMG } else { "" }
     $bucket = if ($plugin -eq "qairt") { "qairt" } elseif ($plugin -eq "llama_cpp") { "llama" } else { "" }
     if (-not $bucket) {
         Write-Output "WARN: unknown plugin $plugin in $name, skipping"
         continue
     }
+    if ($bucket -ne "qairt") { $vlm = ""; $image = "" }
+    $imgpath = if ($image -eq "1") { $IMG } else { "" }
     foreach ($d in $devs -split ',') {
         foreach ($ctx in $ctxList) {
             # Columns 5/6 (tokenizer/mmproj) intentionally blank: the model


### PR DESCRIPTION
## Summary

The bench matrix flags gemma-4 / Qwen-VL models with `vlm`/`image` in `bench-models.json`. On the device those columns force the VLM run path for **llama_cpp** cells too, which bypasses the random-ids timing loop: prefill uses the fixed default prompt (`"Describe the image."` + image tokens, ~64 tokens regardless of `ctx`) and decode does a real chat-templated generation that stops at EOG. So the `ctx`/`pp`/`tg` sweep never took effect for these models — a `ctx=1024` run reported `pp64+tg60/74/75` instead of the requested `pp896+tg128`.

`benchmark.c` already documents that a passively-present mmproj must NOT redirect a llama_cpp `-p N` bench into the VLM loop (only explicit `--vlm` / matrix col 8 does). This change stops the QDC harnesses from setting that column for llama_cpp cells, so they run the random-ids timing path (`-p pp`, forced `-n tg`). qairt cells keep `vlm`/`image` — their VLM path goes through `--prompt-file` and is unaffected.

Applied identically to the three mirrored harnesses: `run_windows.ps1`, `run_linux.sh`, and the on-device pytest `test_bench.py`.

## Test plan

- [x] Dispatch bench `device=SC8480XP model=gemma-4-E2B-it,gemma-4-E4B-it ctx=1024` on this branch → Test column reads `pp896+tg128` for every llama_cpp cell (was `pp64+tg60/74/75`) — pending device run