### PR TITLE
docs(docs): document multi-HTP device list in MTP tutorial and CLI reference

### DIFF
--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -71,6 +71,13 @@ geniex infer unsloth/Qwen3.5-0.8B-GGUF --compute cpu
 geniex infer ai-hub-models/Qwen3-4B --compute npu
 ```
 
+```bash
+# 显式设备列表——分散到多个 HTP 核心（仅限 llama.cpp + 多 DSP 设备）
+GGML_HEXAGON_NDEV=4 geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute HTP0,HTP1,HTP2,HTP3
+```
+
+<Note>将 `GGML_HEXAGON_NDEV` 设置为与 `--compute` 中设备 ID 数量一致。`qairt` 模型会将设备列表强制转为 NPU 并输出警告。性能数据参见 [MTP 教程](/en/tutorials/speculative-decoding-mtp#spreading-across-multiple-htp-cores)。</Note>
+
 <Warning>Qualcomm AI Hub 模型仅在 NPU 上运行。使用 `--compute cpu` 或 `--compute gpu` 会返回错误。</Warning>
 
 ### **`geniex infer` — VLM**

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -71,6 +71,13 @@ geniex infer unsloth/Qwen3.5-0.8B-GGUF --compute cpu
 geniex infer ai-hub-models/Qwen3-4B --compute npu
 ```
 
+```bash
+# Explicit device list — spread across multiple HTP cores (llama.cpp + multi-DSP devices only)
+GGML_HEXAGON_NDEV=4 geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 --compute HTP0,HTP1,HTP2,HTP3
+```
+
+<Note>Set `GGML_HEXAGON_NDEV` to match the number of device IDs in `--compute`. `qairt` models coerce a device list to NPU with a warning. See [Spreading across multiple HTP cores](/en/tutorials/speculative-decoding-mtp#spreading-across-multiple-htp-cores) for MTP performance numbers.</Note>
+
 <Warning>Qualcomm AI Hub Models run on NPU only. Using `--compute cpu` or `--compute gpu` returns an error.</Warning>
 
 ### **`geniex infer` — VLM**

--- a/docs/en/tutorials/speculative-decoding-mtp.mdx
+++ b/docs/en/tutorials/speculative-decoding-mtp.mdx
@@ -102,19 +102,6 @@ GGML_HEXAGON_NDEV=4 geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 \
   --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0
 ```
 
-The model-loaded line confirms all four are active:
-
-```text
-Model loaded: runtime=llama_cpp compute=htp0,htp1,htp2,htp3 ngl=-1 nctx=8192
-```
-
-Perf on Snapdragon X2 Elite (Glymur), Gemma4-26B Q4_0 + MTP, 256 decode tokens:
-
-| `--nctx` | Decode tok/s | MTP accept |
-|---|---|---|
-| 8192  | 10.6 | 53.7% |
-| 16384 | 11.2 | 53.9% |
-
 <Note>The device list bypasses the `npu` / `hybrid` aliases — `npu` pins `HTP0` alone, while a comma-separated list distributes across all named cores. `qairt` models coerce a device list to NPU with a warning.</Note>
 
 ## **Next steps**

--- a/docs/en/tutorials/speculative-decoding-mtp.mdx
+++ b/docs/en/tutorials/speculative-decoding-mtp.mdx
@@ -91,6 +91,32 @@ Paste this straight into the built-in Swagger UI at `http://127.0.0.1:18181` to 
 
 <Note>The `spec_*` fields are part of the model cache key, so changing any of them rebuilds the model on the next request. Keep them stable across a run.</Note>
 
+## **Spreading across multiple HTP cores**
+
+On devices with multiple DSP subsystems (e.g. Snapdragon X2 Elite with four HTP cores), you can spread the workload by passing a comma-separated device list to `--compute`. Set `GGML_HEXAGON_NDEV` to the number of device IDs so the Hexagon backend opens all of them:
+
+```bash
+GGML_HEXAGON_NDEV=4 geniex infer google/gemma-4-26B-A4B-it-qat-q4_0-gguf:Q4_0 \
+  --compute HTP0,HTP1,HTP2,HTP3 \
+  --spec-type draft-mtp \
+  --draft-model RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf:Q4_0
+```
+
+The model-loaded line confirms all four are active:
+
+```text
+Model loaded: runtime=llama_cpp compute=htp0,htp1,htp2,htp3 ngl=-1 nctx=8192
+```
+
+Perf on Snapdragon X2 Elite (Glymur), Gemma4-26B Q4_0 + MTP, 256 decode tokens:
+
+| `--nctx` | Decode tok/s | MTP accept |
+|---|---|---|
+| 8192  | 10.6 | 53.7% |
+| 16384 | 11.2 | 53.9% |
+
+<Note>The device list bypasses the `npu` / `hybrid` aliases — `npu` pins `HTP0` alone, while a comma-separated list distributes across all named cores. `qairt` models coerce a device list to NPU with a warning.</Note>
+
 ## **Next steps**
 
 - [CLI reference](/en/run/cli/reference) — every `geniex infer` flag.


### PR DESCRIPTION
## Summary

- Adds a **"Spreading across multiple HTP cores"** section to the MTP speculative-decoding tutorial, covering:
  - The `GGML_HEXAGON_NDEV=N` env var (must match the number of device IDs in `--compute`)
  - Example command with `--compute HTP0,HTP1,HTP2,HTP3 --spec-type draft-mtp`
  - Load-line confirmation and perf table from the PR #1361 test evidence (Snapdragon X2 Elite, Gemma4-26B Q4_0 + MTP, ~53% draft accept at 8K–16K context)
- Updates the `--compute` section in the **English and Chinese CLI references** to show the device-list syntax, a `GGML_HEXAGON_NDEV` note, and a link to the new tutorial section.

Follows up on #1361.

## Test plan

- [x] MDX files are syntactically valid (no unclosed tags, no nav changes needed)
- [x] `docs.json` unchanged — adding a section inside an existing page requires no nav edit