### PR TITLE
fix(cli): drop unsupported modalities before VLM generate

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -532,6 +532,10 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 		checkAudioDependency()
 	}
 
+	// Warn once per unsupported modality; feeding an audio path to a
+	// vision-only model corrupts the run (the pipeline has no audio encoder).
+	warnedAudio, warnedImage := false, false
+
 	var history []geniex_sdk.VlmChatMessage
 	if systemPrompt != "" {
 		history = append(history, geniex_sdk.VlmChatMessage{Role: geniex_sdk.VlmRoleSystem, Contents: []geniex_sdk.VlmContent{{Type: geniex_sdk.VlmContentTypeText, Text: systemPrompt}}})
@@ -549,6 +553,21 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 			return err
 		},
 		Run: func(prompt string, images, audios []string, onToken func(string) bool) (string, geniex_sdk.ProfileData, error) {
+			if len(audios) > 0 && !caps.SupportsAudio {
+				if !warnedAudio {
+					fmt.Println(render.GetTheme().Warning.Sprint("Warning: this model does not support audio; ignoring audio input."))
+					warnedAudio = true
+				}
+				audios = nil
+			}
+			if len(images) > 0 && !caps.SupportsVision {
+				if !warnedImage {
+					fmt.Println(render.GetTheme().Warning.Sprint("Warning: this model does not support images; ignoring image input."))
+					warnedImage = true
+				}
+				images = nil
+			}
+
 			msg := geniex_sdk.VlmChatMessage{Role: geniex_sdk.VlmRoleUser}
 			msg.Contents = append(msg.Contents, geniex_sdk.VlmContent{Type: geniex_sdk.VlmContentTypeText, Text: prompt})
 			for _, image := range images {


### PR DESCRIPTION
## What

`inferVLM` parses image/audio paths from inline prompt text and previously fed them to the SDK unconditionally. Feeding an audio path to a vision-only model (e.g. QAIRT Gemma-4, `supports_audio=false`, no audio encoder) corrupts the run and yields all-zero output.

This filters each modality against the model's reported capabilities inside the `Run` callback — the single choke point shared by all input sources (REPL inline files, `-p`/`--input` one-shot, and `/mic` recording) — and warns once per modality when input is dropped.

## Why

Fixes qcom-ai-hub/geniex#1443: the CLI only checked image/audio support for `/mic`, not for input files. Placing the guard in `Run` closes all input paths with one check.