### PR TITLE
fix(sdk): default llama.cpp swa_full to false

### DIFF
--- a/sdk/plugins/llama_cpp/src/params.cpp
+++ b/sdk/plugins/llama_cpp/src/params.cpp
@@ -84,6 +84,7 @@ llama_context_params build_context_params(const geniex_ModelConfig& config, int3
     bool     fa     = fa_matrix[static_cast<int>(kHostPlatform)][static_cast<int>(device)];
 
     llama_context_params cpar = llama_context_default_params();
+    cpar.swa_full             = false;
     cpar.n_ctx                = config.n_ctx > 0 ? config.n_ctx : n_ctx_default;
     cpar.n_batch              = config.n_batch > 0 ? config.n_batch : 2048;
     cpar.n_ubatch             = config.n_ubatch > 0 ? config.n_ubatch : ubatch;


### PR DESCRIPTION
## Summary

`llama_context_default_params()` sets `swa_full=true`, so `build_context_params` inherited a full-`n_ctx` SWA KV cache mirror. Upstream `common_params` (what `llama-cli` uses) defaults it to `false`, capping the SWA cache at `n_swa + n_ubatch` cells. Aligning the SDK default with upstream shrinks the SWA cache on models that use sliding-window attention (Gemma-4, etc.).

Reported failure mode: GenieX on Linux Glymur / NPU crossed the fastrpc per-domain HTP mapping budget for Gemma-4 well before `llama-cli` did on the same box, because the SWA KV cache was ~2.7× the size upstream would allocate.

## Test plan

Windows-on-Snapdragon (X2E88100, HTP0), Gemma-4 E4B q4_0-gguf, `nctx=4096`, `n_swa=512`, `--compute NPU`.

- [x] `params.cpp` log confirms `swa_full=false` at both `geniex infer` and `geniex-bench`.
- [x] `llama_kv_cache_iswa: creating SWA KV cache, size = X cells` drops from `4096` to `1536`, matching `pad(min(n_ctx, n_swa + n_ubatch), 256) = pad(1536, 256) = 1536`.
- [x] `using full-size SWA cache` warning no longer emitted.
- [x] HTP0 SWA KV buffer drops from `160.00 MiB` to `60.00 MiB` (-62.5%, -100 MiB); non-SWA KV buffer unchanged at `64.00 MiB`.
- [x] `geniex-bench --plugin llama_cpp --device npu -p 2048 -n 128 -c 4096 -r 3 --warmup 1` shows no perf regression (128-token decode runs, baseline vs patched):

  | | baseline (`swa_full=true`) | patched (`swa_full=false`) | Δ |
  |---|---|---|---|
  | TTFT | ~5119 ms | ~5074 ms | -0.9% |
  | Prefill | ~400.1 tok/s | ~403.7 tok/s | +0.9% |
  | Decode | ~12.03 tok/s | ~12.52 tok/s | **+4.0%** |
  | HTP0 SWA KV | 160.00 MiB | 60.00 MiB | **-62.5%** |

- [x] Linux Glymur / NPU on Gemma-4 26B — the exact scenario that hit `fastrpc_mmap failed`. Pending, no Glymur on the team.