### PR TITLE
ci(bench): add gemma-4-26B-A4B-it QAT GGUF for QDC bench

### DIFF
--- a/sdk/benchmark/qdc/bench-models.json
+++ b/sdk/benchmark/qdc/bench-models.json
@@ -116,6 +116,17 @@
     "image": true
   },
   {
+    "name": "gemma-4-26B-A4B-it",
+    "plugin": "llama_cpp",
+    "devices": ["cpu", "npu", "gpu", "hybrid"],
+    "model_id": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0",
+    "hub": "hf",
+    "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-qat-q4_0-gguf/resolve/main/gemma-4-26B_q4_0-it.gguf",
+    "mmproj_url": "https://huggingface.co/google/gemma-4-26B-A4B-it-qat-q4_0-gguf/resolve/main/gemma-4-26B-it-mmproj.gguf",
+    "vlm": true,
+    "image": true
+  },
+  {
     "name": "Qwen3.5-2B",
     "plugin": "llama_cpp",
     "devices": ["cpu", "npu", "hybrid"],


### PR DESCRIPTION
## Summary
- Add Google's QAT Q4_0 GGUF of `gemma-4-26B-A4B-it` (26B MoE, ~4B active, VLM) to `sdk/benchmark/qdc/bench-models.json` so the Geniex Bench workflow can schedule it.
- Declared `["npu"]` only — first pass validates NPU on QCS9075M; other compute units can be enabled once the NPU path is green.

## Test plan
