### PR TITLE
feat(android): add a CPU-only AAR for baseline armv8.0 devices

### DIFF
--- a/.github/workflows/_build-android-aar.yml
+++ b/.github/workflows/_build-android-aar.yml
@@ -14,6 +14,19 @@ permissions:
 
 jobs:
   build:
+    name: ${{ matrix.variant }}
+    # The gradle project is variant-agnostic: it copies whatever lib/ subdirs
+    # sdk/pkg-geniex ships, so the CPU-only package just yields fewer jniLibs. #1217
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: default
+            sdk_artifact: sdk-android-arm64
+            tag_suffix: ""
+          - variant: cpu
+            sdk_artifact: sdk-android-arm64-cpu
+            tag_suffix: "-cpu"
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -32,7 +45,7 @@ jobs:
       - name: Download Android SDK package
         uses: actions/download-artifact@v8
         with:
-          name: sdk-android-arm64
+          name: ${{ matrix.sdk_artifact }}
           path: sdk/pkg-geniex
 
       - name: Set up JDK 17
@@ -74,20 +87,23 @@ jobs:
 
       - name: Collect AAR
         id: aar
+        env:
+          TAG_SUFFIX: ${{ matrix.tag_suffix }}
         shell: bash
         run: |
           set -euo pipefail
           src="bindings/android/app/build/outputs/aar/app-release.aar"
           [ -f "$src" ] || { echo "::error::AAR not found at $src"; exit 1; }
           mkdir -p dist-aar
-          cp "$src" dist-aar/geniex-android-aar.aar
-          echo "path=dist-aar/geniex-android-aar.aar" >> "$GITHUB_OUTPUT"
+          out="dist-aar/geniex-android-aar${TAG_SUFFIX}.aar"
+          cp "$src" "$out"
+          echo "path=$out" >> "$GITHUB_OUTPUT"
 
       - name: Upload AAR artifact
         if: inputs.upload_artifact
         uses: actions/upload-artifact@v7
         with:
-          name: android-aar
-          path: dist-aar/geniex-android-aar.aar
+          name: android-aar${{ matrix.tag_suffix }}
+          path: ${{ steps.aar.outputs.path }}
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/_build-sdk.yml
+++ b/.github/workflows/_build-sdk.yml
@@ -50,6 +50,11 @@ jobs:
             runner: ubuntu-latest
             preset: arm64-android-snapdragon-release
             container_image: docker.io/qualcomm/geniex-toolchain-android:v0.1.0
+          # minSdk 27 still admits armv8.0 phones, which trap on armv8.7. See #1217.
+          - platform: android-arm64-cpu
+            runner: ubuntu-latest
+            preset: arm64-android-cpu-release
+            container_image: docker.io/qualcomm/geniex-toolchain-android:v0.1.0
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,11 @@ jobs:
           name: android-aar
           path: .
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: android-aar-cpu
+          path: .
+
       - name: Package artifacts and write SHA256 sidecars
         run: |
           set -euo pipefail
@@ -268,6 +273,7 @@ jobs:
 
           mv geniex-cli-setup.exe "geniex-cli-setup-windows-arm64-${RELEASE_TAG}.exe"
           mv geniex-android-aar.aar "geniex-android-aar-${RELEASE_TAG}.aar"
+          mv geniex-android-aar-cpu.aar "geniex-android-aar-cpu-${RELEASE_TAG}.aar"
 
           mv geniex-*.tar.gz "geniex-pysdist-${RELEASE_TAG}.tar.gz"
           mv geniex_llama_cpp-*.tar.gz "geniex-pysdist-llama_cpp-${RELEASE_TAG}.tar.gz"

--- a/docs/cn/resources/troubleshooting.mdx
+++ b/docs/cn/resources/troubleshooting.mdx
@@ -135,6 +135,12 @@ import Feedback from "/snippets/page-feedback.mdx";
   <Accordion title="Qualcomm AI Engine Direct 拒绝 `nGpuLayers` 或 `nCtx`">
     Qualcomm AI Hub 模型在编译期固化了 KV 缓存与上下文长度。请保持 `nGpuLayers` 与 `nCtx` 为默认值，改用 `max_tokens` 与 `enable_thinking` 调节。
   </Accordion>
