### PR TITLE
fix(bench): raise QDC job timeout and drop hybrid from the matrix

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -98,7 +98,7 @@ jobs:
     name: ${{ matrix.device }} · ${{ matrix.model.plugin }} · ${{ matrix.model.name }}
     needs: [build-sdk, load-models]
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 355 # just under the GitHub-hosted 6h job hard cap
     strategy:
       fail-fast: false
       max-parallel: 4

--- a/sdk/benchmark/qdc/bench-models.json
+++ b/sdk/benchmark/qdc/bench-models.json
@@ -26,7 +26,7 @@
   {
     "name": "Qwen3-4B-Instruct-2507",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/Qwen3-4B-Instruct-2507-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/Qwen3-4B-Instruct-2507-GGUF/resolve/main/Qwen3-4B-Instruct-2507-Q4_0.gguf"
@@ -58,7 +58,7 @@
   {
     "name": "Phi-3.5-Mini-Instruct",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "bartowski/Phi-3.5-mini-instruct-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/bartowski/Phi-3.5-mini-instruct-GGUF/resolve/main/Phi-3.5-mini-instruct-Q4_0.gguf"
@@ -85,7 +85,7 @@
   {
     "name": "Qwen2.5-VL-7B",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/Qwen2.5-VL-7B-Instruct-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/Qwen2.5-VL-7B-Instruct-GGUF/resolve/main/Qwen2.5-VL-7B-Instruct-Q4_0.gguf",
@@ -96,7 +96,7 @@
   {
     "name": "gemma-4-E4B-it",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "gpu", "hybrid"],
+    "devices": ["cpu", "npu", "gpu"],
     "model_id": "unsloth/gemma-4-E4B-it-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_0.gguf",
@@ -107,7 +107,7 @@
   {
     "name": "gemma-4-E2B-it",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "gpu", "hybrid"],
+    "devices": ["cpu", "npu", "gpu"],
     "model_id": "unsloth/gemma-4-E2B-it-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_0.gguf",
@@ -118,7 +118,7 @@
   {
     "name": "gemma-4-26B-A4B-it",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "gpu", "hybrid"],
+    "devices": ["cpu", "npu", "gpu"],
     "model_id": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-qat-q4_0-gguf/resolve/main/gemma-4-26B_q4_0-it.gguf",
@@ -137,7 +137,7 @@
   {
     "name": "gemma-4-26B-A4B-it-mtp",
     "plugin": "llama_cpp",
-    "devices": ["npu", "hybrid"],
+    "devices": ["npu"],
     "model_id": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/google/gemma-4-26B-A4B-it-qat-q4_0-gguf/resolve/main/gemma-4-26B_q4_0-it.gguf",
@@ -151,7 +151,7 @@
   {
     "name": "Qwen3.5-2B",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/Qwen3.5-2B-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_0.gguf"
@@ -159,7 +159,7 @@
   {
     "name": "Ministral-3-3B-Instruct-2512",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/Ministral-3-3B-Instruct-2512-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/Ministral-3-3B-Instruct-2512-GGUF/resolve/main/Ministral-3-3B-Instruct-2512-Q4_0.gguf"
@@ -175,7 +175,7 @@
   {
     "name": "granite-4.0-micro",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/granite-4.0-micro-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/granite-4.0-micro-GGUF/resolve/main/granite-4.0-micro-Q4_0.gguf"
@@ -183,7 +183,7 @@
   {
     "name": "Qwen3-VL-2B-Instruct",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/Qwen3-VL-2B-Instruct-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/Qwen3-VL-2B-Instruct-GGUF/resolve/main/Qwen3-VL-2B-Instruct-Q4_0.gguf",
@@ -194,7 +194,7 @@
   {
     "name": "Qwen3-VL-4B-Instruct",
     "plugin": "llama_cpp",
-    "devices": ["cpu", "npu", "hybrid"],
+    "devices": ["cpu", "npu"],
     "model_id": "unsloth/Qwen3-VL-4B-Instruct-GGUF:Q4_0",
     "hub": "hf",
     "url": "https://huggingface.co/unsloth/Qwen3-VL-4B-Instruct-GGUF/resolve/main/Qwen3-VL-4B-Instruct-Q4_0.gguf",

--- a/sdk/benchmark/qdc/run_qdc_jobs.py
+++ b/sdk/benchmark/qdc/run_qdc_jobs.py
@@ -585,7 +585,13 @@ def main() -> int:
     )
     p.add_argument("--cells-out", type=Path, help="write the per-cell JSON list here")
     p.add_argument("--render-dir", type=Path, help="render mode: aggregate JSON here")
-    p.add_argument("--job-timeout", type=int, default=7200)
+    p.add_argument(
+        "--job-timeout",
+        type=int,
+        default=19800,
+        help="host poll and QDC reservation seconds; default 330 min leaves "
+        "headroom for log upload under the GitHub-hosted 6h job cap",
+    )
     args = p.parse_args()
 
     if args.render_dir:


### PR DESCRIPTION
## Summary

The QDC bench aborted `gemma-4-E4B-it` @16K on QCS9075M with `TimeoutError: job did not finish within 7200s` — the device produced every cell, but the host's 120-min poll (`run_qdc_jobs.py --job-timeout` default `7200`, never overridden by the workflow) fired first on a 4-unit × 16K-prefill sweep.

- **Raise the timeout to the runner ceiling.** `--job-timeout` default `7200` → `19800` (330 min), which drives both the host poll and the QDC device reservation (`timeout // 60` min). `bench.yml`'s `timeout-minutes` goes `180` → `355`, just under the GitHub-hosted 6h job hard cap, leaving room for log upload after the poll.
- **Drop `hybrid` from the bench matrix.** Removed the `hybrid` compute unit from every model in `bench-models.json`, except `gpt-oss-20b` which is hybrid-only and would otherwise have no compute unit to run.

## Test plan

- [x] Dispatch `bench.yml` for `gemma-4-E4B-it`, `QCS9075M`, `ctx=16384` on this branch → job completes without the 7200s abort; produced cells are `cpu` / `gpu` / `npu` only, no `hybrid`.
- [x] `bench-models.json` stays valid and only `gpt-oss-20b` still carries `hybrid`; no model becomes empty as a result of the change.