### PR TITLE
feat(server): parse Gemma 4 tool-call format

### DIFF
--- a/cli/server/utils/BUILD.bazel
+++ b/cli/server/utils/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "common.go",
         "toolcall.go",
+        "toolcall_gemma4.go",
     ],
     importpath = "github.com/qualcomm/GenieX/cli/server/utils",
     visibility = ["//visibility:public"],
@@ -20,6 +21,7 @@ go_test(
     name = "utils_test",
     srcs = [
         "common_test.go",
+        "toolcall_gemma4_test.go",
         "toolcall_test.go",
     ],
     embed = [":utils"],

--- a/cli/server/utils/toolcall.go
+++ b/cli/server/utils/toolcall.go
@@ -6,6 +6,7 @@ package utils
 import (
 	"errors"
 	"log/slog"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/bytedance/sonic/ast"
@@ -96,9 +97,14 @@ func parseToolCallObject(obj string) (openai.ChatCompletionMessageFunctionToolCa
 	return toolCall, nil
 }
 
-// ParseToolCalls returns the first balanced {...} object in resp that decodes
-// into a valid tool call, skipping any malformed or non-tool-call objects.
+// ParseToolCalls returns the first tool call in resp. Gemma 4's non-JSON
+// `<|tool_call>call:...` syntax is detected by its marker; every other model
+// wraps a `{"name":..., "arguments":...}` JSON object we scan for directly.
 func ParseToolCalls(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	if strings.Contains(resp, gemma4ToolCallOpen) {
+		return parseToolCallsGemma4(resp)
+	}
+
 	for _, obj := range extractJSONObjects(resp) {
 		if toolCall, err := parseToolCallObject(obj); err == nil {
 			slog.Debug("Parsed tool call", "tool_call", toolCall)

--- a/cli/server/utils/toolcall_gemma4.go
+++ b/cli/server/utils/toolcall_gemma4.go
@@ -1,0 +1,176 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/openai/openai-go/v3"
+)
+
+// Gemma 4 emits tool calls as `<|tool_call>call:NAME{key:value,...}<tool_call|>`
+// instead of JSON. The body is a custom dict where strings are wrapped in
+// `<|"|>...<|"|>`, keys are bare up to ':', and scalars (number/bool/null) are
+// verbatim. Grammar mirrors llama.cpp's common_chat_params_init_gemma4.
+const (
+	gemma4ToolCallOpen = "<|tool_call>call:"
+	gemma4StringMarker = `<|"|>`
+)
+
+var errGemma4 = errors.New("gemma4 tool call not match")
+
+// parseToolCallsGemma4 extracts the first `<|tool_call>call:NAME{...}` in resp
+// and returns it with the dict body transcoded to JSON arguments.
+func parseToolCallsGemma4(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
+	tc := openai.ChatCompletionMessageFunctionToolCallFunction{}
+
+	start := strings.Index(resp, gemma4ToolCallOpen)
+	if start < 0 {
+		return tc, errGemma4
+	}
+	i := start + len(gemma4ToolCallOpen)
+
+	brace := strings.IndexByte(resp[i:], '{')
+	if brace < 0 {
+		return tc, errGemma4
+	}
+	name := strings.TrimSpace(resp[i : i+brace])
+	if name == "" {
+		return tc, errGemma4
+	}
+
+	args, _, err := parseGemma4Dict(resp, i+brace)
+	if err != nil {
+		return tc, err
+	}
+
+	tc.Name = name
+	tc.Arguments = args
+	return tc, nil
+}
+
+func skipGemma4Space(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i++
+	}
+	return i
+}
+
+// parseGemma4Value parses one value at s[i] and returns its JSON encoding and
+// the index just past it.
+func parseGemma4Value(s string, i int) (string, int, error) {
+	if i >= len(s) {
+		return "", i, errGemma4
+	}
+	switch {
+	case strings.HasPrefix(s[i:], gemma4StringMarker):
+		return parseGemma4String(s, i)
+	case s[i] == '{':
+		return parseGemma4Dict(s, i)
+	case s[i] == '[':
+		return parseGemma4Array(s, i)
+	default:
+		return parseGemma4Scalar(s, i)
+	}
+}
+
+func parseGemma4String(s string, i int) (string, int, error) {
+	i += len(gemma4StringMarker)
+	end := strings.Index(s[i:], gemma4StringMarker)
+	if end < 0 {
+		return "", i, errGemma4
+	}
+	quoted, err := sonic.MarshalString(s[i : i+end])
+	if err != nil {
+		return "", i, err
+	}
+	return quoted, i + end + len(gemma4StringMarker), nil
+}
+
+func parseGemma4Dict(s string, i int) (string, int, error) {
+	return parseGemma4Seq(s, i, '{', '}', parseGemma4Member)
+}
+
+func parseGemma4Array(s string, i int) (string, int, error) {
+	return parseGemma4Seq(s, i, '[', ']', parseGemma4Value)
+}
+
+// parseGemma4Member parses one `key:value` pair and returns it as `"key":value`.
+// The key grammar is `[^:}]+`: it must be non-empty and cannot span the dict's
+// closing '}', so a member missing its value fails instead of swallowing later
+// text as the key.
+func parseGemma4Member(s string, i int) (string, int, error) {
+	colon := strings.IndexByte(s[i:], ':')
+	if colon < 0 || strings.IndexByte(s[i:i+colon], '}') >= 0 {
+		return "", i, errGemma4
+	}
+	key := strings.TrimSpace(s[i : i+colon])
+	if key == "" {
+		return "", i, errGemma4
+	}
+	val, next, err := parseGemma4Value(s, skipGemma4Space(s, i+colon+1))
+	if err != nil {
+		return "", i, err
+	}
+	quotedKey, err := sonic.MarshalString(key)
+	if err != nil {
+		return "", next, err
+	}
+	return quotedKey + ":" + val, next, nil
+}
+
+// parseGemma4Seq parses a comma-separated `open ... close` sequence, encoding
+// each element with elem. s[i] must be open (guaranteed by the caller).
+func parseGemma4Seq(s string, i int, open, close byte,
+	elem func(s string, i int) (string, int, error)) (string, int, error) {
+	i++ // past open
+
+	var b strings.Builder
+	b.WriteByte(open)
+
+	i = skipGemma4Space(s, i)
+	if i < len(s) && s[i] == close {
+		b.WriteByte(close)
+		return b.String(), i + 1, nil
+	}
+
+	for {
+		enc, next, err := elem(s, skipGemma4Space(s, i))
+		if err != nil {
+			return "", next, err
+		}
+		b.WriteString(enc)
+		i = skipGemma4Space(s, next)
+
+		if i >= len(s) {
+			return "", i, errGemma4
+		}
+		switch s[i] {
+		case ',':
+			i++
+			b.WriteByte(',')
+		case close:
+			b.WriteByte(close)
+			return b.String(), i + 1, nil
+		default:
+			return "", i, errGemma4
+		}
+	}
+}
+
+// parseGemma4Scalar reads a number/bool/null up to the next ',', '}' or ']'.
+func parseGemma4Scalar(s string, i int) (string, int, error) {
+	start := i
+	for i < len(s) && s[i] != ',' && s[i] != '}' && s[i] != ']' {
+		i++
+	}
+	tok := strings.TrimSpace(s[start:i])
+	var v any
+	if tok == "" || sonic.UnmarshalString(tok, &v) != nil {
+		return "", start, errGemma4
+	}
+	return tok, i, nil
+}

--- a/cli/server/utils/toolcall_gemma4_test.go
+++ b/cli/server/utils/toolcall_gemma4_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import "testing"
+
+func TestParseToolCallsGemma4(t *testing.T) {
+	tests := []struct {
+		name      string
+		resp      string
+		wantName  string
+		wantArgs  string
+		wantError bool
+	}{
+		{
+			name:     "single string argument",
+			resp:     `<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>}<tool_call|>`,
+			wantName: "get_weather",
+			wantArgs: `{"city":"Beijing"}`,
+		},
+		{
+			name:     "multiple arguments mixed types",
+			resp:     `<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>,days:3,metric:true}<tool_call|>`,
+			wantName: "get_weather",
+			wantArgs: `{"city":"Beijing","days":3,"metric":true}`,
+		},
+		{
+			name:     "empty arguments",
+			resp:     `<|tool_call>call:now{}<tool_call|>`,
+			wantName: "now",
+			wantArgs: `{}`,
+		},
+		{
+			name:     "nested dict",
+			resp:     `<|tool_call>call:f{loc:{lat:1.5,lng:<|"|>x<|"|>}}<tool_call|>`,
+			wantName: "f",
+			wantArgs: `{"loc":{"lat":1.5,"lng":"x"}}`,
+		},
+		{
+			name:     "array of strings",
+			resp:     `<|tool_call>call:pick{items:[<|"|>a<|"|>,<|"|>b<|"|>]}<tool_call|>`,
+			wantName: "pick",
+			wantArgs: `{"items":["a","b"]}`,
+		},
+		{
+			name:     "array of dicts",
+			resp:     `<|tool_call>call:batch{items:[{a:1},{b:2}]}<tool_call|>`,
+			wantName: "batch",
+			wantArgs: `{"items":[{"a":1},{"b":2}]}`,
+		},
+		{
+			name:     "null and negative number",
+			resp:     `<|tool_call>call:f{x:null,y:-4.2}<tool_call|>`,
+			wantName: "f",
+			wantArgs: `{"x":null,"y":-4.2}`,
+		},
+		{
+			name:     "string with special chars escaped",
+			resp:     `<|tool_call>call:say{text:<|"|>a "quote" and }brace{<|"|>}<tool_call|>`,
+			wantName: "say",
+			wantArgs: `{"text":"a \"quote\" and }brace{"}`,
+		},
+		{
+			name:     "preceded by reasoning and content",
+			resp:     "<|channel>thought\nlet me check\n<channel|>Sure! <|tool_call>call:go{x:1}<tool_call|>",
+			wantName: "go",
+			wantArgs: `{"x":1}`,
+		},
+		{
+			name:     "picks first of parallel tool calls",
+			resp:     `<|tool_call>call:first{a:1}<tool_call|><|tool_call>call:second{b:2}<tool_call|>`,
+			wantName: "first",
+			wantArgs: `{"a":1}`,
+		},
+		{
+			name:     "whitespace around members",
+			resp:     `<|tool_call>call:f{ a : 1 , b : <|"|>x<|"|> }<tool_call|>`,
+			wantName: "f",
+			wantArgs: `{"a":1,"b":"x"}`,
+		},
+		{
+			name:      "no tool call marker",
+			resp:      "just some plain text",
+			wantError: true,
+		},
+		{
+			name:      "marker but no brace",
+			resp:      `<|tool_call>call:broken`,
+			wantError: true,
+		},
+		{
+			name:      "unterminated dict",
+			resp:      `<|tool_call>call:f{x:1`,
+			wantError: true,
+		},
+		{
+			name:      "unterminated string value",
+			resp:      `<|tool_call>call:f{x:<|"|>abc}<tool_call|>`,
+			wantError: true,
+		},
+		{
+			name:      "empty function name",
+			resp:      `<|tool_call>call:{x:1}<tool_call|>`,
+			wantError: true,
+		},
+		{
+			name:      "empty key rejected",
+			resp:      `<|tool_call>call:f{:1}<tool_call|>`,
+			wantError: true,
+		},
+		{
+			// key scan must stop at '}' rather than swallowing the next member's colon
+			name:      "member without value does not swallow later key",
+			resp:      `<|tool_call>call:f{k}{x:1}<tool_call|>`,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseToolCallsGemma4(tt.resp)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got tool call %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
+			}
+			if got.Arguments != tt.wantArgs {
+				t.Errorf("arguments = %q, want %q", got.Arguments, tt.wantArgs)
+			}
+		})
+	}
+}
+
+// ParseToolCalls must route gemma4-marked output to the gemma4 parser while
+// leaving JSON output on the generic path.
+func TestParseToolCallsDispatch(t *testing.T) {
+	got, err := ParseToolCalls(`<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>}<tool_call|>`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "get_weather" || got.Arguments != `{"city":"Beijing"}` {
+		t.Errorf("gemma4 dispatch failed: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Gemma 4 emits tool calls in a non-JSON syntax — `<|tool_call>call:NAME{key:value,...}<tool_call|>` — where strings are wrapped in `<|"|>...<|"|>`, keys are bare up to `:`, and scalars (number/bool/null) are verbatim. The format-agnostic JSON scanner in `ParseToolCalls` only recognizes `{"name":...,"arguments":...}` objects, so Gemma 4 tool calls fell through to plain text.

This adds a recursive-descent parser (`toolcall_gemma4.go`) that transcodes the custom dict body into JSON arguments, mirroring llama.cpp's `common_chat_params_init_gemma4` grammar (notably the `[^:}]+` key rule). `ParseToolCalls` sniffs the `<|tool_call>call:` marker and routes to it; every other model stays on the existing JSON path, and a parse failure still falls back to returning the raw text as content.

Scope is parse-side only (model output → tool call). The multi-turn injection side is unchanged.

## Test plan

- [x] `bazelisk test //cli/server/utils:utils_test` — table-driven coverage: strings/scalars/nested dicts/arrays, escaping, whitespace, parallel calls (first wins), and malformed inputs (empty key, member without value, unterminated string/dict) all rejected.
- [x] `gofmt` clean.
- [x] End-to-end against a real Gemma 4 GGUF model on the local server (`-c hybrid`): all 20 agentic-test-suite tool_call cases parsed as `finish_reason=tool_calls`, no text fallback.