### PR TITLE
fix(resume): re-fetch file when size mismatches legacy no-marker state

### DIFF
--- a/sdk/model-manager/crates/core/src/resume.rs
+++ b/sdk/model-manager/crates/core/src/resume.rs
@@ -25,20 +25,21 @@ pub const PROGRESS_SUFFIX: &str = ".progress";
 pub fn filter_pending<'a>(files: &'a [FileSpec], dest_dir: &Path) -> Vec<FileSpec> {
     files
         .iter()
-        .filter(|f| needs_fetch(&f.name, dest_dir))
+        .filter(|f| needs_fetch(f, dest_dir))
         .cloned()
         .collect()
 }
 
-fn needs_fetch(name: &str, dest_dir: &Path) -> bool {
+fn needs_fetch(spec: &FileSpec, dest_dir: &Path) -> bool {
+    let name = &spec.name;
     if name.is_empty() {
         return false;
     }
     let marker = dest_dir.join(format!("{name}{PROGRESS_SUFFIX}"));
     let output = dest_dir.join(name);
-    // Legacy published state (file present, no marker): treat as done.
     if !marker.exists() && output.exists() {
-        return false;
+        let on_disk = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+        return on_disk != spec.size;
     }
     if let Ok(data) = std::fs::read(&marker) {
         // Non-empty, all-0x01 bitmap means every chunk already
@@ -98,5 +99,13 @@ mod tests {
         std::fs::write(tmp.path().join("a.gguf"), b"xxxxxxxxxx").unwrap();
         let pending = filter_pending(&[local_spec("a.gguf")], tmp.path());
         assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn refetches_truncated_file_without_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.gguf"), b"xxxxx").unwrap();
+        let pending = filter_pending(&[local_spec("a.gguf")], tmp.path());
+        assert_eq!(pending.len(), 1);
     }
 }


### PR DESCRIPTION
## Problem
A disk-full interruption leaves a truncated destination file with no `.progress` marker — the copy error returns before the marker write in the executor. On re-pull, `resume::needs_fetch` treated any "file exists, no marker" case as done, causing the pull to skip the truncated file and report "Download success".

Reported in qcom-ai-hub/geniex#1456.

## Solution
Add a size check to the legacy no-marker path: compare the on-disk file size against `spec.size`. If they differ, return `true` (needs re-fetch). Correctly-sized files written before the `.progress` marker system was introduced are still skipped unchanged.

Only `resume.rs` changes — no SDK API, no FFI, no CLI.

## Test plan
- [x] `cargo test -p model-manager-core resume` — all 5 resume unit tests pass, including new `refetches_truncated_file_without_marker`