### PR TITLE
fix(sdk): retry transient QDC 5xx during job status/log polling

### DIFF
--- a/sdk/benchmark/qdc/_qdc.py
+++ b/sdk/benchmark/qdc/_qdc.py
@@ -58,7 +58,7 @@ def _is_quota_error(exc: Exception) -> bool:
     return any(h in msg for h in _QUOTA_HINTS)
 
 
-# QDC's status/log endpoints occasionally blip with a 5xx (mostly 504
+# QDC's upload/status/log endpoints occasionally blip with a 5xx (mostly 504
 # Gateway Time-out, some 500) with no fault on our side; retrying the same
 # call a few seconds later almost always succeeds. Unlike the pending-job
 # quota, this isn't capacity we need to wait out, so the retry is short.
@@ -175,7 +175,13 @@ def submit_and_wait(
 ) -> str:
     """Upload the artifact, submit the job (retrying on quota), and block until terminal."""
     log.info("uploading artifact (%d MB)", zip_path.stat().st_size // 1_000_000)
-    artifact_id = qdc_api.upload_file(client, str(zip_path), ArtifactType.TESTSCRIPT)
+    artifact_id = _call_with_retry(
+        qdc_api.upload_file,
+        client,
+        str(zip_path),
+        ArtifactType.TESTSCRIPT,
+        what="upload artifact",
+    )
     job_id = _submit_with_retry(
         client,
         target_id=target_id,

--- a/sdk/benchmark/qdc/_qdc.py
+++ b/sdk/benchmark/qdc/_qdc.py
@@ -11,8 +11,10 @@ plumbing lives here so neither caller reimplements it.
 
 from __future__ import annotations
 
+import json
 import logging
 import random
+import re
 import time
 import zipfile
 from pathlib import Path
@@ -32,9 +34,12 @@ log = logging.getLogger(__name__)
 
 POLL_INTERVAL = 30
 LOG_UPLOAD_TIMEOUT = 600
-SUBMIT_RETRY_BUDGET = 3600
+SUBMIT_RETRY_BUDGET = 7200
 SUBMIT_BACKOFF_BASE = 30
 SUBMIT_BACKOFF_CAP = 300
+TRANSIENT_RETRY_ATTEMPTS = 5
+TRANSIENT_BACKOFF_BASE = 10
+TRANSIENT_BACKOFF_CAP = 60
 
 FRAMEWORK = {
     "linux": TestFramework.BASH,
@@ -51,6 +56,43 @@ _QUOTA_HINTS = ("pending jobs", "too many", "quota", "limit", "capacity")
 def _is_quota_error(exc: Exception) -> bool:
     msg = str(exc).lower()
     return any(h in msg for h in _QUOTA_HINTS)
+
+
+# QDC's status/log endpoints occasionally blip with a 5xx (mostly 504
+# Gateway Time-out, some 500) with no fault on our side; retrying the same
+# call a few seconds later almost always succeeds. Unlike the pending-job
+# quota, this isn't capacity we need to wait out, so the retry is short.
+# A 504's body is an empty/HTML gateway page rather than JSON, and the SDK's
+# try_call() does a bare json.loads() on it without checking the status code
+# first, so the observable symptom is often a JSONDecodeError rather than an
+# exception that mentions "status code 5xx".
+_TRANSIENT_STATUS_RE = re.compile(r"status code 5\d\d\b")
+
+
+def _is_transient_error(exc: Exception) -> bool:
+    if isinstance(exc, json.JSONDecodeError):
+        return True
+    return bool(_TRANSIENT_STATUS_RE.search(str(exc)))
+
+
+def _call_with_retry(fn, *args, what: str, **kwargs):
+    attempt = 0
+    while True:
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if not _is_transient_error(exc) or attempt >= TRANSIENT_RETRY_ATTEMPTS:
+                raise
+            sleep = min(TRANSIENT_BACKOFF_CAP, TRANSIENT_BACKOFF_BASE * 2**attempt)
+            log.warning(
+                "%s hit a transient error (attempt %d): %s; retrying in %ds",
+                what,
+                attempt + 1,
+                exc,
+                sleep,
+            )
+            time.sleep(sleep)
+            attempt += 1
 
 
 def make_client(api_key: str):
@@ -73,7 +115,9 @@ def _wait_for_job(client, job_id: str, timeout: int) -> str:
     terminal = {JobState.COMPLETED, JobState.CANCELED}
     elapsed = 0
     while elapsed < timeout:
-        raw = qdc_api.get_job_status(client, job_id)
+        raw = _call_with_retry(
+            qdc_api.get_job_status, client, job_id, what="job status poll"
+        )
         try:
             state = JobState(raw)
         except ValueError:
@@ -90,7 +134,11 @@ def _wait_for_job(client, job_id: str, timeout: int) -> str:
 def _submit_with_retry(client, **submit_kwargs) -> str:
     # All max-parallel runners share the key's pending-job quota; instead of
     # crashing when it's full, back off (with jitter so the runners don't retry
-    # in lockstep) until a slot frees up or the budget runs out.
+    # in lockstep) until a slot frees up or the budget runs out. Under a full
+    # matrix run the quota realistically stays contested for closer to two
+    # hours than one (observed elapsed-before-giveup times up to ~54min on a
+    # 60min budget, with the "N pending" count still fluctuating rather than
+    # stuck), so the budget leaves comfortable room under the job's timeout.
     elapsed = 0
     attempt = 0
     while True:
@@ -165,7 +213,15 @@ def download_log_members(
     """
     elapsed = 0
     while elapsed < LOG_UPLOAD_TIMEOUT:
-        status = (qdc_api.get_job_log_upload_status(client, job_id) or "").lower()
+        status = (
+            _call_with_retry(
+                qdc_api.get_job_log_upload_status,
+                client,
+                job_id,
+                what="log upload status poll",
+            )
+            or ""
+        ).lower()
         if status in {"completed", "failed"}:
             break
         log.info("waiting for log upload (status=%s)", status)
@@ -173,11 +229,20 @@ def download_log_members(
         elapsed += POLL_INTERVAL
 
     out: list[tuple[str, bytes]] = []
-    for lf in qdc_api.get_job_log_files(client, job_id) or []:
+    log_files = _call_with_retry(
+        qdc_api.get_job_log_files, client, job_id, what="list job log files"
+    )
+    for lf in log_files or []:
         if not want(_basename(lf.filename)):
             continue
         dl = tmp / "log.bin"
-        qdc_api.download_job_log_files(client, lf.filename, str(dl))
+        _call_with_retry(
+            qdc_api.download_job_log_files,
+            client,
+            lf.filename,
+            str(dl),
+            what="download job log file",
+        )
         if zipfile.is_zipfile(dl):
             with zipfile.ZipFile(dl) as z:
                 for name in z.namelist():


### PR DESCRIPTION
## Summary

The `Geniex Bench` workflow has been failing on the large majority of its per-device/per-model jobs. Auditing [a recent run](https://github.com/qualcomm/GenieX/actions/runs/32382544204) (91 failing jobs) showed the dominant cause: QDC's job-status and log-download endpoints intermittently return a 504 (occasionally 500) with no fault on the caller's side, and `sdk/benchmark/qdc/_qdc.py` had no retry around those calls — a single blip crashed the whole benchmark cell even though the device job itself had already completed successfully.

A 504's response body isn't JSON, and the QDC SDK's `try_call()` does a bare `json.loads()` on it without checking the status code first, so the actual observed crash is usually a `JSONDecodeError` rather than an exception whose message mentions "status code 5xx" — that alone accounted for 38 of the 91 failing jobs in the audited run.

This PR adds a short, bounded retry (`_call_with_retry`) around the QDC calls in the polling/download/upload path that can hit this: `get_job_status`, `get_job_log_upload_status`, `get_job_log_files`, `download_job_log_files`, and (added after this PR's own `test-sdk-qdc` CI job hit the identical bug one call site over, mid-review) `upload_file`. It mirrors the existing retry pattern already used for job submission (`_submit_with_retry`), just with a much shorter backoff since this is a transient blip, not capacity to wait out.

Separately, the existing pending-job-quota submit retry (`_submit_with_retry`) was giving up after a 1-hour budget; in the same audited run several jobs were still retrying with a fluctuating (not stuck) pending-job count right up to that limit. Raised the budget to 2 hours, which still leaves comfortable room under the job's 355-minute timeout.

Not in scope: a handful of the 91 failures were genuine on-device functional failures unrelated to CI infra (e.g. a VLM `Multimodal generation failed` error code on `Qwen2.5-VL-7B-qairt`, and a `geniex-bench` non-zero exit on Android for a couple of models) — those need separate model/plugin-level investigation.

## Test plan

- [x] Reproduced the exact `JSONDecodeError` and `status code 5xx` exceptions from the failing run's logs against `_call_with_retry` locally — confirms both transient signatures are retried, a permanent error still raises immediately, and exhausting `TRANSIENT_RETRY_ATTEMPTS` still re-raises.
- [x] `test-sdk-qdc` (linux, windows, android) on this PR itself exercises `_qdc.py` against real QDC devices — one run hit a live `status code 500` during artifact upload before the second commit, confirming the fix is needed and covers this path too.