### PR TITLE
feat(sdk): inject tools into the QAIRT VLM chat template

### DIFF
--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -15,9 +15,10 @@
 #define portable_strdup strdup
 #endif
 
-#include "dispatch.h"             // provided by geniex-qairt/models/
-#include "geniex-proc/types.h"    // ChatMessage, MMContent, Role::, Modality::
-#include "llm/llm_spec_loader.h"  // parseGenieSamplerConfig
+#include "dispatch.h"               // provided by geniex-qairt/models/
+#include "geniex-proc/tokenizer.h"  // ApplyChatTemplateOptions
+#include "geniex-proc/types.h"      // ChatMessage, MMContent, Role::, Modality::
+#include "llm/llm_spec_loader.h"    // parseGenieSamplerConfig
 #include "logging.h"
 #include "path_utils.h"
 #include "pipeline/vlm_pipeline.h"
@@ -234,8 +235,21 @@ int32_t QairtVlm::apply_chat_template(
     // Record pending size — committed to history_size_ only after a successful generate().
     pending_history_size_ = messages.size();
 
-    // TODO: honor input->enable_thinking once VisionProcessor exposes it.
-    std::string formatted = pipeline_->applyChatTemplate(new_messages, /*add_generation_prompt=*/true);
+    // Tools are injected on the first turn only, matching the LLM path.
+    ApplyChatTemplateOptions opts;
+    opts.add_generation_prompt = true;
+    if (history_size_ == 0 && input->tools && input->tools[0] != '\0') {
+        opts.tools_json = input->tools;
+    }
+    opts.enable_thinking = input->enable_thinking;
+
+    std::string formatted;
+    try {
+        formatted = pipeline_->applyChatTemplate(new_messages, opts);
+    } catch (const std::exception& e) {
+        GENIEX_LOG_ERROR("applyChatTemplate failed: {}", e.what());
+        return GENIEX_ERROR_COMMON_INVALID_INPUT;
+    }
 
     output->formatted_text = portable_strdup(formatted.c_str());
     if (!output->formatted_text) return GENIEX_ERROR_COMMON_MEMORY_ALLOCATION;


### PR DESCRIPTION
## Summary

Enable tool calls for QAIRT VLMs (e.g. `qualcomm/Gemma-4-E4B-it`). The QAIRT VLM path now threads `tools_json` and `enable_thinking` into `applyChatTemplate` on the first turn, mirroring the existing LLM path, so tool definitions are rendered into the prompt.

Gemma4 gets real jinja-based tool support; Qwen2-VL / InternVL hand-roll ChatML and warn when tools are supplied but cannot be rendered (see submodule PRs).

Bumps the `geniex-qairt` submodule.

Depends on:
- qualcomm/geniex-proc#20
- qualcomm/geniex-qairt-plugin#37

## Test plan

- [x] SDK bridge builds on Windows ARM64 (qcs)
- [x] `clang-format-18` clean on `sdk/plugins/qairt/src/vlm.cpp`
- [x] End-to-end via `geniex serve`: Gemma-4 tool-call request returns `get_weather({"city":"Tokyo"})`; prompt_tokens 34 → 85 confirms tools are injected into the prompt
- [x] Verified against a separately-running server instance