### PR TITLE
test(sdk): add cross-backend logits parity check

### DIFF
--- a/tests/_quality_data.py
+++ b/tests/_quality_data.py
@@ -25,6 +25,8 @@ the in-repo asset surface small. Tracked alongside the perplexity follow-up.
 
 from __future__ import annotations
 
+import math
+
 # (prompt, expected_substring). Matched case-insensitively against `out.text`.
 LLM_QUALITY_PROMPTS: list[tuple[str, str]] = [
     ('The capital of France is', 'Paris'),
@@ -53,3 +55,63 @@ VLM_QUALITY_KEYWORDS: tuple[str, ...] = (
 VLM_QUALITY_MAX_NEW_TOKENS = 256
 VLM_QUALITY_TEMPERATURE = 0.0
 VLM_QUALITY_SEED = 1
+
+
+PARITY_INPUT_IDS: list[int] = [
+    1,
+    2,
+    3,
+    5,
+    8,
+    13,
+    21,
+    34,
+    55,
+    89,
+    144,
+    233,
+    377,
+    610,
+    987,
+    1597,
+    2584,
+    4181,
+    6765,
+    10946,
+    17711,
+    28657,
+    46368,
+    75025,
+    121393,
+    100,
+    200,
+    300,
+    400,
+    500,
+    600,
+    700,
+]
+PARITY_TOP1_MIN = 0.70
+PARITY_KL_MAX = 0.35
+PARITY_QAIRT_KL_MAX = 1e-4
+
+
+def parity_softmax(row: list[float]) -> list[float]:
+    m = max(row)
+    exps = [math.exp(x - m) for x in row]
+    s = sum(exps)
+    return [e / s for e in exps]
+
+
+def parity_kl_divergence(p_logits: list[float], q_logits: list[float]) -> float:
+    p = parity_softmax(p_logits)
+    q = parity_softmax(q_logits)
+    return sum(pi * (math.log(pi) - math.log(max(qi, 1e-30))) for pi, qi in zip(p, q) if pi > 0)
+
+
+def parity_top1_agreement(
+    ref_rows: list[list[tuple[int, float]]],
+    cand_rows: list[list[tuple[int, float]]],
+) -> float:
+    hits = sum(1 for a, b in zip(ref_rows, cand_rows) if a[0][0] == b[0][0])
+    return hits / len(ref_rows)

--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -22,15 +22,21 @@ from _quality_data import (
     LLM_QUALITY_PROMPTS,
     LLM_QUALITY_SEED,
     LLM_QUALITY_TEMPERATURE,
+    PARITY_INPUT_IDS,
+    PARITY_KL_MAX,
+    PARITY_TOP1_MIN,
     VLM_QUALITY_KEYWORDS,
     VLM_QUALITY_MAX_NEW_TOKENS,
     VLM_QUALITY_PROMPT,
     VLM_QUALITY_SEED,
     VLM_QUALITY_TEMPERATURE,
+    parity_kl_divergence,
+    parity_top1_agreement,
 )
 
 _LLM_BACKENDS = ['cpu', 'gpu', 'npu']
 _VLM_BACKENDS = ['cpu', 'gpu', 'npu']
+_PARITY_CANDIDATES = ['gpu', 'npu', 'hybrid']
 
 
 def test_model_manager_pull(llama_cpp_llm_paths, llama_cpp_vlm_paths, llama_cpp_mtp_paths):
@@ -178,6 +184,28 @@ def test_vlm_quality_keywords(llama_cpp_vlm_paths, quality_image, device_map):
             f'device_map={device_map!r} keywords={VLM_QUALITY_KEYWORDS} '
             f'got={out.text!r}'
         )
+
+
+def _forward_parity(device_map: str) -> tuple[list[list[tuple[int, float]]], list[float]]:
+    with geniex.AutoModelForCausalLM.from_pretrained(
+        LLAMA_CPP_LLM_MODEL,
+        precision=LLAMA_CPP_LLM_PRECISION,
+        device_map=device_map,
+    ) as llm:
+        top1_rows = llm.forward_logits(PARITY_INPUT_IDS, all_positions=True, top_n=1)
+        last_row = llm.forward_logits(PARITY_INPUT_IDS, all_positions=False, top_n=0)[0]
+    return top1_rows, last_row
+
+
+@pytest.mark.llm
+@pytest.mark.parametrize('device_map', _PARITY_CANDIDATES)
+def test_llm_logits_parity(llama_cpp_llm_paths, device_map):
+    ref_top1, ref_last = _forward_parity('cpu')
+    cand_top1, cand_last = _forward_parity(device_map)
+    agree = parity_top1_agreement(ref_top1, cand_top1)
+    kl = parity_kl_divergence(ref_last, cand_last)
+    assert agree >= PARITY_TOP1_MIN, f'device_map={device_map!r} top1={agree:.3f} < {PARITY_TOP1_MIN}'
+    assert kl <= PARITY_KL_MAX, f'device_map={device_map!r} KL={kl:.4f} > {PARITY_KL_MAX}'
 
 
 @pytest.mark.llm

--- a/tests/test_qairt.py
+++ b/tests/test_qairt.py
@@ -16,11 +16,15 @@ from _quality_data import (
     LLM_QUALITY_PROMPTS,
     LLM_QUALITY_SEED,
     LLM_QUALITY_TEMPERATURE,
+    PARITY_INPUT_IDS,
+    PARITY_QAIRT_KL_MAX,
     VLM_QUALITY_KEYWORDS,
     VLM_QUALITY_MAX_NEW_TOKENS,
     VLM_QUALITY_PROMPT,
     VLM_QUALITY_SEED,
     VLM_QUALITY_TEMPERATURE,
+    parity_kl_divergence,
+    parity_top1_agreement,
 )
 
 
@@ -141,6 +145,26 @@ def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
         assert matched, (
             f'prompt={prompt!r} expected_substring={expected!r} ' f'device_map={device_map!r} got={out.text!r}'
         )
+
+
+@pytest.mark.llm
+@pytest.mark.parametrize('device_map', ['npu'])
+def test_llm_logits_self_consistency(qairt_llm_paths, device_map):
+    def _forward() -> tuple[list[list[tuple[int, float]]], list[float]]:
+        with geniex.AutoModelForCausalLM.from_pretrained(
+            QAIRT_LLM_MODEL,
+            device_map=device_map,
+        ) as llm:
+            top1_rows = llm.forward_logits(PARITY_INPUT_IDS, all_positions=True, top_n=1)
+            last_row = llm.forward_logits(PARITY_INPUT_IDS, all_positions=False, top_n=0)[0]
+        return top1_rows, last_row
+
+    ref_top1, ref_last = _forward()
+    cand_top1, cand_last = _forward()
+    agree = parity_top1_agreement(ref_top1, cand_top1)
+    kl = parity_kl_divergence(ref_last, cand_last)
+    assert agree == 1.0, f'device_map={device_map!r} top1={agree:.3f} != 1.0'
+    assert kl <= PARITY_QAIRT_KL_MAX, f'device_map={device_map!r} KL={kl:.6f} > {PARITY_QAIRT_KL_MAX}'
 
 
 @pytest.mark.vlm


### PR DESCRIPTION
## Summary

- Add `test_llm_logits_parity` in `tests/test_llama_cpp.py` that compares llama_cpp `gpu` / `npu` / `hybrid` logits against `cpu` on a fixed pre-tokenized prompt, using top-1 agreement (over all positions) and last-row KL divergence.
- Add `test_llm_logits_self_consistency` in `tests/test_qairt.py` that runs the same forward twice on qairt `npu` and asserts bit-exact top-1 with near-zero KL, guarding against non-determinism regressions in the NPU pipeline.
- Extend the existing shared `tests/_quality_data.py` with pure-Python `parity_softmax` / `parity_kl_divergence` / `parity_top1_agreement` helpers, the input ids, and thresholds. No new file, no numpy, no tokenizer dep.

Filename-based auto-marker + the QDC entry scripts' hardcoded `-m "llama_cpp or qairt"` filter pick these up on all three QDC legs (linux/QCS9075M, windows/SC8480XP, android/SM8850) without touching workflow files.

## Test plan

- [x] `python -m pytest tests/test_llama_cpp.py::test_llm_logits_parity tests/test_qairt.py::test_llm_logits_self_consistency -v` — 4/4 pass on Windows-arm64 Snapdragon (`GENIEX_DEVICE_TEST=1`), ~1 min wall-clock.
- [x] `pytest tests -m "llama_cpp or qairt" -k logits --collect-only` collects the 4 new cases — QDC `-m` filter picks them up unchanged.
- [x] QDC / windows (SC8480XP) — all 4 new tests PASS (31/31 leg total).
- [x] QDC / android (SM8850) — `[npu]`, `[hybrid]`, self-consistency PASS; `[gpu]` auto-skipped by pre-existing Adreno OpenCL guard.
- [x] QDC / linux (QCS9075M) — all 4 new tests PASS. Two pre-existing failures on this leg (`test_mtp_multi_turn[npu]`, `test_llm_quality_keywords[...-Paris-npu]`) are unrelated to this PR.