### PR TITLE
feat(sdk): return PROMPT_TOO_LONG when the prompt itself overflows

### DIFF
--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -59,6 +59,7 @@ var (
 	ErrCommonRateLimited            = SDKError(C.GENIEX_ERROR_COMMON_RATE_LIMITED)
 	ErrCommonHubServer              = SDKError(C.GENIEX_ERROR_COMMON_HUB_SERVER)
 	ErrLlmTokenizationContextLength = SDKError(C.GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH)
+	ErrLlmGenerationPromptTooLong   = SDKError(C.GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG)
 )
 
 // Init must be called before any other SDK function.

--- a/cli/cmd/geniex/common/error.go
+++ b/cli/cmd/geniex/common/error.go
@@ -48,6 +48,13 @@ const (
 - This model may not be compatible with your system. Try another model.
 - See help in our discord or slack.`
 
+	hintPromptTooLong = `⚠️ Prompt too long — the input alone is longer than the context window.
+
+👉 Try these:
+- Shorten the prompt (or the conversation history) so it fits the window.
+- llama_cpp: raise the window with '--nctx <N>' (default 4096), up to the model's trained max. Larger windows use more memory.
+- qairt: the window is fixed at compile time and can't be raised at runtime. Add '--sliding-window' to evict the oldest context, or pull a bundle built for a longer context.`
+
 	hintContextLength = `⚠️ Context length exceeded — the conversation outgrew the context window.
 
 👉 Try these:
@@ -129,6 +136,7 @@ var errorHints = []struct {
 	{geniex_sdk.ErrCommonModelLoad, hintModelLoad},
 	{geniex_sdk.ErrCommonPluginLoad, hintPluginLoad},
 	{geniex_sdk.ErrCommonPluginInvalid, hintPluginInvalid},
+	{geniex_sdk.ErrLlmGenerationPromptTooLong, hintPromptTooLong},
 	{geniex_sdk.ErrLlmTokenizationContextLength, hintContextLength},
 	{geniex_sdk.ErrCommonAuth, hintHubAuthRequired},
 	{geniex_sdk.ErrCommonHubModelNotFound, hintModelNotFound},

--- a/cli/cmd/geniex/common/process.go
+++ b/cli/cmd/geniex/common/process.go
@@ -122,6 +122,15 @@ func (p *Processor) Process() error {
 		case errors.Is(err, ErrNoImage):
 			fmt.Println(render.GetTheme().Error.Sprintf("No image file provided, please provide an image file"))
 			fmt.Println()
+		case errors.Is(err, geniex_sdk.ErrLlmGenerationPromptTooLong):
+			if p.Reset != nil {
+				if resetErr := p.Reset(); resetErr != nil {
+					return resetErr
+				}
+			}
+			fmt.Println(render.GetTheme().Error.Sprintf("Prompt is longer than the context window; conversation is reset."))
+			fmt.Println(render.GetTheme().Error.Sprintf("Raise it with --nctx <N> (llama_cpp; larger uses more memory), or add --sliding-window (qairt)."))
+			fmt.Println()
 		case errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength):
 			if p.Reset != nil {
 				if resetErr := p.Reset(); resetErr != nil {

--- a/cli/cmd/geniex/common/process_test.go
+++ b/cli/cmd/geniex/common/process_test.go
@@ -31,6 +31,12 @@ func TestProcessContextLengthExceeded(t *testing.T) {
 			wantRuns:  2, // first errors+resets, second returns nil then EOF
 		},
 		{
+			name:      "prompt too long resets and continues",
+			runErr:    geniex_sdk.ErrLlmGenerationPromptTooLong,
+			wantReset: 1,
+			wantRuns:  2,
+		},
+		{
 			name:        "reset failure aborts the loop",
 			runErr:      geniex_sdk.ErrLlmTokenizationContextLength,
 			resetErr:    errors.New("reset boom"),

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -321,12 +321,15 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		if !parseTool && reasoningSeparated(param.ReasoningFormat) {
 			class = reasoningClass()
 		}
-		profile, fullText, err := gen(prompt, sink(class, &content, &reasoning))
-		if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
-			writeContextLengthExceeded(c, fullText, profile)
+		profile, _, err := gen(prompt, sink(class, &content, &reasoning))
+		// A prompt that never fit is a client error (400). A window exhausted
+		// mid-generation is a normal truncated completion (finish_reason=length),
+		// so it falls through to the regular response below.
+		if errors.Is(err, geniex_sdk.ErrLlmGenerationPromptTooLong) {
+			writePromptTooLong(c, profile)
 			return
 		}
-		if err != nil {
+		if err != nil && !errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
 			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return
 		}

--- a/cli/server/handler/chat_response.go
+++ b/cli/server/handler/chat_response.go
@@ -41,25 +41,16 @@ func writeKeepAliveError(c *gin.Context, err error) bool {
 	return true
 }
 
-// OpenAI's 400 body, plus the partial generation under `choices` so clients can
-// recover the truncated output.
-func writeContextLengthExceeded(c *gin.Context, fullText string, profile geniex_sdk.ProfileData) {
-	choice := openai.ChatCompletionChoice{
-		FinishReason: "length",
-		Message: openai.ChatCompletionMessage{
-			Role:    constant.Assistant(openai.MessageRoleAssistant),
-			Content: fullText,
-		},
-	}
-
+// OpenAI's 400 body for a prompt that is longer than the context window. No
+// partial output exists (nothing was generated), so this returns only the error.
+func writePromptTooLong(c *gin.Context, profile geniex_sdk.ProfileData) {
 	c.JSON(http.StatusBadRequest, map[string]any{
 		"error": map[string]any{
-			"message": "model context window exceeded; output truncated",
+			"message": "prompt is longer than the model's context window",
 			"type":    "invalid_request_error",
 			"code":    "context_length_exceeded",
 		},
-		"choices": []openai.ChatCompletionChoice{choice},
-		"usage":   profile2Usage(profile),
+		"usage": profile2Usage(profile),
 	})
 }
 

--- a/cli/server/handler/chat_stream.go
+++ b/cli/server/handler/chat_stream.go
@@ -4,6 +4,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -98,7 +99,10 @@ func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, in
 			}
 			return true
 		}
-		if err := wait(); err != nil {
+		// A context window exhausted mid-stream is a normal truncated completion
+		// (finish_reason=length): fall through to the finish chunk. Other errors
+		// (including a too-long prompt) are surfaced as an error event.
+		if err := wait(); err != nil && !errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
 			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return false
 		}
@@ -121,7 +125,10 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			buffer.WriteString(r)
 			return true
 		}
-		if err := wait(); err != nil {
+		// A context window exhausted mid-stream is a normal truncated completion:
+		// fall through and emit what was buffered. Other errors (including a
+		// too-long prompt) are surfaced as an error event.
+		if err := wait(); err != nil && !errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
 			slog.Error("Generation error", "error", err)
 			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return false

--- a/cli/server/handler/completion.go
+++ b/cli/server/handler/completion.go
@@ -224,11 +224,14 @@ func Completions(c *gin.Context) {
 			PromptUTF8: prompt,
 			Config:     genConfig,
 		})
-		if errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
-			writeCompletionContextLengthExceeded(c, echo+out.FullText, out.ProfileData)
+		// A prompt that never fit is a client error (400). A window exhausted
+		// mid-generation is a normal truncated completion (finish_reason=length),
+		// so it falls through to the regular response below.
+		if errors.Is(err, geniex_sdk.ErrLlmGenerationPromptTooLong) {
+			writeCompletionPromptTooLong(c, out.ProfileData)
 			return
 		}
-		if err != nil {
+		if err != nil && !errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
 			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return
 		}
@@ -284,7 +287,10 @@ func streamCompletion(c *gin.Context, dataCh <-chan string, wait func() error, i
 			c.SSEvent("", completionTextChunk(r))
 			return true
 		}
-		if err := wait(); err != nil {
+		// A context window exhausted mid-stream is a normal truncated completion
+		// (finish_reason=length): fall through to the finish chunk. Other errors
+		// (including a too-long prompt) are surfaced as an error event.
+		if err := wait(); err != nil && !errors.Is(err, geniex_sdk.ErrLlmTokenizationContextLength) {
 			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return false
 		}
@@ -322,16 +328,15 @@ func writeCompletionResponse(c *gin.Context, text string, profile geniex_sdk.Pro
 	})
 }
 
-// OpenAI's 400 body, plus the partial generation under `choices` so clients can
-// recover the truncated output.
-func writeCompletionContextLengthExceeded(c *gin.Context, text string, profile geniex_sdk.ProfileData) {
+// OpenAI's 400 body for a prompt that is longer than the context window. No
+// partial output exists (nothing was generated), so this returns only the error.
+func writeCompletionPromptTooLong(c *gin.Context, profile geniex_sdk.ProfileData) {
 	c.JSON(http.StatusBadRequest, map[string]any{
 		"error": map[string]any{
-			"message": "model context window exceeded; output truncated",
+			"message": "prompt is longer than the model's context window",
 			"type":    "invalid_request_error",
 			"code":    "context_length_exceeded",
 		},
-		"choices": []completionChoice{{Text: text, FinishReason: "length"}},
-		"usage":   profile2Usage(profile),
+		"usage": profile2Usage(profile),
 	})
 }

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -329,8 +329,10 @@ int32_t LlamaLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
 
     const bool spec_prefill = this->spec != nullptr && (this->draft_ctx != nullptr);
 
-    // Decode one batch (caller chunks long inputs) and advance n_past.
-    auto process = [&](const llama_token* tokens, int n_tokens) -> int32_t {
+    // Decode one batch (caller chunks long inputs) and advance n_past. overflow_err
+    // is returned when the context is exhausted even after shifting, letting the
+    // caller distinguish a too-long prompt (prefill) from a full window (decode).
+    auto process = [&](const llama_token* tokens, int n_tokens, int32_t overflow_err) -> int32_t {
         int rc;
         if (spec_prefill) {
             llama_batch batch = llama_batch_init(n_tokens, /*embd=*/0, /*n_seq_max=*/1);
@@ -356,7 +358,7 @@ int32_t LlamaLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
             case 0:
                 break;
             case 1:
-                return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+                return overflow_err;
             default:
                 return GENIEX_ERROR_LLM_GENERATION_FAILED;
         }
@@ -370,9 +372,13 @@ int32_t LlamaLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
         common_sampler_accept(this->sampler, id, /* accept_grammar= */ false);
     }
 
+    // A context overflow during prefill means the prompt itself doesn't fit,
+    // even after any context shift (or the model can't shift at all); during
+    // decode it means the window filled up mid-generation. Distinct causes, so
+    // process() reports the one matching the phase.
     for (int i = 0; i < (int)embd_inp.size() && res == GENIEX_SUCCESS; i += n_batch) {
         int n_eval = std::min(n_batch, (int)embd_inp.size() - i);
-        res        = process(embd_inp.data() + i, n_eval);
+        res        = process(embd_inp.data() + i, n_eval, GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG);
     }
 
     profiler.prompt_end();
@@ -438,7 +444,7 @@ int32_t LlamaLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
                 break;
             }
 
-            res = process(&id, 1);
+            res = process(&id, 1, GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH);
         }
     }
 

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -298,7 +298,8 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             }
 
             // Evaluate chunks (like eval_message does). 1 means the prompt does
-            // not fit the KV cache: report truncation, not a generic failure.
+            // not fit the KV cache: since this is prefill, the prompt itself is
+            // too long, not a generic failure.
             llama_pos new_n_past = this->n_past;
             switch (mtmd_helper_eval_chunks(
                 this->ctx_vision, this->ctx, chunks, this->n_past, 0, llama_n_batch(this->ctx), true, &new_n_past)) {
@@ -307,7 +308,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
                     this->n_past = new_n_past;
                     break;
                 case 1:
-                    res = GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+                    res = GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG;
                     break;
                 default:
                     GENIEX_LOG_ERROR("mtmd_helper_eval_chunks failed");
@@ -363,13 +364,14 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
 
             int32_t decode_ret = llama_decode(this->ctx, batch);
             free(prompt_tokens);
-            // 1 means the prompt does not fit the KV cache: report truncation, not a generic failure.
+            // 1 means the prompt does not fit the KV cache: since this is
+            // prefill, the prompt itself is too long, not a generic failure.
             switch (decode_ret) {
                 case 0:
                     this->n_past += prompt_len;
                     break;
                 case 1:
-                    res = GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+                    res = GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG;
                     break;
                 default:
                     GENIEX_LOG_ERROR("llama_decode failed");

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -277,6 +277,10 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
         output->profile_data.stop_reason = "length";
         GENIEX_LOG_WARN("QAIRT generate: context length exceeded (partial result populated)");
         return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+    } else if (result.stop_reason == "prompt_too_long") {
+        output->profile_data.stop_reason = "length";
+        GENIEX_LOG_WARN("QAIRT generate: prompt exceeds max context length");
+        return GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG;
     } else if (result.stop_reason == "error") {
         output->profile_data.stop_reason = "eos";
         GENIEX_LOG_ERROR("QAIRT generate failed during prompt processing (empty result)");

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -304,6 +304,10 @@ int32_t QairtVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
         output->profile_data.stop_reason = "length";
         GENIEX_LOG_WARN("QAIRT VLM generate: context length exceeded (partial result populated)");
         return GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
+    } else if (result.stop_reason == "prompt_too_long") {
+        output->profile_data.stop_reason = "length";
+        GENIEX_LOG_WARN("QAIRT VLM generate: prompt exceeds max context length");
+        return GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG;
     } else if (result.stop_reason == "error") {
         output->profile_data.stop_reason = "eos";
         GENIEX_LOG_ERROR("QAIRT VLM generate failed during prompt processing (empty result)");


### PR DESCRIPTION
## Summary

Overlong input previously always mapped to `GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH`, so callers could not distinguish a prompt that never fit the context window from a window that filled up mid-generation. This PR splits the two:

- **Prompt too long** — the prompt alone exceeds the context window (even after a context shift, or the model can't shift). Now returns the new `GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG` from both the `llama_cpp` and `qairt` LLM/VLM plugins.
- **Context length exceeded** — the in-flight generation fills the window mid-decode. Keeps returning `CONTEXT_LENGTH`.

Downstream behavior:

- **SDK plugins** — `llama_cpp` reports the phase-appropriate error from its shared `process()` (prefill → prompt-too-long, decode → context-length); `qairt` reads the pipeline's new `"prompt_too_long"` stop_reason.
- **Go binding** — exposes `ErrLlmGenerationPromptTooLong`.
- **Server** — prompt-too-long is a `400` client error with no partial output; a window exhausted mid-generation is a normal truncated completion (`finish_reason=length`, HTTP 200) on both blocking and streaming paths, for chat and completion.
- **CLI** — a distinct hint and a reset-and-continue path for prompt-too-long.

Sliding-window support is unchanged: the error is reported only when prefill actually fails, never via a pre-check.

The `qairt` plugin behavior depends on the companion submodule change (qualcomm/geniex-qairt-plugin#34); this PR bumps the `third-party/geniex-qairt` pointer to include it.

## Test plan

- [x] `llama_cpp` end-to-end (local): prompt-too-long, sliding-window intact, server 400 for prompt-too-long, server 200 `finish_reason=length` for mid-generation fill (blocking + streaming)
- [x] `qairt` runtime (qcs, Qwen3-1.7B): CLI prompt-too-long vs context-length messages, `--sliding-window` continues, server 400, server 200 `finish_reason=length`
- [x] `qairt` unit tests (qcs): `ctest -L unit` — `ThrowsWhenPromptExceedsContext`, `SlidingWindowDisabledByDefaultStillThrows`, new `ThrowsWhenGenerationExceedsContext`, 8/8 pass
- [x] CLI `process_test.go`: prompt-too-long resets and continues
- [ ] CI: lint → build-sdk → CLI/Python/Android → docker
- [ ] Depends on qualcomm/geniex-qairt-plugin#34 merging first (submodule pointer)

Depends on qualcomm/geniex-qairt-plugin#34