+
+  <Accordion title="初始化报 'this device's CPU lacks features required by geniex'">
+    与 Linux 上同一处启动检查。默认 AAR 按 **armv8.7-a** 编译，带 `fp16`、`dotprod`、`i8mm` 扩展，而 `minSdk` 27 仍覆盖早于这些扩展的机型，因此 `geniex_init` 直接返回 `NOT_SUPPORTED`，而不是在运行中途以裸 `SIGILL` 崩溃。
+
+    这类设备请改用 **CPU-only** AAR——[release 资产](https://github.com/qualcomm/GenieX/releases)中的 `geniex-android-aar-cpu-<tag>.aar`。它按纯 `armv8.0-a` 编译、不带任何 ISA 扩展，只提供 CPU 推理（无 Qualcomm AI Engine Direct、无 OpenCL、无 Hexagon），因而相应更慢。除此之外可直接替换：`com.geniex.sdk` 命名空间与 API 完全一致。Maven Central 上只发布默认 AAR。
+  </Accordion>
 </AccordionGroup>
 
 ## **仍有问题？**

--- a/docs/en/resources/troubleshooting.mdx
+++ b/docs/en/resources/troubleshooting.mdx
@@ -149,6 +149,12 @@ import Feedback from "/snippets/page-feedback.mdx";
   <Accordion title="`nGpuLayers` or `nCtx` rejected on Qualcomm AI Engine Direct">
     Qualcomm AI Hub Models are compiled with fixed KV cache and context length. Leave both `nGpuLayers` and `nCtx` at their defaults; tune `max_tokens` and `enable_thinking` instead.
   </Accordion>
+
+  <Accordion title="Init fails with 'this device's CPU lacks features required by geniex'">
+    The same startup guard as on Linux. The default AAR is compiled for **armv8.7-a** with the `fp16`, `dotprod`, and `i8mm` extensions, but `minSdk` 27 still admits phones that predate them, so `geniex_init` returns `NOT_SUPPORTED` instead of crashing with a raw `SIGILL` partway through a run.
+
+    Ship the **CPU-only** AAR on those devices — `geniex-android-aar-cpu-<tag>.aar` from the [release assets](https://github.com/qualcomm/GenieX/releases). It is compiled for plain `armv8.0-a` with no ISA extensions, ships CPU inference only (no Qualcomm AI Engine Direct, no OpenCL, no Hexagon), and is correspondingly slower. Otherwise it is a drop-in replacement: same `com.geniex.sdk` namespace and API. Only the default AAR is published to Maven Central.
+  </Accordion>
 </AccordionGroup>
 
 ## **Still stuck?**

--- a/notes/build.md
+++ b/notes/build.md
@@ -127,6 +127,24 @@ cmake --build build-android -j
 cmake --install build-android --prefix pkg-geniex
 ```
 
+#### CPU-only variant (baseline armv8.0-a)
+
+`minSdk` is 27, so the AAR still targets phones that predate the armv8.7 ISA the
+`snapdragon` presets bake in and trap at startup (see
+[#1217](https://github.com/qualcomm/GenieX/issues/1217)). Swap the preset for
+`arm64-android-cpu-{debug,release}` — same container, plain `-march=armv8-a`, and
+CPU-only (no QAIRT, Hexagon, or OpenCL):
+
+```bash
+cmake --preset arm64-android-cpu-debug -B build-android-cpu .
+cmake --build build-android-cpu -j
+cmake --install build-android-cpu --prefix pkg-geniex
+```
+
+`bindings/android` needs no changes: `assembleRelease` packages whatever
+`sdk/pkg-geniex/lib/` holds, so the same gradle project yields the CPU-only AAR
+that CI publishes as `geniex-android-aar-cpu-<tag>.aar`.
+
 Deploy and smoke-test on device:
 
 ```bash

--- a/notes/release.md
+++ b/notes/release.md
@@ -9,7 +9,7 @@ git tag v1.2.3 && git push origin v1.2.3
 - Tags containing `-` are drafts (and push the sdist to TestPyPI).
 - Bare `vX.Y.Z` tags publish immediately (and push the sdist to production PyPI).
 - Assets: `geniex-sdk-{linux,windows}-arm64-<tag>.zip`, `geniex-cli-linux-arm64-<tag>.tar.gz`, `geniex-cli-setup-windows-arm64-<tag>.exe`, `geniex-android-aar-<tag>.aar`, `geniex-bench-{linux,windows,android}-arm64-<tag>.{tar.gz,zip}`, `geniex-pysdist{,-llama_cpp,-qairt}-<tag>.tar.gz`, and per-file `.sha256` sidecars.
-- The CPU-only variant ([#1217](https://github.com/qualcomm/GenieX/issues/1217)) adds a `-cpu` infix on the Linux assets: `geniex-{sdk,cli}-linux-arm64-cpu-<tag>.*`. Docker mirrors it as the `-cpu` tag. No `geniex-bench` archive — the SDK zip already ships `bin/geniex-bench`.
+- The CPU-only variant ([#1217](https://github.com/qualcomm/GenieX/issues/1217)) adds a `-cpu` infix on the Linux and Android assets: `geniex-{sdk,cli}-linux-arm64-cpu-<tag>.*` and `geniex-android-aar-cpu-<tag>.aar`. Docker mirrors it as the `-cpu` tag; Maven Central publishes only the default AAR. No `geniex-bench` archive: on Linux the SDK zip already ships `bin/geniex-bench`, and no device in the benchmark fleet needs a CPU-only build.
 - Re-running the same tag via **Actions → Release → Run workflow** is safe **as long as you set "Use workflow from" to the tag** (Tags tab in the dropdown). Dispatching from `main` is rejected by `resolve-tag` so the workflow never builds a tag against the wrong commit.
 - S3 mirror at `s3://qaihub-public-assets/qai-hub-geniex/` — see [§ S3 mirror & manifest](#s3-mirror--manifest) below.
 

--- a/sdk/CMakePresets.json
+++ b/sdk/CMakePresets.json
@@ -85,6 +85,24 @@
       }
     },
     {
+      "name": "arm64-android-cpu",
+      "hidden": true,
+      "architecture": {
+        "value": "arm64",
+        "strategy": "external"
+      },
+      "toolset": {
+        "value": "host=x86_64",
+        "strategy": "external"
+      },
+      "cacheVariables": {
+        "ANDROID_ABI": "arm64-v8a",
+        "ANDROID_PLATFORM": "android-31",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/arm64-android-llvm-cpu.cmake",
+        "PREBUILT_LIB_DIR": "android_aarch64"
+      }
+    },
+    {
       "name": "arm64-linux-snapdragon",
       "hidden": true,
       "architecture": {
@@ -139,6 +157,14 @@
       "inherits": ["arm64-android-snapdragon", "snapdragon", "release", "base"]
     },
     {
+      "name": "arm64-android-cpu-debug",
+      "inherits": ["arm64-android-cpu", "cpu-only", "debug", "base"]
+    },
+    {
+      "name": "arm64-android-cpu-release",
+      "inherits": ["arm64-android-cpu", "cpu-only", "release", "base"]
+    },
+    {
       "name": "arm64-linux-snapdragon-debug",
       "inherits": ["arm64-linux-snapdragon", "snapdragon", "debug", "base"]
     },
@@ -179,6 +205,16 @@
     {
       "name": "arm64-android-snapdragon-release",
       "configurePreset": "arm64-android-snapdragon-release",
+      "jobs": 0
+    },
+    {
+      "name": "arm64-android-cpu-debug",
+      "configurePreset": "arm64-android-cpu-debug",
+      "jobs": 0
+    },
+    {
+      "name": "arm64-android-cpu-release",
+      "configurePreset": "arm64-android-cpu-release",
       "jobs": 0
     },
     {

--- a/sdk/cmake/arm64-android-llvm-cpu.cmake
+++ b/sdk/cmake/arm64-android-llvm-cpu.cmake
@@ -1,0 +1,7 @@
+set(ANDROID_NDK_ROOT "$ENV{ANDROID_NDK_ROOT}")
+include("${ANDROID_NDK_ROOT}/build/cmake/android.toolchain.cmake")
+
+# CPU-only variant for armv8.0 devices, which the default armv8.7 build traps on
+# at startup. No ISA extensions. #1217
+set(CMAKE_C_FLAGS "-march=armv8-a -fvectorize -ffp-model=fast -fno-finite-math-only -flto -D_GNU_SOURCE")
+set(CMAKE_CXX_FLAGS "-march=armv8-a -fvectorize -ffp-model=fast -fno-finite-math-only -flto -D_GNU_SOURCE")


### PR DESCRIPTION
## Summary

The Android AAR has the same defect #1217 describes for Linux, one ISA level higher. `sdk/cmake/arm64-android-llvm.cmake` builds everything with `-march=armv8.7-a+fp16+dotprod+i8mm`, but `minSdk` is 27 — so the AAR still installs on phones that predate those extensions, where the #1180 startup guard turns the would-be `SIGILL` into `geniex_init` returning `NOT_SUPPORTED`. Graceful, but still no inference.

This adds the Android counterpart to the Linux CPU-only variant from #1340.

- **`sdk/cmake/arm64-android-llvm-cpu.cmake`** — identical to the default Android toolchain except `-march=armv8-a`. Unlike the Linux/gcc side, NDK clang emits no LSE at all here, so no outline-atomics helper is involved.
- **`arm64-android-cpu-{debug,release}` presets** — compose the existing hidden `cpu-only` preset (QAIRT / Hexagon / OpenCL off, `GENIEX_CPU_ONLY=ON`), so the startup HWCAP check is compiled out rather than failing on a device it can no longer describe.
- **CI** — a fifth `build-sdk` leg (`android-arm64-cpu`) plus a `variant` matrix on `_build-android-aar.yml`. **The gradle project needs no changes**: `copyBridgeLibs` copies whatever `lib/` subdirs `sdk/pkg-geniex` ships, so the CPU-only package's absent `qairt/` simply yields fewer jniLibs, and `GenieXSdk.kt` only `System.loadLibrary("npu_jni")` — plugins are `dlopen`'d by the registry.
- **Release** — adds `geniex-android-aar-cpu-<tag>.aar`. Deliberately *not* added: a CPU-only `geniex-bench` archive (no device in the benchmark fleet needs one) and a second Maven Central coordinate (a product decision, so the CPU-only AAR ships via release assets only).
- **Docs** — EN + CN troubleshooting entries and `notes/build.md`.

Same `com.geniex.sdk` namespace and API, so it is a drop-in replacement on affected devices.

## Test plan

Built in `docker.io/qualcomm/geniex-toolchain-android:v0.1.0`, installed to a scratch prefix:

- [x] `cmake --preset arm64-android-cpu-release` configures and builds clean
- [x] `GENIEX_CPU_ONLY` reaches the compiler — `-DGENIEX_CPU_ONLY` and `-march=armv8-a` both present in `geniex.dir/flags.make`
- [x] the HWCAP guard is gone — `nm -uC ml.cpp.o | grep -c getauxval` = 0
- [x] no LSE instructions in `libgeniex.so`, `libllama.so`, `libggml-cpu.so`
- [x] no `sdot`/`udot`/`smmla`/`ummla`/`usmmla`/`fmlal`/`bfdot`/`bfmmla` in `libggml-cpu.so`
- [x] install tree carries no `qairt/`, `hexagon`, `opencl`, `Qnn*` or `htp` files
- [x] `file` reports `ELF 64-bit … ARM aarch64`, interpreter `/system/bin/linker64`
- [x] release CI green end to end on `v0.4.1-alpha.3` — run [32356785568](https://github.com/qualcomm/GenieX/actions/runs/32356785568), 22/22 jobs, including `build-sdk / android-arm64-cpu` and `build-android-aar / cpu`; `geniex-android-aar-cpu-v0.4.1-alpha.3.aar` is on the draft release
- [ ] **not** yet exercised on a physical armv8.0 Android device — the ISA claims above are static analysis of the shipped `.so` files, not a device run

## Notes for reviewers

Stacked on #1340 — base is `feat/david/armv8-baseline-build` so this diff shows only the three Android commits. GitHub will retarget it to `main` when #1340 merges.

Refs #1217
