### PR TITLE
feat(sdk): resolve AIHM version from latest.txt instead of pinning

### DIFF
--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -50,10 +50,23 @@ impl StoreConfig {
         std::env::var("GENIEX_AIHUBBASEURL").unwrap_or_else(|_| DEFAULT_AI_HUB_BASE_URL.to_string())
     }
 
-    /// Pinned aihm release version the SDK consumes. The public bucket has
-    /// no `latest` alias; override via `GENIEX_AIHUBVERSION`.
-    pub fn ai_hub_version() -> String {
-        std::env::var("GENIEX_AIHUBVERSION").unwrap_or_else(|_| DEFAULT_AI_HUB_VERSION.to_string())
+    /// Explicit AIHM version pin. When set, this wins outright over the
+    /// dynamic `releases/latest.txt` lookup in
+    /// [`crate::source::ai_hub::resolve_ai_hub_version`] — no network call
+    /// is made.
+    pub fn ai_hub_version_override() -> Option<String> {
+        std::env::var("GENIEX_AIHUBVERSION")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    }
+
+    /// Version used when no override is set and `releases/latest.txt`
+    /// can't be read (network failure, missing pointer, malformed
+    /// content). Kept close to the newest release AIHM has published, so
+    /// bump it opportunistically when noticed stale.
+    pub fn ai_hub_version_fallback() -> String {
+        DEFAULT_AI_HUB_VERSION.to_string()
     }
 
     /// Cache directory for AI Hub index JSONs. Matches the Go CLI layout
@@ -79,7 +92,7 @@ impl StoreConfig {
 const DEFAULT_AI_HUB_BASE_URL: &str =
     "https://qaihub-public-assets.s3.us-west-2.amazonaws.com/qai-hub-models";
 
-/// Mirrors `cli/internal/config/config.go:DefaultAIHubVersion`.
+/// Fallback for [`StoreConfig::ai_hub_version_fallback`].
 const DEFAULT_AI_HUB_VERSION: &str = "v0.60.0";
 
 fn default_data_dir() -> PathBuf {

--- a/sdk/model-manager/crates/core/src/pull.rs
+++ b/sdk/model-manager/crates/core/src/pull.rs
@@ -39,7 +39,7 @@ use crate::executor::{Executor, ProgressCallback};
 use crate::manifest_builder::ManifestHint;
 use crate::mapping::canonicalize_model_name;
 use crate::resume;
-use crate::source::ai_hub::{AiHubConfig, AiHubSource};
+use crate::source::ai_hub::{resolve_ai_hub_version, AiHubConfig, AiHubSource};
 use crate::source::dockerhub::DockerHubSource;
 use crate::source::hf::HfSource;
 use crate::source::localfs::LocalFsSource;
@@ -98,7 +98,7 @@ pub async fn pull(store: &Store, mut req: PullRequest) -> Result<()> {
     validate_model_name(&req.model_name)?;
 
     let transport: Arc<dyn HttpTransport> = Arc::new(ReqwestTransport::new()?);
-    let source: Box<dyn ModelSource> = build_source(&req, store, transport.clone())?;
+    let source: Box<dyn ModelSource> = build_source(&req, store, transport.clone()).await?;
     pull_with_source(
         store,
         &req.model_name,
@@ -207,7 +207,7 @@ pub fn pull_blocking(
     handle.block_on(pull(store, req))
 }
 
-pub(crate) fn build_source(
+pub(crate) async fn build_source(
     req: &PullRequest,
     store: &Store,
     transport: Arc<dyn HttpTransport>,
@@ -233,13 +233,10 @@ pub(crate) fn build_source(
             display_name,
             chipset,
         } => {
-            let cfg = AiHubConfig::new(
-                StoreConfig::ai_hub_base_url(),
-                StoreConfig::ai_hub_version(),
-                chipset.clone(),
-                store.config().ai_hub_cache_dir(),
-                false,
-            );
+            let endpoint = StoreConfig::ai_hub_base_url();
+            let cache_dir = store.config().ai_hub_cache_dir();
+            let version = resolve_ai_hub_version(&endpoint, &cache_dir).await;
+            let cfg = AiHubConfig::new(endpoint, version, chipset.clone(), cache_dir, false);
             let src = AiHubSource::with_transport(
                 display_name.clone(),
                 req.model_name.clone(),

--- a/sdk/model-manager/crates/core/src/query.rs
+++ b/sdk/model-manager/crates/core/src/query.rs
@@ -45,7 +45,7 @@ pub async fn query(store: &Store, mut req: PullRequest) -> Result<ModelQuery> {
     validate_model_name(&req.model_name)?;
 
     let transport: Arc<dyn HttpTransport> = Arc::new(ReqwestTransport::new()?);
-    let source = build_source(&req, store, transport)?;
+    let source = build_source(&req, store, transport).await?;
     let plan = source.plan().await?;
     Ok(model_query_from_plan(req.model_name, plan))
 }

--- a/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/ai_hub/mod.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, SystemTime};
 use async_trait::async_trait;
 use url::Url;
 
+use crate::config::StoreConfig;
 use crate::error::{parse_manifest, Error, Result};
 use crate::manifest::{ModelFileInfo, ModelManifest, ModelType};
 use crate::transport::{HttpTransport, ReqwestTransport};
@@ -38,10 +39,14 @@ use super::{basename, BytesSource, FileSpec, ModelSource, Plan};
 
 const MANIFEST_FILENAME: &str = "manifest.json";
 const PLATFORM_FILENAME: &str = "platform.json";
+const LATEST_VERSION_FILENAME: &str = "latest.txt";
 const MAX_INDEX_BYTES: u64 = 8 * 1024 * 1024;
 
-/// TTL for the on-disk index cache (matches Go CLI's 24h).
+/// 24h TTL for manifest / platform / info JSON caches (matches Go CLI).
 const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// 1h TTL for the `latest.txt` version pointer.
+const LATEST_VERSION_TTL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone)]
 pub struct AiHubConfig {
@@ -92,6 +97,59 @@ async fn fetch_platform_info(
     )
     .await?;
     parse_manifest("platform.json", &platform_bytes)
+}
+
+/// Resolve the AIHM release version. `GENIEX_AIHUBVERSION` wins if set;
+/// otherwise fetch `releases/latest.txt` (1h disk cache) and fall back
+/// to the pinned default on any failure so pull never blocks.
+pub async fn resolve_ai_hub_version(endpoint: &str, cache_dir: &Path) -> String {
+    if let Some(pinned) = StoreConfig::ai_hub_version_override() {
+        return pinned;
+    }
+
+    let cache_path = cache_dir.join(LATEST_VERSION_FILENAME);
+    if let Some(bytes) = read_cache_fresh(&cache_path, LATEST_VERSION_TTL) {
+        if let Some(v) = parse_latest_version(&bytes) {
+            return v;
+        }
+    }
+
+    let transport: Arc<dyn HttpTransport> = match ReqwestTransport::new() {
+        Ok(t) => Arc::new(t),
+        Err(e) => {
+            crate::logging::warn(&format!("aihub latest.txt transport init: {e}"));
+            return StoreConfig::ai_hub_version_fallback();
+        }
+    };
+
+    let url = format!("{endpoint}/releases/{LATEST_VERSION_FILENAME}");
+    match fetch_direct(&url, &transport).await {
+        Ok(bytes) => match parse_latest_version(&bytes) {
+            Some(v) => {
+                write_cache(&cache_path, &bytes);
+                v
+            }
+            None => {
+                crate::logging::warn(&format!("aihub latest.txt at {url} is empty/malformed"));
+                StoreConfig::ai_hub_version_fallback()
+            }
+        },
+        Err(e) => {
+            crate::logging::warn(&format!("aihub latest.txt fetch from {url}: {e}"));
+            StoreConfig::ai_hub_version_fallback()
+        }
+    }
+}
+
+/// Normalize `latest.txt`'s bare `0.61.0` body into the `v0.61.0` form
+/// the `releases/{version}/...` path segment expects. `None` for empty
+/// or non-UTF-8 bodies.
+fn parse_latest_version(bytes: &[u8]) -> Option<String> {
+    let text = std::str::from_utf8(bytes)
+        .ok()?
+        .trim()
+        .trim_start_matches('v');
+    (!text.is_empty()).then(|| format!("v{text}"))
 }
 
 /// The `os.ostype` values this build runs on; `None` means "don't filter".
@@ -533,16 +591,26 @@ async fn fetch_with_cache(
     Ok(bytes)
 }
 
-/// Return cached bytes if the file is within `ttl` and stamped with the
-/// requested `version`, so a release bump invalidates stale caches before
-/// the TTL elapses. Any I/O or parse error is a cache miss.
-fn read_cache(path: &Path, version: &str, ttl: Duration) -> Option<Vec<u8>> {
+/// Return cached bytes when the file's mtime is still within `ttl`. Pure
+/// filesystem check — no content parsing, no version stamp comparison —
+/// so it's the right fit for `latest.txt`, whose body *is* the version
+/// and carries no self-identifying field to cross-check. Also used as
+/// the freshness precheck inside [`read_cache`] before it validates the
+/// embedded version stamp.
+fn read_cache_fresh(path: &Path, ttl: Duration) -> Option<Vec<u8>> {
     let meta = std::fs::metadata(path).ok()?;
     let mtime = meta.modified().ok()?;
     if SystemTime::now().duration_since(mtime).ok()? > ttl {
         return None;
     }
-    let bytes = std::fs::read(path).ok()?;
+    std::fs::read(path).ok()
+}
+
+/// Return cached bytes if the file is within `ttl` and stamped with the
+/// requested `version`, so a release bump invalidates stale caches before
+/// the TTL elapses. Any I/O or parse error is a cache miss.
+fn read_cache(path: &Path, version: &str, ttl: Duration) -> Option<Vec<u8>> {
+    let bytes = read_cache_fresh(path, ttl)?;
     // manifest.json stamps `version`; platform.json / info.json use
     // `aihm_version`. Both omit the leading `v` the config carries.
     let doc: serde_json::Value = serde_json::from_slice(&bytes).ok()?;

--- a/sdk/model-manager/crates/core/tests/ai_hub_latest_version.rs
+++ b/sdk/model-manager/crates/core/tests/ai_hub_latest_version.rs
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! `resolve_ai_hub_version` against a wiremock'd `releases/latest.txt`.
+//!
+//! Covers the qcom-ai-hub/geniex#1434 contract: dynamic discovery via the
+//! pointer AIHM's release pipeline writes
+//! (qcom-ai-hub/ai-hub-models-internal#4284), a short-TTL disk cache so a
+//! version bump propagates without re-hitting the network every call, an
+//! explicit `GENIEX_AIHUBVERSION` override that skips the network
+//! entirely, and a graceful fallback when the pointer is missing.
+
+use model_manager_core::config::StoreConfig;
+use model_manager_core::source::ai_hub::resolve_ai_hub_version;
+use tempfile::tempdir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+/// Serializes access to `GENIEX_AIHUBVERSION` across this file's tests.
+/// It's the only env var these tests touch, but `cargo test` runs test
+/// functions on threads within one process, so two tests racing to
+/// set/unset it could otherwise observe each other's value. `unwrap_or_else`
+/// recovers from poisoning: a panic (i.e. assertion failure) in one test
+/// while holding the guard must not cascade into unrelated failures on
+/// every other test in this file via a "poisoned lock" panic of its own.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn unset_override() -> std::sync::MutexGuard<'static, ()> {
+    let guard = lock_env();
+    std::env::remove_var("GENIEX_AIHUBVERSION");
+    guard
+}
+
+/// `resolve_ai_hub_version` fetches via `fetch_direct`, which does a HEAD
+/// (for size) before a ranged GET — mirrors `ai_hub_pull.rs`'s
+/// `install_static` helper for the same reason.
+fn parse_range(req: &Request) -> (u64, u64) {
+    let hdr = req.headers.get("range").unwrap().to_str().unwrap();
+    let rest = hdr.strip_prefix("bytes=").unwrap();
+    let (s, e) = rest.split_once('-').unwrap();
+    let start: u64 = s.parse().unwrap();
+    let end: u64 = e.parse().unwrap();
+    (start, end - start + 1)
+}
+
+/// `up_to_times`: caps how many times each of HEAD/GET may be served —
+/// used by the cache-reuse test to prove a second `resolve_ai_hub_version`
+/// call didn't hit the network at all.
+async fn mount_latest_txt(server: &MockServer, body: Vec<u8>, up_to_times: Option<u64>) {
+    let p = "/qai-hub-models/releases/latest.txt";
+    let mut head_mock = Mock::given(method("HEAD")).and(path(p)).respond_with(
+        ResponseTemplate::new(200)
+            .append_header("Content-Length", body.len().to_string())
+            .append_header("Accept-Ranges", "bytes"),
+    );
+    if let Some(n) = up_to_times {
+        head_mock = head_mock.up_to_n_times(n);
+    }
+    head_mock.mount(server).await;
+
+    let body = std::sync::Arc::new(body);
+    let mut get_mock =
+        Mock::given(method("GET"))
+            .and(path(p))
+            .respond_with(move |req: &Request| {
+                let (start, len) = parse_range(req);
+                let slice = body[start as usize..(start + len) as usize].to_vec();
+                ResponseTemplate::new(206).set_body_bytes(slice)
+            });
+    if let Some(n) = up_to_times {
+        get_mock = get_mock.up_to_n_times(n);
+    }
+    get_mock.mount(server).await;
+}
+
+#[tokio::test]
+async fn resolves_latest_txt_with_v_prefix_normalized() {
+    let _g = unset_override();
+    let server = MockServer::start().await;
+    mount_latest_txt(&server, b"0.61.0\n".to_vec(), None).await;
+
+    let cache_dir = tempdir().unwrap();
+    let endpoint = format!("{}/qai-hub-models", server.uri());
+    let version = resolve_ai_hub_version(&endpoint, cache_dir.path()).await;
+
+    assert_eq!(version, "v0.61.0");
+}
+
+#[tokio::test]
+async fn falls_back_to_pinned_default_when_pointer_missing() {
+    let _g = unset_override();
+    // No route mounted: wiremock answers every request 404.
+    let server = MockServer::start().await;
+    let cache_dir = tempdir().unwrap();
+    let endpoint = format!("{}/qai-hub-models", server.uri());
+
+    let version = resolve_ai_hub_version(&endpoint, cache_dir.path()).await;
+
+    assert_eq!(version, StoreConfig::ai_hub_version_fallback());
+}
+
+#[tokio::test]
+async fn falls_back_when_pointer_body_is_empty() {
+    let _g = unset_override();
+    let server = MockServer::start().await;
+    mount_latest_txt(&server, b"   \n".to_vec(), None).await;
+
+    let cache_dir = tempdir().unwrap();
+    let endpoint = format!("{}/qai-hub-models", server.uri());
+    let version = resolve_ai_hub_version(&endpoint, cache_dir.path()).await;
+
+    assert_eq!(version, StoreConfig::ai_hub_version_fallback());
+}
+
+#[tokio::test]
+async fn env_override_wins_without_touching_the_network() {
+    let guard = lock_env();
+    std::env::set_var("GENIEX_AIHUBVERSION", "v0.42.0");
+
+    // No server at all — if the override didn't short-circuit, this would
+    // hang/fail against a connection nothing is listening on.
+    let cache_dir = tempdir().unwrap();
+    let version =
+        resolve_ai_hub_version("http://127.0.0.1:0/qai-hub-models", cache_dir.path()).await;
+
+    std::env::remove_var("GENIEX_AIHUBVERSION");
+    drop(guard);
+
+    assert_eq!(version, "v0.42.0");
+}
+
+#[tokio::test]
+async fn second_call_reuses_disk_cache_instead_of_refetching() {
+    let _g = unset_override();
+    let server = MockServer::start().await;
+    mount_latest_txt(&server, b"0.61.0\n".to_vec(), Some(1)).await;
+
+    let cache_dir = tempdir().unwrap();
+    let endpoint = format!("{}/qai-hub-models", server.uri());
+
+    let first = resolve_ai_hub_version(&endpoint, cache_dir.path()).await;
+    assert_eq!(first, "v0.61.0");
+
+    // The mock above only answers once; a second network hit would 404
+    // (unmatched request), so a cache hit is the only way this passes.
+    let second = resolve_ai_hub_version(&endpoint, cache_dir.path()).await;
+    assert_eq!(second, "v0.61.0");
+}

--- a/sdk/model-manager/crates/ffi/src/chipset.rs
+++ b/sdk/model-manager/crates/ffi/src/chipset.rs
@@ -6,7 +6,7 @@ use std::os::raw::c_char;
 use model_manager_core::config::StoreConfig;
 use model_manager_core::source::ai_hub::{
     detect::detect_host_chipset, detect_host_chipset_reference, list_supported_chipsets,
-    AiHubConfig,
+    resolve_ai_hub_version, AiHubConfig,
 };
 
 use crate::init::{get_store, runtime_handle};
@@ -28,14 +28,11 @@ pub struct GenieXChipsetList {
     pub count: i32,
 }
 
-fn ai_hub_cfg_for_chipset_query(store: &model_manager_core::store::Store) -> AiHubConfig {
-    AiHubConfig::new(
-        StoreConfig::ai_hub_base_url(),
-        StoreConfig::ai_hub_version(),
-        String::new(),
-        store.config().ai_hub_cache_dir(),
-        false,
-    )
+async fn ai_hub_cfg_for_chipset_query(store: &model_manager_core::store::Store) -> AiHubConfig {
+    let endpoint = StoreConfig::ai_hub_base_url();
+    let cache_dir = store.config().ai_hub_cache_dir();
+    let version = resolve_ai_hub_version(&endpoint, &cache_dir).await;
+    AiHubConfig::new(endpoint, version, String::new(), cache_dir, false)
 }
 
 #[no_mangle]
@@ -44,9 +41,12 @@ pub extern "C" fn geniex_model_list_chipsets(out: *mut GenieXChipsetList) -> i32
         if out.is_null() {
             return Err(GENIEX_ERROR_COMMON_INVALID_INPUT);
         }
-        let cfg = ai_hub_cfg_for_chipset_query(get_store()?);
+        let store = get_store()?;
         let chipsets = runtime_handle()
-            .block_on(list_supported_chipsets(&cfg))
+            .block_on(async {
+                let cfg = ai_hub_cfg_for_chipset_query(store).await;
+                list_supported_chipsets(&cfg).await
+            })
             .map_err(|e| report(&e))?;
 
         let infos: Vec<GenieXChipsetInfo> = chipsets
@@ -116,8 +116,11 @@ pub extern "C" fn geniex_model_detect_chipset(offline: i32, out_chipset: *mut *m
         let detected = if offline != 0 {
             detect_host_chipset()
         } else {
-            let cfg = ai_hub_cfg_for_chipset_query(get_store()?);
-            runtime_handle().block_on(detect_host_chipset_reference(&cfg))
+            let store = get_store()?;
+            runtime_handle().block_on(async {
+                let cfg = ai_hub_cfg_for_chipset_query(store).await;
+                detect_host_chipset_reference(&cfg).await
+            })
         };
         let ptr = detected
             .map(|s| str_to_cptr(&s))

--- a/sdk/model-manager/crates/ffi/src/hub_models.rs
+++ b/sdk/model-manager/crates/ffi/src/hub_models.rs
@@ -4,7 +4,7 @@
 use std::os::raw::c_char;
 
 use model_manager_core::config::StoreConfig;
-use model_manager_core::source::ai_hub::{list_hub_models, AiHubConfig};
+use model_manager_core::source::ai_hub::{list_hub_models, resolve_ai_hub_version, AiHubConfig};
 
 use crate::init::{get_store, runtime_handle};
 use crate::store::{to_ffi_type, GenieXModelType};
@@ -45,15 +45,14 @@ pub extern "C" fn geniex_model_list_hub(
             Some(unsafe { cstr_to_str(chipset)? })
         };
         let store = get_store()?;
-        let cfg = AiHubConfig::new(
-            StoreConfig::ai_hub_base_url(),
-            StoreConfig::ai_hub_version(),
-            String::new(),
-            store.config().ai_hub_cache_dir(),
-            false,
-        );
         let models = runtime_handle()
-            .block_on(list_hub_models(&cfg, chipset))
+            .block_on(async {
+                let endpoint = StoreConfig::ai_hub_base_url();
+                let cache_dir = store.config().ai_hub_cache_dir();
+                let version = resolve_ai_hub_version(&endpoint, &cache_dir).await;
+                let cfg = AiHubConfig::new(endpoint, version, String::new(), cache_dir, false);
+                list_hub_models(&cfg, chipset).await
+            })
             .map_err(|e| report(&e))?;
 
         let infos: Vec<GenieXHubModelInfo> = models


### PR DESCRIPTION
## Summary
- Model Manager now resolves the AIHM release version via `releases/latest.txt` instead of a pinned constant, so `geniex pull`/`list` can pick up new AIHM releases without a code change.
- Falls back to the pinned default on any failure (network, missing pointer, malformed content) — never blocks a pull.
- Reuses the same 24h disk cache as manifest.json/platform.json, so a version bump still cascades into invalidating those.
- `GENIEX_AIHUBVERSION` still overrides outright, skipping the network entirely.

## Why draft
AIHM hasn't actually published `latest.txt` yet — qcom-ai-hub/ai-hub-models-internal#4284 merged, but no release has run since (still 403 on S3 as of today). Verification so far is limited to mocked scenarios (unit/integration tests + a manual smoke run); haven't run it against the real pointer yet. Will validate live and mark ready once AIHM's next release publishes it.

Refs: qcom-ai-hub/geniex#1434