### PR TITLE
feat(sdk): accept an explicit device list as a compute unit

### DIFF
--- a/bindings/go/device.go
+++ b/bindings/go/device.go
@@ -97,9 +97,9 @@ func freeResolveDeviceOutput(c *C.geniex_ResolveDeviceOutput) {
 // ModelName may be empty if the caller doesn't know it; it's currently
 // unused by the resolver and reserved for future model-specific defaults.
 //
-// A non-nil error means ComputeUnit was a non-empty unknown alias; the SDK
-// returned GENIEX_ERROR_COMMON_INVALID_DEVICE. Warning is non-empty when the
-// alias was coerced (e.g. qairt ↦ NPU regardless of user input).
+// A non-nil error means ComputeUnit was neither a known alias nor a valid
+// device list; the SDK returned GENIEX_ERROR_COMMON_INVALID_DEVICE. Warning is
+// non-empty when the value was coerced (e.g. qairt ↦ NPU regardless of user input).
 func ResolveDevice(input ResolveDeviceInput) (*ResolveDeviceOutput, error) {
 	cInput := input.toCPtr()
 	defer freeResolveDeviceInput(cInput)
@@ -108,7 +108,7 @@ func ResolveDevice(input ResolveDeviceInput) (*ResolveDeviceOutput, error) {
 	res := C.geniex_resolve_device(cInput, &cOutput)
 	if res != C.GENIEX_SUCCESS {
 		if res == C.GENIEX_ERROR_COMMON_INVALID_DEVICE {
-			return nil, fmt.Errorf("invalid compute unit %q, must be one of: cpu, gpu, npu, hybrid", input.ComputeUnit)
+			return nil, fmt.Errorf("invalid compute unit %q, must be one of: cpu, gpu, npu, hybrid, or a device list like HTP0,HTP1", input.ComputeUnit)
 		}
 		return nil, SDKError(res)
 	}

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -28,24 +28,23 @@ import (
 
 var (
 	// disableStream *bool // reuse in run.go
-	ngl            int32
-	nctx           int32
-	maxTokens      int32
-	stop           []string
-	stopFile       string
-	enableThink    bool
-	prompt         []string
-	tokenFile      string
-	input          string
-	systemPrompt   string
-	computeUnit    string
-	deviceOverride string
-	slidingWindow  bool
-	specType       string
-	draftModel     string
-	draftTokens    int32
-	draftMin       int32
-	draftPMin      float32
+	ngl           int32
+	nctx          int32
+	maxTokens     int32
+	stop          []string
+	stopFile      string
+	enableThink   bool
+	prompt        []string
+	tokenFile     string
+	input         string
+	systemPrompt  string
+	computeUnit   string
+	slidingWindow bool
+	specType      string
+	draftModel    string
+	draftTokens   int32
+	draftMin      int32
+	draftPMin     float32
 
 	// sampler config
 	temperature       float32
@@ -80,8 +79,7 @@ var (
 	llmFlags = func() *pflag.FlagSet {
 		llmFlags := pflag.NewFlagSet("LLM/VLM Model", pflag.ExitOnError)
 		llmFlags.SortFlags = false
-		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: npu)")
-		llmFlags.StringVarP(&deviceOverride, "device", "", "", "override device list, e.g. HTP0,HTP1,HTP2,HTP3; bypasses --compute for device selection (llama_cpp only)")
+		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, hybrid, or an explicit device list like HTP0,HTP1,HTP2,HTP3 (llama_cpp only) (default: npu)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
 		llmFlags.Int32VarP(&nctx, "nctx", "", 4096, "context window size; raise to extend context (llama_cpp only)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")
@@ -296,15 +294,6 @@ func resolveModelParams(runtimeID, modelName string) (deviceID string, resolvedN
 	resolvedNgl = resolved.Ngl
 	if resolved.Warning != "" {
 		fmt.Println(render.GetTheme().Warning.Sprintf("Warning: %s", resolved.Warning))
-	}
-
-	if deviceOverride != "" {
-		if runtimeID == geniex_sdk.RuntimeLlamaCpp {
-			deviceID = deviceOverride
-		} else {
-			fmt.Println(render.GetTheme().Warning.Sprintf(
-				"Warning: --device is only supported by llama_cpp; ignoring for runtime %s", runtimeID))
-		}
 	}
 	return
 }
@@ -602,11 +591,11 @@ func inferVLM(paths *geniex_sdk.ModelPaths) error {
 				PromptUTF8: tmplOut.FormattedText,
 				OnToken:    onToken,
 				Config: &geniex_sdk.GenerationConfig{
-					MaxTokens:      maxTokens,
-					Stop:           stopSequences,
-					SamplerConfig:  samplerConfig,
-					ImagePaths:     images,
-					AudioPaths:     audios,
+					MaxTokens:     maxTokens,
+					Stop:          stopSequences,
+					SamplerConfig: samplerConfig,
+					ImagePaths:    images,
+					AudioPaths:    audios,
 				},
 			})
 			if err != nil {

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -39,6 +39,7 @@ var (
 	input          string
 	systemPrompt   string
 	computeUnit    string
+	deviceOverride string
 	slidingWindow  bool
 	specType       string
 	draftModel     string
@@ -80,6 +81,7 @@ var (
 		llmFlags := pflag.NewFlagSet("LLM/VLM Model", pflag.ExitOnError)
 		llmFlags.SortFlags = false
 		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, or hybrid (default: npu)")
+		llmFlags.StringVarP(&deviceOverride, "device", "", "", "override device list, e.g. HTP0,HTP1,HTP2,HTP3; bypasses --compute for device selection (llama_cpp only)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
 		llmFlags.Int32VarP(&nctx, "nctx", "", 4096, "context window size; raise to extend context (llama_cpp only)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")
@@ -294,6 +296,15 @@ func resolveModelParams(runtimeID, modelName string) (deviceID string, resolvedN
 	resolvedNgl = resolved.Ngl
 	if resolved.Warning != "" {
 		fmt.Println(render.GetTheme().Warning.Sprintf("Warning: %s", resolved.Warning))
+	}
+
+	if deviceOverride != "" {
+		if runtimeID == geniex_sdk.RuntimeLlamaCpp {
+			deviceID = deviceOverride
+		} else {
+			fmt.Println(render.GetTheme().Warning.Sprintf(
+				"Warning: --device is only supported by llama_cpp; ignoring for runtime %s", runtimeID))
+		}
 	}
 	return
 }

--- a/notes/run.md
+++ b/notes/run.md
@@ -47,8 +47,11 @@ Defaults when the user passes nothing (`--device ""` / `device_map="auto"`):
 so `cpu` / `gpu` / `hybrid` against a qairt model get coerced to `NPU`
 with a warning on stderr — the CLI does **not** exit early.
 
-Concrete ids (`HTP0,HTP1,HTP2,HTP3`, `GPUOpenCL`, etc.) pass through
-unchanged when supplied via `<plugin>:<device>`.
+Beyond the aliases, `--compute` also accepts an explicit device list of
+concrete ids (`HTP0,HTP1,HTP2,HTP3`, `GPUOpenCL`) — `llama_cpp` passes it
+through to llama.cpp verbatim (handy for multi-DSP recipes that need more
+than the single `HTP0` the `npu` alias pins); `--ngl` still applies. qairt
+is NPU-only, so a device list gets coerced to `NPU` with a warning.
 
 ## Compute-unit selection (llama_cpp)
 

--- a/sdk/src/device.cpp
+++ b/sdk/src/device.cpp
@@ -41,17 +41,48 @@ std::string to_lower(const char* s) {
     return out;
 }
 
-std::string to_lower_trim(const char* s) {
-    std::string out   = to_lower(s);
-    size_t      start = 0;
-    while (start < out.size() && std::isspace(static_cast<unsigned char>(out[start]))) ++start;
-    size_t end = out.size();
-    while (end > start && std::isspace(static_cast<unsigned char>(out[end - 1]))) --end;
-    return out.substr(start, end - start);
+std::string trim(const std::string& s) {
+    size_t start = 0;
+    while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) ++start;
+    size_t end = s.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) --end;
+    return s.substr(start, end - start);
 }
+
+std::string to_lower_trim(const char* s) { return trim(to_lower(s)); }
 
 bool is_known_alias(const std::string& s) {
     return s == kAliasCPU || s == kAliasGPU || s == kAliasNPU || s == kAliasHybrid;
+}
+
+// A concrete llama.cpp device name: "HTP0".."HTPn" or "GPUOpenCL".
+bool is_device_token(const std::string& t) {
+    if (t == kDeviceGPUOpenCL) return true;
+    if (t.rfind("HTP", 0) == 0 && t.size() > 3) {
+        for (size_t i = 3; i < t.size(); ++i)
+            if (!std::isdigit(static_cast<unsigned char>(t[i]))) return false;
+        return true;
+    }
+    return false;
+}
+
+// Parse an explicit device list like "HTP0,HTP1,HTP2,HTP3" (or a single
+// "HTP0"). Returns true and fills `out` with the whitespace-stripped list
+// only when every comma-separated token is a valid device name.
+bool parse_device_list(const std::string& raw, std::string& out) {
+    if (raw.empty()) return false;
+    std::string normalized;
+    size_t      start = 0;
+    while (start <= raw.size()) {
+        size_t      end = raw.find(',', start);
+        std::string tok = trim(raw.substr(start, end == std::string::npos ? std::string::npos : end - start));
+        start           = (end == std::string::npos) ? raw.size() + 1 : end + 1;
+        if (!is_device_token(tok)) return false;
+        if (!normalized.empty()) normalized += ',';
+        normalized += tok;
+    }
+    out = normalized;
+    return !out.empty();
 }
 
 }  // namespace
@@ -73,10 +104,16 @@ int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_Res
     }
 
     const std::string plugin = input->plugin_id;
-    std::string       alias  = to_lower_trim(input->mode);
+    const std::string raw    = trim(input->mode ? input->mode : "");
+    std::string       alias  = to_lower(raw.c_str());
 
-    if (!alias.empty() && alias != kAliasAuto && !is_known_alias(alias)) {
-        GENIEX_LOG_ERROR("geniex_resolve_device: invalid device mode '{}'", alias);
+    // Besides the aliases, mode may be an explicit device list ("HTP0,HTP1")
+    // that bypasses the alias table and is handed straight to llama.cpp.
+    std::string device_list;
+    const bool  has_device_list = parse_device_list(raw, device_list);
+
+    if (!alias.empty() && alias != kAliasAuto && !is_known_alias(alias) && !has_device_list) {
+        GENIEX_LOG_ERROR("geniex_resolve_device: invalid device mode '{}'", raw);
         return GENIEX_ERROR_COMMON_INVALID_DEVICE;
     }
 
@@ -87,11 +124,13 @@ int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_Res
     }
 
     // QAIRT is NPU-only and rejects any non-zero n_gpu_layers, so force
-    // ngl to 0. Non-npu aliases are coerced with a warning, not an error.
+    // ngl to 0. Non-npu aliases and device lists are coerced with a
+    // warning, not an error.
     if (plugin == kPluginQairt) {
-        if (alias != kAliasNPU) {
-            std::string msg =
-                "qairt plugin only supports NPU inference; ignoring device='" + alias + "' and running on NPU";
+        if (has_device_list || alias != kAliasNPU) {
+            const std::string shown = has_device_list ? device_list : alias;
+            std::string       msg =
+                "qairt plugin only supports NPU inference; ignoring device='" + shown + "' and running on NPU";
             output->warning = portable_strdup(msg.c_str());
         }
         output->device_id = portable_strdup(kDeviceQairtNPU);
@@ -99,8 +138,15 @@ int32_t geniex_resolve_device(const geniex_ResolveDeviceInput* input, geniex_Res
         return GENIEX_SUCCESS;
     }
 
-    // llama_cpp: ngl passes through unchanged (-1 means "all layers" to
-    // llama.cpp). Only cpu forces it to 0.
+    // llama_cpp: an explicit device list passes through verbatim; ngl is
+    // left at its default (-1 = "all layers").
+    if (has_device_list) {
+        output->device_id = portable_strdup(device_list.c_str());
+        return GENIEX_SUCCESS;
+    }
+
+    // ngl passes through unchanged (-1 means "all layers" to llama.cpp).
+    // Only cpu forces it to 0.
     if (alias == kAliasCPU) {
         output->ngl = 0;
     } else if (alias == kAliasGPU) {


### PR DESCRIPTION
## Summary

- `geniex_resolve_device` (`sdk/src/device.cpp`) now accepts a comma-separated device list — e.g. `HTP0,HTP1,HTP2,HTP3` or `GPUOpenCL` — as the compute unit, alongside the `cpu` / `gpu` / `npu` / `hybrid` aliases. The logic lives in the single-source-of-truth resolver, so the CLI `--compute` flag, Python, and Android all pick it up with one flag (no separate `--device` knob).
- `llama_cpp` hands the list straight to `llama.cpp` (`resolve_devices()` already parses comma-separated ids); `--ngl` still applies. `qairt` is NPU-only, so a device list is coerced to `NPU` with a warning.
- Unblocks multi-DSP recipes like `--compute HTP0,HTP1,HTP2,HTP3` that need more than the single `HTP0` the `npu` alias pins.

## Test plan

- [x] On a Snapdragon X2 Elite (Glymur) Linux/aarch64 device: `GGML_HEXAGON_NDEV=4 geniex --verbose infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute HTP0,HTP1,HTP2,HTP3 --spec-type draft-mtp --draft-model <mtp> --nctx {8192,16384}` logs `Using 4 device(s): HTP0,HTP1,HTP2,HTP3` at `GENIEX_LOG=info` and runs Gemma4-26B + MTP end-to-end. Perf in the comment below.
- [x] `--compute foo` (non-alias, non-device) still returns `INVALID_DEVICE`; `cpu` / `gpu` / `npu` / `hybrid` unchanged.
