### PR TITLE
fix(sdk): reuse VLM KV via char-level prefix match

### DIFF
--- a/sdk/plugins/llama_cpp/include/vlm.h
+++ b/sdk/plugins/llama_cpp/include/vlm.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "chat.h"
 #include "htp_session.h"
 #include "mtmd.h"
@@ -28,9 +30,11 @@ class LlamaVlm : public IVlm {
     bool supports_vision = false;
     bool supports_audio  = false;
 
-    // Conversation state tracking
-    int32_t n_past              = 0;
-    int32_t global_n_past_chars = 0;  // Track character position in prompt text (not tokens)
+    // Append-only KV reuse: skip the common prefix + last generation, feed only
+    // the rest. Recurrent models can't roll back, so we never re-feed old tokens.
+    int32_t     n_past = 0;
+    std::string past_prompt;  // last turn's full prompt
+    std::string past_gen;     // last turn's generated text
 
     // Tracks whether this instance pinned an HTP session; releases on last handoff.
     htp::SessionGuard htp_guard_;

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -3,6 +3,7 @@
 
 #include "vlm.h"
 
+#include <algorithm>
 #include <cstring>
 #include <nlohmann/json.hpp>
 
@@ -124,8 +125,9 @@ int32_t LlamaVlm::reset() {
     // leave cache state inconsistent with n_past. Keep this aligned with LlamaLlm::reset().
     llama_memory_clear(llama_get_memory(this->ctx), /*clear data=*/true);
 
-    this->n_past              = 0;
-    this->global_n_past_chars = 0;
+    this->n_past = 0;
+    this->past_prompt.clear();
+    this->past_gen.clear();
 
     return GENIEX_SUCCESS;
 }
@@ -257,17 +259,32 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
 
     GENIEX_LOG_DEBUG("total media files loaded: {}", n_media);
 
-    // Get the full prompt length for tracking
-    const int32_t full_prompt_len = (int32_t)strlen(input->prompt_utf8);
-    GENIEX_LOG_DEBUG("full prompt length: {}, global_text_pos: {}", full_prompt_len, this->global_n_past_chars);
+    // Incremental text to feed (see vlm.h). Mismatch breaks append-only — fail.
+    const std::string full_prompt(input->prompt_utf8);
 
-    // Extract only the new text portion that hasn't been processed yet
     std::string new_text_portion;
-    if (this->global_n_past_chars < full_prompt_len) {
-        new_text_portion = std::string(input->prompt_utf8 + this->global_n_past_chars);
-        GENIEX_LOG_DEBUG("new text portion length: {}", new_text_portion.length());
+    if (this->n_past == 0 || this->past_prompt.empty()) {
+        new_text_portion = full_prompt;
     } else {
-        GENIEX_LOG_DEBUG("no new text to process (global_text_pos >= full_prompt_len)");
+        size_t lcp     = 0;
+        size_t lcp_max = std::min(full_prompt.size(), this->past_prompt.size());
+        while (lcp < lcp_max && full_prompt[lcp] == this->past_prompt[lcp]) ++lcp;
+
+        const size_t reuse_end = lcp + this->past_gen.size();
+        const bool   gen_matches =
+            reuse_end <= full_prompt.size() && full_prompt.compare(lcp, this->past_gen.size(), this->past_gen) == 0;
+
+        if (!gen_matches) {
+            GENIEX_LOG_ERROR("prefix reuse failed: prompt[{}:{}] does not match last generation (|G|={})",
+                lcp,
+                reuse_end,
+                this->past_gen.size());
+            return GENIEX_ERROR_VLM_GENERATION_FAILED;
+        }
+
+        new_text_portion = full_prompt.substr(reuse_end);
+        GENIEX_LOG_DEBUG(
+            "prefix reuse: |A|={}, |G|={}, increment={} bytes", lcp, this->past_gen.size(), new_text_portion.size());
     }
 
     // Use mtmd path when ctx_vision is available, fallback to direct llama path otherwise
@@ -518,7 +535,9 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
     auto full_text_str = full_text.str();
     output->full_text  = strdup(full_text_str.c_str());
     if (generated_token_count > 0) {
-        this->global_n_past_chars = full_prompt_len + full_text_str.length();
+        // Record this turn so the next can reuse A+T+G (see vlm.h).
+        this->past_prompt = full_prompt;
+        this->past_gen    = full_text_str;
     }
 
     GENIEX_LOG_DEBUG("completed generation with {} tokens", generated_token_count);


### PR DESCRIPTION
## Problem

Repeated sequential prompts on `unsloth/Qwen3.5-2B-GGUF` (e.g. `1 2 3 4 5 6 7 8` entered several times) drove the VLM into repetitive generation and leaked chat-template tokens (`<|im_start|>user`). `--presence-penalty` / `--repetition-penalty` / `--stop` did not mitigate it.

## Root cause

The VLM path tracked cross-turn reuse with a monotonically growing character counter (`global_n_past_chars`), assuming the KV text equaled the rendered prompt concatenated turn over turn. Qwen3.5 injects a fixed empty `<think>\n\n</think>\n\n` block at the generation-prompt tail, which the template **drops** once that turn becomes history. The counter therefore drifted by the block length every turn, so the "new" slice fed into the KV was misaligned — corrupting the cache and producing repetition + template-token leakage.

## Fix

Track the last turn's full prompt and generated text instead. Compute the increment via char-level longest-common-prefix against the previous prompt, skip the recorded generation, and append only the remainder:

- The injected think block is absorbed by the prefix match and stays in KV as harmless padding (the model generated right after it, so the stream is self-consistent).
- Reuse is **append-only** — no mid-sequence rollback — so it works on hybrid/recurrent architectures like qwen35 that cannot `seq_rm` a KV tail.
- A prefix mismatch fails loudly (`GENIEX_ERROR_VLM_GENERATION_FAILED`) rather than silently re-prefilling.

## Verification

- 8-turn repro (`-c hybrid`, greedy): all turns coherent, no repetition, no template-token leakage.
- Debug counters confirm append-only reuse: increment stays constant (~95 bytes / ~29 tokens) while `|A|` grows monotonically; prompt tokens no longer scale with history; 0 prefix-mismatch failures.

## Notes

- No public header (`geniex.h`) change — not an FFI change.
- Thinking is expected to stay disabled for this path: with thinking enabled the model's reasoning is stripped from history on the next turn, breaking the append-only precondition (the guard correctly surfaces this as an error rather than corrupting KV).