### PR TITLE
test(python): disable thinking in llm quality keyword cells

### DIFF
--- a/tests/_quality_data.py
+++ b/tests/_quality_data.py
@@ -17,6 +17,11 @@ before `generate()` to reproduce that path — feeding the raw string lets
 Qwen3-style models drift into completion mode and the keyword only appears
 by sampler luck.
 
+Thinking is disabled for the keyword cells. With it on, Qwen3 spends most of
+`LLM_QUALITY_MAX_NEW_TOKENS` on a reasoning trace, the answer gets truncated,
+and the binding strips the trace — leaving a stub that looks like a missing
+keyword (qcom-ai-hub/geniex#1460).
+
 One intentional delta vs. upstream: VLM only ships the dog photo + first
 keyword set. Upstream also iterates a Qualcomm AIHub product image with
 vocabulary like person/phone/text; that second image is deferred to keep

--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -148,6 +148,7 @@ def test_llm_quality_keywords(llama_cpp_llm_paths, device_map, prompt, expected)
             [{'role': 'user', 'content': prompt}],
             tokenize=False,
             add_generation_prompt=True,
+            enable_thinking=False,
         )
         out = llm.generate(
             formatted,
@@ -156,6 +157,11 @@ def test_llm_quality_keywords(llama_cpp_llm_paths, device_map, prompt, expected)
             seed=LLM_QUALITY_SEED,
         )
         assert out.text, f'empty completion for prompt={prompt!r}'
+        # A think trace that eats the whole budget leaves a truncated answer
+        # stub, which reads as a missing keyword — report it as truncation.
+        assert (
+            out.profile.stop_reason != 'length'
+        ), f'completion truncated at {LLM_QUALITY_MAX_NEW_TOKENS} tokens: prompt={prompt!r} got={out.text!r}'
         # Hoist to a bool so pytest's assertion introspection doesn't echo
         # out.text 4-5x per failure.
         matched = expected.lower() in out.text.lower()

--- a/tests/test_qairt.py
+++ b/tests/test_qairt.py
@@ -134,6 +134,7 @@ def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
             [{'role': 'user', 'content': prompt}],
             tokenize=False,
             add_generation_prompt=True,
+            enable_thinking=False,
         )
         out = llm.generate(
             formatted,
@@ -142,6 +143,11 @@ def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
             seed=LLM_QUALITY_SEED,
         )
         assert out.text, f'empty completion for prompt={prompt!r}'
+        # A think trace that eats the whole budget leaves a truncated answer
+        # stub, which reads as a missing keyword — report it as truncation.
+        assert (
+            out.profile.stop_reason != 'length'
+        ), f'completion truncated at {LLM_QUALITY_MAX_NEW_TOKENS} tokens: prompt={prompt!r} got={out.text!r}'
         matched = expected.lower() in out.text.lower()
         assert matched, (
             f'prompt={prompt!r} expected_substring={expected!r} ' f'device_map={device_map!r} got={out.text!r}'


### PR DESCRIPTION
Fixes the QAIRT Paris keyword failure on QCS9075M (qcom-ai-hub/geniex#1460).

Root cause, reproduced on the QDC QCS9075M cell: the keyword cells didn't pass `enable_thinking=False`, so Qwen3-4B spent ~250 of the 256-token budget on a `<think>` trace, closed it, started the answer, and hit the cap right before ` Paris`. `GenerateOutput.from_raw` then strips the think block, leaving a stub that happens to equal the prompt — which is why CI reported `got='The capital of France is'` and looked like the NPU echoing the prompt.

On device with `enable_thinking=False`: `gen=9`, `'The capital of France is PARIS.'`

Applied to both plugin matrices — llama_cpp was passing only because its traces happened to fit under the cap. The added `stop_reason != 'length'` assertion makes a future truncation report itself instead of masquerading as a missing keyword.