### PR TITLE
feat(sdk): measure media encoder time separately from prefill

### DIFF
--- a/bindings/android/app/src/main/cpp/android_utils.cpp
+++ b/bindings/android/app/src/main/cpp/android_utils.cpp
@@ -29,50 +29,6 @@ void throw_runtime_exception(JNIEnv *env, const char *_Nonnull format, ...) {
     }
 }
 
-jobject create_java_profile_data(JNIEnv *env, geniex_ProfileData data) {
-    jclass cls = env->FindClass("com/geniex/sdk/bean/ProfilingData");
-    if (!cls) return nullptr;
-
-    // (DDDJJDDLjava/lang/String;)V
-    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDJJDDLjava/lang/String;)V");
-    if (!ctor) return nullptr;
-
-    const auto ttft_ms   = static_cast<jdouble>(data.ttft / 1000.0);
-    const auto prompt_ms = static_cast<jdouble>(data.prompt_time / 1000.0);
-    const auto decode_ms = static_cast<jdouble>(data.decode_time / 1000.0);
-
-    const auto prompt_tokens = static_cast<jlong>(data.prompt_tokens);
-    const auto gen_tokens    = static_cast<jlong>(data.generated_tokens);
-
-    // ---- compute speeds locally (tokens/sec) ----
-    auto tok_per_s = [](int64_t tokens, int64_t time_us) -> jdouble {
-        if (time_us <= 0) return 0.0;
-        return static_cast<jdouble>(tokens) * 1e6 / static_cast<jdouble>(time_us);
-    };
-
-    const jdouble prefill_speed  = tok_per_s(data.prompt_tokens, data.prompt_time);
-    const jdouble decoding_speed = tok_per_s(data.generated_tokens, data.decode_time);
-
-    LOGd("prefill_speed=%.6f tok/s, decoding_speed=%.6f tok/s", prefill_speed, decoding_speed);
-
-    jstring jStopReason = env->NewStringUTF(data.stop_reason ? data.stop_reason : "");
-
-    jobject obj = env->NewObject(cls,
-        ctor,
-        ttft_ms,
-        prompt_ms,
-        decode_ms,  // D D D
-        prompt_tokens,
-        gen_tokens,  // J J
-        prefill_speed,
-        decoding_speed,  // D D
-        jStopReason      // String
-    );
-
-    env->DeleteLocalRef(jStopReason);
-    return obj;
-}
-
 bool check_jni_exception(JNIEnv *env, const char *where) {
     if (env->ExceptionCheck()) {
         LOGe("Exception at %s", where);

--- a/bindings/android/app/src/main/cpp/android_utils.h
+++ b/bindings/android/app/src/main/cpp/android_utils.h
@@ -21,8 +21,6 @@ namespace geniex_android_sdk {
 
 void throw_runtime_exception(JNIEnv* env, const char* _Nonnull format, ...);
 
-jobject create_java_profile_data(JNIEnv* env, geniex_ProfileData data);
-
 bool check_jni_exception(JNIEnv* env, const char* where);
 
 const char* getStringField(JNIEnv* env, jclass cls, jobject inputObj, const char* fieldName);

--- a/bindings/android/app/src/main/cpp/jniutils.cpp
+++ b/bindings/android/app/src/main/cpp/jniutils.cpp
@@ -271,11 +271,12 @@ jobject extract_profiling_data(JNIEnv* env, const geniex_ProfileData& data) {
     jclass cls = env->FindClass("com/geniex/sdk/bean/ProfilingData");
     if (!cls) return nullptr;
 
-    // (DDDJJDDJJLjava/lang/String;)V
-    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDJJDDJJLjava/lang/String;)V");
+    // (DDDDJJDDJJLjava/lang/String;)V
+    jmethodID ctor = env->GetMethodID(cls, "<init>", "(DDDDJJDDJJLjava/lang/String;)V");
     if (!ctor) return nullptr;
 
     const jdouble ttft_ms   = static_cast<jdouble>(data.ttft / 1000.0);
+    const jdouble media_ms  = static_cast<jdouble>(data.media_time / 1000.0);
     const jdouble prompt_ms = static_cast<jdouble>(data.prompt_time / 1000.0);
     const jdouble decode_ms = static_cast<jdouble>(data.decode_time / 1000.0);
 
@@ -301,8 +302,9 @@ jobject extract_profiling_data(JNIEnv* env, const geniex_ProfileData& data) {
     jobject obj = env->NewObject(cls,
         ctor,
         ttft_ms,
+        media_ms,
         prompt_ms,
-        decode_ms,  // D D D
+        decode_ms,  // D D D D
         prompt_tokens,
         gen_tokens,  // J J
         prefill_speed,

--- a/bindings/android/app/src/main/java/com/geniex/sdk/bean/ProfilingData.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/bean/ProfilingData.kt
@@ -2,9 +2,10 @@ package com.geniex.sdk.bean
 
 data class ProfilingData(
     val ttftMs: Double,  /* Time to first token (ms) */
-    val promptTimeMs: Double,  /* Prompt processing time (ms) */
+    val mediaMs: Double,  /* Image/audio encoder time (ms); 0 for text-only runs */
+    val promptTimeMs: Double,  /* Prefill time (ms); includes media-token prefill, excludes encoder */
     val decodeTimeMs: Double,   /* Token generation time (ms) */
-    val promptTokens: Long,    /* Number of prompt tokens */
+    val promptTokens: Long,    /* Number of prompt tokens (text + media tokens) */
     val generatedTokens: Long,  /* Number of generated tokens */
     val prefillSpeed: Double,   /* Prefill speed (tokens/sec) */
     val decodingSpeed: Double,  /* Decoding speed (tokens/sec) */

--- a/bindings/go/common.go
+++ b/bindings/go/common.go
@@ -15,6 +15,7 @@ import (
 
 type ProfileData struct {
 	TTFT            int64
+	MediaTime       int64
 	PromptTime      int64
 	DecodeTime      int64
 	PromptTokens    int64
@@ -31,13 +32,14 @@ func (p ProfileData) TotalTokens() int64 {
 }
 
 func (p ProfileData) TotalTimeUs() int64 {
-	return p.PromptTime + p.DecodeTime
+	return p.MediaTime + p.PromptTime + p.DecodeTime
 }
 
 // LCOV_EXCL_START
 func newProfileDataFromCPtr(c C.geniex_ProfileData) ProfileData {
 	return ProfileData{
 		TTFT:            int64(c.ttft),
+		MediaTime:       int64(c.media_time),
 		PromptTime:      int64(c.prompt_time),
 		DecodeTime:      int64(c.decode_time),
 		PromptTokens:    int64(c.prompt_tokens),

--- a/bindings/python/geniex/_ffi/_types.py
+++ b/bindings/python/geniex/_ffi/_types.py
@@ -32,6 +32,7 @@ geniex_token_callback = CFUNCTYPE(c_bool, c_char_p, c_void_p)
 class geniex_ProfileData(Structure):
     _fields_ = [
         ('ttft', c_int64),
+        ('media_time', c_int64),
         ('prompt_time', c_int64),
         ('decode_time', c_int64),
         ('prompt_tokens', c_int64),

--- a/bindings/python/geniex/generation/output.py
+++ b/bindings/python/geniex/generation/output.py
@@ -24,6 +24,7 @@ def _format_us(us: int) -> str:
 @dataclass(repr=False)
 class ProfileData:
     ttft: int = 0
+    media_time: int = 0
     prompt_time: int = 0
     decode_time: int = 0
     prompt_tokens: int = 0
@@ -43,6 +44,7 @@ class ProfileData:
         stop = c.stop_reason.decode() if c.stop_reason else None
         return cls(
             ttft=c.ttft,
+            media_time=c.media_time,
             prompt_time=c.prompt_time,
             decode_time=c.decode_time,
             prompt_tokens=c.prompt_tokens,
@@ -58,6 +60,7 @@ class ProfileData:
         return (
             f'ProfileData('
             f'ttft={_format_us(self.ttft)}, '
+            f'media_time={_format_us(self.media_time)}, '
             f'prompt_time={_format_us(self.prompt_time)}, '
             f'decode_time={_format_us(self.decode_time)}, '
             f'prompt_tokens={self.prompt_tokens} tok, '

--- a/cli/cmd/geniex/common/process.go
+++ b/cli/cmd/geniex/common/process.go
@@ -234,6 +234,19 @@ func (p *Processor) printProfile(pd geniex_sdk.ProfileData) {
 			strings.TrimSpace(`
 total time:     %fs
 ttft:           %fs
+			`),
+			float64(pd.TotalTimeUs())/1e6,
+			float64(pd.TTFT)/1e6,
+		)
+
+		// media time is part of ttft (ttft ≈ media time + prompt time),
+		// so it precedes the prefill lines to match the time order.
+		if pd.MediaTime > 0 {
+			text += fmt.Sprintf("\nmedia time:     %fs", float64(pd.MediaTime)/1e6)
+		}
+
+		text += "\n" + fmt.Sprintf(
+			strings.TrimSpace(`
 prompt time:    %fs
 prompt tokens:  %d token(s)
 prompt speed:   %f tok/s
@@ -242,8 +255,6 @@ decode tokens:  %d token(s)
 decode speed:   %f tok/s
 stop reason:    %s
 			`),
-			float64(pd.TotalTimeUs())/1e6,
-			float64(pd.TTFT)/1e6,
 			float64(pd.PromptTime)/1e6,
 			pd.PromptTokens,
 			pd.PrefillSpeed,

--- a/notes/bench.md
+++ b/notes/bench.md
@@ -45,7 +45,11 @@ On-device, all platforms perform the same work:
 2. Invoke `geniex-bench --matrix-file <tsv> --output-json-dir <out> --chipset <chip>`.
 3. The benchmark binary (`sdk/benchmark/benchmark.c`) runs each cell:
    1 warmup + 3 measured repetitions, writing a per-cell JSON with aggregated
-   stats (median / stdev / min / max for TTFT, prefill tok/s, decode tok/s).
+   stats (median / stdev / min / max for TTFT, prefill tok/s, decode tok/s;
+   median-only for `media_ms`, non-zero on VLM cells).
+   For VLM cells `prefill_tps` is the full prefill (text + media tokens); only
+   the encoder time is split out into `media_ms` — see
+   [run.md § Performance metrics](run.md#performance-metrics).
 4. Results land in `QDC_logs/results/` which QDC auto-collects.
 
 ## 3. Result collection & bench report rendering
@@ -75,8 +79,11 @@ Example output:
 - **Matrix-driven** — model x device pairs run in parallel on QDC.
 - **Platform isolation** — differences are confined to artifact-building and entry
   scripts; the on-device benchmark binary and JSON schema are shared.
-- **Common per-cell JSON schema** — every platform produces the same v2 schema,
-  so the aggregator renders uniformly regardless of origin.
+- **Common per-cell JSON schema** — every platform produces the same schema
+  (`schema_version` `4`), so the aggregator renders uniformly regardless of
+  origin. v4 added the `media_us` per-run encoder time and its `media_ms` agg
+  median. On a VLM run `prompt_tokens` counts text + media tokens, so
+  `prefill_tps` reflects the full prefill.
 
 ## Downloading geniex-bench
 

--- a/notes/run.md
+++ b/notes/run.md
@@ -214,3 +214,26 @@ Run `geniex update` to upgrade:
 - **Linux** — prints the install-script one-liner to re-run (`curl -fsSL … | bash`); auto-update is not wired up yet.
 
 Pass `--skip-update` on any command to skip the probe (and the notify banner) entirely for that invocation.
+
+## Performance metrics
+
+`--verbose` (and the Go/Python APIs' `ProfileData`, and `geniex-bench`) report one number per inference phase. Which metric covers which phase:
+
+| Metric | Field | Phase it measures |
+|--------|-------|-------------------|
+| `ttft` | `ttft` | Start of generate → first sampled token. For a VLM this **includes** the media encoder, so it is *not* comparable to a pure prefill number. |
+| media time | `media_time` | The vision/audio **encoder** only — turning pixels/audio into decoder-space embeddings. `0` on text-only runs. |
+| prompt / prefill time | `prompt_time` | Prefill — running the prompt tokens through the model. On a VLM this includes prefilling the media (soft) tokens; it excludes the encoder. |
+| prompt / prefill speed | `prefill_speed` | `prompt_tokens / prompt_time`. |
+| decode time / speed | `decode_time` / `decoding_speed` | Generation phase (first token → last token). |
+
+Key points:
+
+- **`media_time` is the encoder only.** Everything downstream of the encoder (prefilling the media tokens through the model) lives in `prompt_time`, same as text.
+- **`prompt_tokens` counts text + media tokens** on a VLM run, so `prefill_speed` reflects the full prefill the model actually did.
+- `ttft` spans encoder + prefill, so `ttft ≈ media_time + prompt_time` for a VLM.
+
+Both runtimes measure `media_time` at the same boundary (encoder wall time only), so the numbers are comparable across plugins:
+
+- **llama.cpp** — timed per-chunk. For a media chunk the encode (`mtmd_encode_chunk`) is timed as `media_time`; prefilling the resulting embeddings (`mtmd_helper_decode_image_chunk` → `llama_decode`) is counted in `prompt_time` alongside the text chunks. The split is exact and `ttft ≈ media_time + prompt_time` holds tightly.
+- **QAIRT** — `media_time` is the encoder wall time (`encodeVision`); the media-token NPU prefill stays in `prompt_time` (= `ttft − media_time`). QAIRT's `prompt_time` is derived from `ttft`, so treat it as indicative, not exact. The encoder number itself is directly measured.

--- a/notes/run.md
+++ b/notes/run.md
@@ -235,5 +235,5 @@ Key points:
 
 Both runtimes measure `media_time` at the same boundary (encoder wall time only), so the numbers are comparable across plugins:
 
-- **llama.cpp** — timed per-chunk. For a media chunk the encode (`mtmd_encode_chunk`) is timed as `media_time`; prefilling the resulting embeddings (`mtmd_helper_decode_image_chunk` → `llama_decode`) is counted in `prompt_time` alongside the text chunks. The split is exact and `ttft ≈ media_time + prompt_time` holds tightly.
+- **llama.cpp** — timed per-chunk: the encode (`mtmd_encode_chunk`) is `media_time`; prefilling the embeddings (`mtmd_helper_decode_image_chunk` → `llama_decode`) goes to `prompt_time`, same as text chunks. Bitmap loading and tokenization are timed by neither, so they fall only in `ttft`; `ttft ≈ media_time + prompt_time` up to that overhead.
 - **QAIRT** — `media_time` is the encoder wall time (`encodeVision`); the media-token NPU prefill stays in `prompt_time` (= `ttft − media_time`). QAIRT's `prompt_time` is derived from `ttft`, so treat it as indicative, not exact. The encoder number itself is directly measured.

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -147,9 +147,10 @@ typedef struct {
     int32_t     run_idx;
     bool        is_warmup;
     int64_t     ttft_us;
+    int64_t     media_us; /* image/audio encoder time; 0 for text-only */
     int64_t     prompt_time_us;
     int64_t     decode_time_us;
-    int64_t     prompt_tokens;
+    int64_t     prompt_tokens; /* text + media tokens */
     int64_t     gen_tokens;
     double      prefill_tps;
     double      decode_tps;
@@ -159,11 +160,13 @@ typedef struct {
 } run_result_t;
 
 /* Adjust the reported prefill metrics for the engine's real prefill work.
- * QAIRT pads the prompt to a QAIRT_PREFILL_CHUNK multiple before prefill, so
- * prompt_tokens/prefill_tps should reflect that padded length (#1194); QAIRT's
- * prompt_time equals ttft, so recomputing the rate over the padded count keeps
- * rate == prompt_tokens / prompt_time consistent. llama_cpp does no such
- * padding, so its metrics are left as the SDK reported them. */
+ * QAIRT pads the (text) prompt to a QAIRT_PREFILL_CHUNK multiple before prefill,
+ * so prompt_tokens/prefill_tps should reflect that padded length (#1194);
+ * recomputing the rate over the padded count keeps rate == prompt_tokens /
+ * prompt_time consistent. Media tokens are encoded separately and are not
+ * chunk-padded, so they are excluded from prompt_tokens (see the SDK's split of
+ * media out of prefill). llama_cpp does no such padding, so its metrics are left
+ * as the SDK reported them. */
 static void normalize_prefill_metrics(run_result_t* r, const char* plugin) {
     if (!plugin || strcmp(plugin, "qairt") != 0 || r->prompt_tokens <= 0) return;
     int64_t padded   = ((r->prompt_tokens + QAIRT_PREFILL_CHUNK - 1) / QAIRT_PREFILL_CHUNK) * QAIRT_PREFILL_CHUNK;
@@ -1291,6 +1294,7 @@ static void run_llm(const options_t* o, const char* device_id, int32_t ngl, run_
                 memset(r, 0, sizeof(*r));
                 r->run_idx        = run_idx;
                 r->ttft_us        = gout.profile_data.ttft;
+                r->media_us       = gout.profile_data.media_time;
                 r->prompt_time_us = gout.profile_data.prompt_time;
                 r->decode_time_us = gout.profile_data.decode_time;
                 r->prompt_tokens  = gout.profile_data.prompt_tokens;
@@ -1444,6 +1448,7 @@ static void run_vlm(const options_t* o, const char* device_id, int32_t ngl, run_
                 memset(r, 0, sizeof(*r));
                 r->run_idx        = run_idx;
                 r->ttft_us        = gout.profile_data.ttft;
+                r->media_us       = gout.profile_data.media_time;
                 r->prompt_time_us = gout.profile_data.prompt_time;
                 r->decode_time_us = gout.profile_data.decode_time;
                 r->prompt_tokens  = gout.profile_data.prompt_tokens;
@@ -1477,6 +1482,7 @@ typedef struct {
     double decode_med, decode_lo, decode_hi, decode_mean, decode_sd;
     double gen_tokens_med;
     double prompt_tokens_med;
+    double media_ms_med;
 } agg_t;
 
 static void aggregate(const run_result_t* runs, int n, agg_t* a) {
@@ -1500,6 +1506,9 @@ static void aggregate(const run_result_t* runs, int n, agg_t* a) {
     for (int i = 0; i < n; ++i) tmp[i] = (double)runs[i].prompt_tokens;
     summarize(tmp, n, &med, &lo, &hi);
     a->prompt_tokens_med = med;
+    for (int i = 0; i < n; ++i) tmp[i] = (double)runs[i].media_us / 1000.0;
+    summarize(tmp, n, &med, &lo, &hi);
+    a->media_ms_med = med;
     free(tmp);
 }
 
@@ -1576,7 +1585,7 @@ static void write_json(const options_t* o, const char* device_id, int32_t ngl, i
         exit(1);
     }
     fprintf(f, "{\n");
-    json_field_str(f, "schema_version", "3", false);
+    json_field_str(f, "schema_version", "4", false);
     json_field_str(f, "cell_id", o->cell_id ? o->cell_id : "cell", false);
     json_field_str(f, "plugin", o->plugin, false);
     json_field_str(f, "device", o->device, false);
@@ -1612,17 +1621,19 @@ static void write_json(const options_t* o, const char* device_id, int32_t ngl, i
     for (int i = 0; i < o->repeat; ++i) {
         const run_result_t* r = &runs[i];
         fprintf(f,
-            "      {\"run_idx\": %d, \"ttft_us\": %lld, \"prompt_tokens\": %lld, "
-            "\"gen_tokens\": %lld, \"prefill_tps\": %.6f, \"decode_tps\": %.6f, "
-            "\"prompt_time_us\": %lld, \"decode_time_us\": %lld, \"stop_reason\": %s%s%s}%s\n",
+            "      {\"run_idx\": %d, \"ttft_us\": %lld, \"media_us\": %lld, "
+            "\"prompt_time_us\": %lld, \"decode_time_us\": %lld, "
+            "\"prompt_tokens\": %lld, \"gen_tokens\": %lld, "
+            "\"prefill_tps\": %.6f, \"decode_tps\": %.6f, \"stop_reason\": %s%s%s}%s\n",
             r->run_idx,
             (long long)r->ttft_us,
+            (long long)r->media_us,
+            (long long)r->prompt_time_us,
+            (long long)r->decode_time_us,
             (long long)r->prompt_tokens,
             (long long)r->gen_tokens,
             r->prefill_tps,
             r->decode_tps,
-            (long long)r->prompt_time_us,
-            (long long)r->decode_time_us,
             r->stop_reason ? "\"" : "null",
             r->stop_reason ? r->stop_reason : "",
             r->stop_reason ? "\"" : "",
@@ -1652,7 +1663,8 @@ static void write_json(const options_t* o, const char* device_id, int32_t ngl, i
         a->decode_mean,
         a->decode_sd);
     fprintf(f, "      \"gen_tokens\":  {\"median\": %.6f},\n", a->gen_tokens_med);
-    fprintf(f, "      \"prompt_tokens\":{\"median\": %.6f}\n", a->prompt_tokens_med);
+    fprintf(f, "      \"prompt_tokens\":{\"median\": %.6f},\n", a->prompt_tokens_med);
+    fprintf(f, "      \"media_ms\":{\"median\": %.6f}\n", a->media_ms_med);
     fprintf(f, "    }\n");
     fprintf(f, "}\n");
     fclose(f);
@@ -1770,8 +1782,10 @@ static void write_md_row(const options_t* o, int32_t ngl, int64_t model_size_byt
     }
     if (first) {
         fprintf(f,
-            "| Model | Size | Backend | Device | ngl | Test | TTFT (ms) | Prefill (tok/s) | Decode (tok/s) |\n"
-            "|-------|-----:|---------|--------|----:|------|----------:|----------------:|---------------:|\n");
+            "| Model | Size | Backend | Device | ngl | Test | TTFT (ms) | Media enc (ms) | Prefill (tok/s) | "
+            "Decode (tok/s) |\n"
+            "|-------|-----:|---------|--------|----:|------|----------:|---------------:|----------------:|"
+            "---------------:|\n");
     }
 
     char  size_buf[32];
@@ -1787,8 +1801,14 @@ static void write_md_row(const options_t* o, int32_t ngl, int64_t model_size_byt
     snprintf(
         test_buf, sizeof(test_buf), "pp%lld+tg%lld", (long long)a->prompt_tokens_med, (long long)a->gen_tokens_med);
 
+    char media_buf[24];
+    if (a->media_ms_med > 0)
+        snprintf(media_buf, sizeof(media_buf), "%.1f", a->media_ms_med);
+    else
+        snprintf(media_buf, sizeof(media_buf), "-");
+
     fprintf(f,
-        "| %s | %s | %s | %s | %s | %s | %.1f ± %.1f | %.1f ± %.1f | %.1f ± %.1f |\n",
+        "| %s | %s | %s | %s | %s | %s | %.1f ± %.1f | %s | %.1f ± %.1f | %.1f ± %.1f |\n",
         model ? model : (o->cell_id ? o->cell_id : "cell"),
         size_buf,
         o->plugin,
@@ -1797,6 +1817,7 @@ static void write_md_row(const options_t* o, int32_t ngl, int64_t model_size_byt
         test_buf,
         a->ttft_ms_med,
         a->ttft_ms_sd,
+        media_buf,
         a->prefill_med,
         a->prefill_sd,
         a->decode_med,

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -160,13 +160,11 @@ typedef struct {
 } run_result_t;
 
 /* Adjust the reported prefill metrics for the engine's real prefill work.
- * QAIRT pads the (text) prompt to a QAIRT_PREFILL_CHUNK multiple before prefill,
- * so prompt_tokens/prefill_tps should reflect that padded length (#1194);
- * recomputing the rate over the padded count keeps rate == prompt_tokens /
- * prompt_time consistent. Media tokens are encoded separately and are not
- * chunk-padded, so they are excluded from prompt_tokens (see the SDK's split of
- * media out of prefill). llama_cpp does no such padding, so its metrics are left
- * as the SDK reported them. */
+ * QAIRT pads the prompt to a QAIRT_PREFILL_CHUNK multiple before prefill, so
+ * prompt_tokens/prefill_tps should reflect that padded length (#1194). Padding
+ * the full count is correct: prompt_tokens already includes the media tokens,
+ * which are prefilled through the same chunked path. llama_cpp does no such
+ * padding, so its metrics are left as the SDK reported them. */
 static void normalize_prefill_metrics(run_result_t* r, const char* plugin) {
     if (!plugin || strcmp(plugin, "qairt") != 0 || r->prompt_tokens <= 0) return;
     int64_t padded   = ((r->prompt_tokens + QAIRT_PREFILL_CHUNK - 1) / QAIRT_PREFILL_CHUNK) * QAIRT_PREFILL_CHUNK;

--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -489,8 +489,8 @@ def render(
     lines = [f"## QDC Bench — {device} — {label}", ""]
     lines += _details_block(cells, device, label, models)
     lines += [
-        "| Model | Backend | Device | Ctx | ngl | Test | TTFT (ms) | Prefill (tok/s) | Decode (tok/s) |",
-        "|-------|---------|--------|----:|----:|------|----------:|----------------:|---------------:|",
+        "| Model | Backend | Device | Ctx | ngl | Test | TTFT (ms) | Media enc (ms) | Prefill (tok/s) | Decode (tok/s) |",
+        "|-------|---------|--------|----:|----:|------|----------:|---------------:|----------------:|---------------:|",
     ]
     sort_key = lambda c: (_model_label(c), c["plugin"], c["device"], _ctx_from_cell(c))  # noqa: E731
     for c in sorted(cells, key=sort_key):
@@ -505,14 +505,16 @@ def render(
         ctx_s = str(ctx) if ctx else "-"
         p_med = (agg.get("prompt_tokens") or {}).get("median")
         g_med = (agg.get("gen_tokens") or {}).get("median")
-        test = (
-            f"pp{int(p_med)}+tg{int(g_med)}"
-            if p_med is not None and g_med is not None
-            else "-"
-        )
+        menc_med = (agg.get("media_ms") or {}).get("median")
+        has_media = menc_med is not None and menc_med > 0
+        if p_med is not None and g_med is not None:
+            test = f"pp{int(p_med)}+tg{int(g_med)}"
+        else:
+            test = "-"
+        media_enc = f"{menc_med:.1f}" if has_media and menc_med is not None else "-"
         lines.append(
             f"| {model} | {c['plugin']} | {c['device']} | {ctx_s} | {ngl} | {test} | "
-            f"{_fmt_med_sd(agg, 'ttft_ms')} | {_fmt_med_sd(agg, 'prefill_tps')} | "
+            f"{_fmt_med_sd(agg, 'ttft_ms')} | {media_enc} | {_fmt_med_sd(agg, 'prefill_tps')} | "
             f"{_fmt_med_sd(agg, 'decode_tps')} |"
         )
     lines += _render_mtp_table(cells, models)

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -349,10 +349,11 @@ GENIEX_API int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input,
 /** Profile data structure for performance metrics */
 typedef struct {
     int64_t ttft;        /* Time to first token (us) */
-    int64_t prompt_time; /* Prompt processing time (us) */
+    int64_t media_time;  /* Image/audio encoder time (us); 0 for text-only runs */
+    int64_t prompt_time; /* Prefill time (us); includes media-token prefill, excludes encoder */
     int64_t decode_time; /* Token generation time (us) */
 
-    int64_t prompt_tokens;    /* Number of prompt tokens */
+    int64_t prompt_tokens;    /* Number of prompt tokens (text + media tokens) */
     int64_t generated_tokens; /* Number of generated tokens */
 
     double prefill_speed;  /* Prefill speed (tokens/sec) */

--- a/sdk/plugins/llama_cpp/include/profiler.h
+++ b/sdk/plugins/llama_cpp/include/profiler.h
@@ -25,6 +25,8 @@ class Profiler {
    public:
     Profiler() { start(); }
 
+    void       media_start();
+    void       media_end();
     void       prompt_start();
     void       prompt_end();
     void       decode_start();
@@ -46,8 +48,8 @@ class Profiler {
     void           start();
 
     timestamp start_time{};
+    timestamp media_start_time{};
     timestamp prompt_start_time{};
-    timestamp prompt_end_time{};
     timestamp decode_start_time{};
     timestamp decode_end_time{};
     timestamp first_token_time{};
@@ -55,6 +57,8 @@ class Profiler {
 
     bool       ttft_recorded    = false;
     StopReason stop_reason      = StopReason::GENIEX_STOP_REASON_UNKNOWN;
+    int64_t    media_us         = 0;  // encoder time, accumulated across all media chunks
+    int64_t    prompt_us        = 0;  // prefill time, accumulated across all chunks
     uint32_t   prompt_tokens    = 0;
     uint32_t   generated_tokens = 0;
     int64_t    draft_n_total    = 0;

--- a/sdk/plugins/llama_cpp/src/profiler.cpp
+++ b/sdk/plugins/llama_cpp/src/profiler.cpp
@@ -24,9 +24,23 @@ static const char* stop_reason_to_string(StopReason reason) {
 
 void Profiler::start() { start_time = clock::now(); }
 
+void Profiler::media_start() { media_start_time = clock::now(); }
+
+void Profiler::media_end() {
+    if (media_start_time != timestamp{}) {
+        media_us += to_us(clock::now() - media_start_time);
+        media_start_time = timestamp{};
+    }
+}
+
 void Profiler::prompt_start() { prompt_start_time = clock::now(); }
 
-void Profiler::prompt_end() { prompt_end_time = clock::now(); }
+void Profiler::prompt_end() {
+    if (prompt_start_time != timestamp{}) {
+        prompt_us += to_us(clock::now() - prompt_start_time);
+        prompt_start_time = timestamp{};
+    }
+}
 
 void Profiler::decode_start() { decode_start_time = clock::now(); }
 
@@ -61,9 +75,8 @@ void Profiler::to_profile_data(ProfileData& pd) {
         pd.ttft = to_us(first_token_time - start_time);
     }
 
-    if (prompt_start_time != timestamp{} && prompt_end_time != timestamp{}) {
-        pd.prompt_time = to_us(prompt_end_time - prompt_start_time);
-    }
+    pd.media_time  = media_us;
+    pd.prompt_time = prompt_us;
 
     if (decode_start_time != timestamp{} && decode_end_time != timestamp{}) {
         pd.decode_time = to_us(decode_end_time - decode_start_time);

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -197,7 +197,6 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
     }
 
     common::Profiler profiler;
-    profiler.prompt_start();
 
     int32_t res = GENIEX_SUCCESS;
 
@@ -206,7 +205,8 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
 
     this->set_sampler(cfg.sampler_config);
 
-    // Prepare multimodal input: collect bitmaps for images and audio
+    // Bitmap loading and tokenization fall outside both media_time and
+    // prompt_time (only the chunk loop below is timed), so they show up in ttft.
     std::vector<mtmd_bitmap*> bitmaps;
     int                       n_media = 0;
 
@@ -297,23 +297,70 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
                 return GENIEX_ERROR_VLM_GENERATION_FAILED;
             }
 
-            // Evaluate chunks (like eval_message does). 1 means the prompt does
-            // not fit the KV cache: since this is prefill, the prompt itself is
-            // too long, not a generic failure.
-            llama_pos new_n_past = this->n_past;
-            switch (mtmd_helper_eval_chunks(
-                this->ctx_vision, this->ctx, chunks, this->n_past, 0, llama_n_batch(this->ctx), true, &new_n_past)) {
-                case 0:
-                    profiler.update_prompt_tokens(new_n_past - this->n_past);
-                    this->n_past = new_n_past;
-                    break;
-                case 1:
-                    res = GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG;
-                    break;
-                default:
-                    GENIEX_LOG_ERROR("mtmd_helper_eval_chunks failed");
-                    res = GENIEX_ERROR_VLM_GENERATION_FAILED;
-                    break;
+            // Time each phase separately: encoder → media_time, decode/prefill →
+            // prompt_time. prompt_tokens counts text + media tokens.
+            const size_t  n_chunks      = mtmd_input_chunks_size(chunks);
+            const int32_t n_batch       = llama_n_batch(this->ctx);
+            llama_pos     n_past_cur    = this->n_past;
+            uint32_t      prompt_tokens = 0;
+            for (size_t i = 0; i < n_chunks && res == GENIEX_SUCCESS; ++i) {
+                const mtmd_input_chunk* chunk    = mtmd_input_chunks_get(chunks, i);
+                const bool              is_media = mtmd_input_chunk_get_type(chunk) != MTMD_INPUT_CHUNK_TYPE_TEXT;
+                const bool              is_last  = (i == n_chunks - 1);
+                // Token count, not KV positions (differ under M-RoPE; KV uses new_n_past).
+                const size_t n_tokens = mtmd_input_chunk_get_n_tokens(chunk);
+
+                llama_pos new_n_past = n_past_cur;
+                int32_t   ret;
+                if (is_media) {
+                    profiler.media_start();
+                    ret = mtmd_encode_chunk(this->ctx_vision, chunk);
+                    profiler.media_end();
+                    if (ret != 0) {
+                        // encode returns 1 on a generic error, not KV-full: fail, don't truncate.
+                        GENIEX_LOG_ERROR("media chunk encoding failed");
+                        res = GENIEX_ERROR_VLM_GENERATION_FAILED;
+                        break;
+                    }
+                    float* embd = mtmd_get_output_embd(this->ctx_vision);
+                    profiler.prompt_start();
+                    ret = mtmd_helper_decode_image_chunk(this->ctx_vision,
+                        this->ctx,
+                        chunk,
+                        embd,
+                        n_past_cur,
+                        0,
+                        n_batch,
+                        &new_n_past,
+                        nullptr,
+                        nullptr);
+                    profiler.prompt_end();
+                } else {
+                    profiler.prompt_start();
+                    ret = mtmd_helper_eval_chunk_single(
+                        this->ctx_vision, this->ctx, chunk, n_past_cur, 0, n_batch, is_last, &new_n_past);
+                    profiler.prompt_end();
+                }
+
+                // This is prefill: a return of 1 (KV cache full) means the prompt
+                // itself is too long, not a generic failure.
+                switch (ret) {
+                    case 0:
+                        prompt_tokens += (uint32_t)n_tokens;
+                        n_past_cur = new_n_past;
+                        break;
+                    case 1:
+                        res = GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG;
+                        break;
+                    default:
+                        GENIEX_LOG_ERROR("chunk evaluation failed");
+                        res = GENIEX_ERROR_VLM_GENERATION_FAILED;
+                        break;
+                }
+            }
+            if (res == GENIEX_SUCCESS) {
+                profiler.update_prompt_tokens(prompt_tokens);
+                this->n_past = n_past_cur;
             }
             mtmd_input_chunks_free(chunks);
         } else {
@@ -322,7 +369,6 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             GENIEX_LOG_DEBUG("no new text content, skipping mtmd processing");
         }
 
-        profiler.prompt_end();
         profiler.decode_start();
     } else {
         GENIEX_LOG_DEBUG("using text-only (direct llama) path");
@@ -351,10 +397,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
 
             GENIEX_LOG_DEBUG("_ml_vlm_generate_internal: Tokenized new text portion into {} tokens", prompt_len);
 
-            // Record prompt processing end and decode start
-            profiler.prompt_end();
             profiler.update_prompt_tokens(prompt_len);
-            profiler.decode_start();
 
             llama_batch batch = llama_batch_get_one(prompt_tokens, prompt_len);
             // Set positions based on current n_past
@@ -362,7 +405,10 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
                 batch.pos[i] = this->n_past + i;
             }
 
+            profiler.prompt_start();
             int32_t decode_ret = llama_decode(this->ctx, batch);
+            profiler.prompt_end();
+            profiler.decode_start();
             free(prompt_tokens);
             // 1 means the prompt does not fit the KV cache: since this is
             // prefill, the prompt itself is too long, not a generic failure.

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -260,13 +260,14 @@ int32_t QairtLlm::generate(const geniex_LlmGenerateInput* input, geniex_LlmGener
 
     // Profile data (convert ms -> us)
     output->profile_data.ttft             = static_cast<int64_t>(result.ttft_ms * 1000.0);
+    output->profile_data.media_time       = 0;                          // text-only
     output->profile_data.prompt_time      = output->profile_data.ttft;  // approximate
     output->profile_data.decode_time      = static_cast<int64_t>(result.decode_ms * 1000.0);
     output->profile_data.prompt_tokens    = result.prompt_tokens;
     output->profile_data.generated_tokens = result.generated_tokens;
-    output->profile_data.decoding_speed   = result.tokens_per_second;
     output->profile_data.prefill_speed =
         result.prompt_tokens > 0 && result.ttft_ms > 0.0 ? result.prompt_tokens / (result.ttft_ms / 1000.0) : 0.0;
+    output->profile_data.decoding_speed = result.tokens_per_second;
 
     // Stop Reason
     if (result.stop_reason == "user") {

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -284,10 +284,10 @@ int32_t QairtVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
     output->full_text = portable_strdup(result.full_text.c_str());
     if (!output->full_text) return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;
 
-    // Profile data (convert ms → µs to match geniex_ProfileData convention).
-    // media_time is the vision/audio encoder wall time only; prefilling the
-    // resulting media tokens stays in prompt_time (= ttft − encoder), same as
-    // text. prompt_tokens counts text + media tokens.
+    // Profile data (ms → µs). media_time is the encoder only; the media-token
+    // prefill stays in prompt_time, derived as ttft − encoder since QAIRT exposes
+    // no separate prefill number. When the encoder dominates ttft the subtraction
+    // clamps to 0, so prefill_speed reports 0 (unknown) rather than a bogus rate.
     const int64_t media_us  = static_cast<int64_t>(result.media_ms * 1000.0);
     const int64_t prompt_us = std::max<int64_t>(static_cast<int64_t>(result.ttft_ms * 1000.0) - media_us, 0);
 

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -284,16 +284,21 @@ int32_t QairtVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
     output->full_text = portable_strdup(result.full_text.c_str());
     if (!output->full_text) return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;
 
-    // Profile data (convert ms → µs to match geniex_ProfileData convention)
+    // Profile data (convert ms → µs to match geniex_ProfileData convention).
+    // media_time is the vision/audio encoder wall time only; prefilling the
+    // resulting media tokens stays in prompt_time (= ttft − encoder), same as
+    // text. prompt_tokens counts text + media tokens.
+    const int64_t media_us  = static_cast<int64_t>(result.media_ms * 1000.0);
+    const int64_t prompt_us = std::max<int64_t>(static_cast<int64_t>(result.ttft_ms * 1000.0) - media_us, 0);
+
     output->profile_data.ttft             = static_cast<int64_t>(result.ttft_ms * 1000.0);
-    output->profile_data.prompt_time      = output->profile_data.ttft;
+    output->profile_data.media_time       = media_us;
+    output->profile_data.prompt_time      = prompt_us;
     output->profile_data.decode_time      = static_cast<int64_t>(result.decode_ms * 1000.0);
     output->profile_data.prompt_tokens    = result.prompt_tokens;
     output->profile_data.generated_tokens = result.generated_tokens;
+    output->profile_data.prefill_speed    = prompt_us > 0 ? result.prompt_tokens / (prompt_us / 1e6) : 0.0;
     output->profile_data.decoding_speed   = result.tokens_per_second;
-    output->profile_data.prefill_speed    = (result.prompt_tokens > 0 && result.ttft_ms > 0.0)
-                                                ? static_cast<double>(result.prompt_tokens) / (result.ttft_ms / 1000.0)
-                                                : 0.0;
 
     // Stop Reason
     if (result.stop_reason == "user") {


### PR DESCRIPTION
 **Draft — depends on qualcomm/geniex-qairt-plugin#36** (the qairt submodule bump in this PR points at that PR's branch; blocked until it merges and the submodule pin moves to a landed commit).

## Summary

Makes the VLM image/audio **encoder time** measurable and separate from prefill, across both plugins and every binding, and fixes VLM `prefill_speed`. Closes the customer-blocking gap where encoder time was invisible and `prefill_speed` was computed against the wrong window.

Unified semantics (both plugins):

| Field | Meaning |
|-------|---------|
| `media_time` | vision/audio **encoder (embedding) pass only**; 0 for text-only |
| `prompt_time` | prefill, **including** the media-token positions, excluding the encoder |
| `prompt_tokens` | text **+** media tokens |
| `prefill_speed` | `prompt_tokens / prompt_time` — full prefill, self-consistent |

Invariant: `ttft ≈ media_time + prompt_time` (small inter-chunk orchestration gaps fall outside both, which is more honest than forcing equality by subtraction).

- **llama.cpp** — per-chunk accumulation: `mtmd_encode_chunk` → `media_time`; the decode/prefill calls → `prompt_time`. Text-only path unchanged.
- **qairt** — reads the encoder time the plugin now exposes via `VLMModel::lastMediaMs()` (qualcomm/geniex-qairt-plugin#36). Includes the Gemma4 override that would otherwise report `media_time = 0`.
- **FFI** — drops `geniex_ProfileData.media_tokens` (folded into `prompt_tokens`); updates Go, Python ctypes, Android JNI in lockstep.
- **Tooling** — CLI media-time line; geniex-bench `schema_version` `4` (adds `media_us` per-run / `media_ms` agg); run/bench notes.

## Test plan

- [x] llama.cpp (local, Vulkan): text-only, single-image, multi-image, image+audio — all show `ttft ≈ media + prompt`, `prompt_tokens` = text+media, gaps ≤27 ms.
- [x] qairt Gemma4-E4B on NPU (qcs, Windows ARM64): `media_us=2683062`, `prompt_time_us=650058`, `ttft_us=3333120`, `prompt_tokens=384` — `media_ms` now non-zero (was 0 before).
- [ ] qairt Qwen-VL on NPU (base pathway) — pending.
- [ ] CI PR graph green after submodule pin lands.

Closes #1420