### PR TITLE
fix(sdk): align llama_cpp MTP speculative decode with llama.cpp

### DIFF
--- a/sdk/CMakePresets.json
+++ b/sdk/CMakePresets.json
@@ -28,6 +28,7 @@
         "GENIEX_PLUGIN_LLAMA_CPP": "ON",
         "GGML_HEXAGON": "ON",
         "GGML_OPENCL": "ON",
+        "GGML_OPENMP": "OFF",
         "GENIEX_PLUGIN_QAIRT": "ON",
         "GENIEX_BENCHMARK": "ON",
         "CMAKE_PREFIX_PATH": "$env{OPENCL_SDK_ROOT}",
@@ -45,6 +46,7 @@
         "GENIEX_PLUGIN_QAIRT": "OFF",
         "GGML_HEXAGON": "OFF",
         "GGML_OPENCL": "OFF",
+        "GGML_OPENMP": "OFF",
         "GENIEX_BENCHMARK": "ON",
         "GENIEX_CPU_ONLY": "ON"
       }

--- a/sdk/plugins/llama_cpp/include/llm.h
+++ b/sdk/plugins/llama_cpp/include/llm.h
@@ -63,7 +63,8 @@ class LlamaLlm : public ILlm {
    private:
     void set_sampler(const geniex_SamplerConfig* cfg);
 
-    int32_t setup_speculative(const geniex_ModelConfig& config, Device device, const char* device_id);
+    int32_t setup_speculative(
+        const geniex_ModelConfig& config, Device device, const char* device_id, common_params_speculative& spar);
     void    teardown_speculative();
     int32_t decode_speculative(const geniex_GenerationConfig& cfg, const std::vector<llama_token>& prompt_ids,
         const std::function<bool(llama_token)>& emit, const std::function<int()>& n_generated,

--- a/sdk/plugins/llama_cpp/include/params.h
+++ b/sdk/plugins/llama_cpp/include/params.h
@@ -38,8 +38,19 @@ Device classify_device(const char* device_id, int n_gpu_layers);
 // the upstream-fixed count; pure CPU uses cores/2). build_model_params only
 // reads n_gpu_layers. Device selection and tensor-buffer overrides stay at the
 // call site.
+//
+// spec is the parsed speculative config (nullptr when disabled, and always
+// nullptr for the draft context itself): a target context that drafts needs
+// n_max recurrent-state snapshots to roll back rejected drafts and one logits
+// row per drafted token. Mirrors common_context_params_to_llama +
+// server_output_limits.
 llama_model_params   build_model_params(const geniex_ModelConfig& config, Device device);
-llama_context_params build_context_params(const geniex_ModelConfig& config, int32_t n_ctx_default, Device device);
+llama_context_params build_context_params(const geniex_ModelConfig& config, int32_t n_ctx_default, Device device,
+    const common_params_speculative* spec = nullptr);
+
+// Parse spec_type / spec_n_* into llama.cpp's own speculative params. Returns
+// nullopt when speculative decoding is disabled or no type name resolves.
+std::optional<common_params_speculative> build_speculative_params(const geniex_ModelConfig& config);
 
 // Build threadpool tuning (cpumask / strict / poll) for a given thread count
 // on the given target device. Returned struct is what ggml_threadpool_new

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -95,7 +95,11 @@ int32_t LlamaLlm::create(const geniex_LlmCreateInput* input) {
         return GENIEX_ERROR_COMMON_MODEL_LOAD;
     }
 
-    llama_context_params cpar = build_context_params(config, /*n_ctx_default=*/4096, device);
+    // Parse the speculative config before the target context: a drafting target
+    // needs its rollback snapshots and per-draft logits rows sized up front.
+    std::optional<common_params_speculative> spar = build_speculative_params(config);
+
+    llama_context_params cpar = build_context_params(config, /*n_ctx_default=*/4096, device, spar ? &*spar : nullptr);
     this->ctx                 = llama_init_from_model(this->model, cpar);
     if (!this->ctx) {
         return GENIEX_ERROR_COMMON_MODEL_LOAD;
@@ -110,8 +114,8 @@ int32_t LlamaLlm::create(const geniex_LlmCreateInput* input) {
 
     // Speculative decoding: optional, keyed on a non-empty spec_type ("none" also
     // disables). Failure is non-fatal — we log and fall back to plain decoding.
-    if (config.spec_type && config.spec_type[0] != '\0' && strcmp(config.spec_type, "none") != 0) {
-        int32_t spec_ret = setup_speculative(config, device, input->device_id);
+    if (spar) {
+        int32_t spec_ret = setup_speculative(config, device, input->device_id, *spar);
         if (spec_ret != GENIEX_SUCCESS) {
             GENIEX_LOG_WARN("speculative decoding setup failed; falling back to plain decoding");
             teardown_speculative();
@@ -698,25 +702,15 @@ void LlamaLlm::teardown_speculative() {
     this->spec_n_max = 0;
 }
 
-int32_t LlamaLlm::setup_speculative(const geniex_ModelConfig& config, Device device, const char* device_id) {
-    std::vector<common_speculative_type> types =
-        common_speculative_types_from_names(string_split<std::string>(config.spec_type, ','));
-    types.erase(std::remove(types.begin(), types.end(), COMMON_SPECULATIVE_TYPE_NONE), types.end());
-    if (types.empty()) {
-        GENIEX_LOG_ERROR("unrecognized --spec-type: '{}'", config.spec_type);
-        return GENIEX_ERROR_COMMON_INVALID_INPUT;
-    }
-
-    const bool needs_draft = std::any_of(types.begin(), types.end(), [](common_speculative_type t) {
+int32_t LlamaLlm::setup_speculative(
+    const geniex_ModelConfig& config, Device device, const char* device_id, common_params_speculative& spar) {
+    const bool needs_draft = std::any_of(spar.types.begin(), spar.types.end(), [](common_speculative_type t) {
         return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP || t == COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 ||
                t == COMMON_SPECULATIVE_TYPE_DRAFT_SIMPLE;
     });
+    const bool is_mtp =
+        std::find(spar.types.begin(), spar.types.end(), COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != spar.types.end();
 
-    common_params_speculative spar;
-    spar.types       = types;
-    spar.draft.n_max = config.spec_n_max > 0 ? config.spec_n_max : 3;
-    if (config.spec_n_min > 0) spar.draft.n_min = config.spec_n_min;
-    if (config.spec_p_min > 0) spar.draft.p_min = config.spec_p_min;
     spar.draft.ctx_tgt = this->ctx;
     this->spec_n_max   = spar.draft.n_max;
 
@@ -738,13 +732,17 @@ int32_t LlamaLlm::setup_speculative(const geniex_ModelConfig& config, Device dev
             return GENIEX_ERROR_COMMON_MODEL_LOAD;
         }
 
+        // Mirrors common_base_params_to_speculative: the draft context inherits
+        // the target's params verbatim; only the MTP wiring, the disabled
+        // rollback and the single-output limits differ.
         llama_context_params dcpar = build_context_params(config, /*n_ctx_default=*/4096, device);
-        dcpar.ctx_type             = LLAMA_CONTEXT_TYPE_MTP;
-        dcpar.ctx_other            = this->ctx;
-        dcpar.n_rs_seq             = 0;
-        const uint32_t draft_batch = std::max<uint32_t>(64, static_cast<uint32_t>(this->spec_n_max));
-        dcpar.n_batch              = draft_batch;
-        dcpar.n_ubatch             = draft_batch;
+        if (is_mtp) {
+            dcpar.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+        }
+        dcpar.ctx_other             = this->ctx;
+        dcpar.n_rs_seq              = 0;
+        dcpar.n_outputs_max         = dcpar.n_seq_max;
+        dcpar.n_outputs_max_per_seq = 1;
 
         this->draft_ctx = llama_init_from_model(this->draft_model, dcpar);
         if (!this->draft_ctx) {

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -662,10 +662,14 @@ int32_t LlamaLlm::decode_speculative(const geniex_GenerationConfig& cfg, const s
         }
         this->n_past += (int)n_accept + 1;
 
-        // Drop any rejected draft tail from both KV caches.
-        llama_memory_seq_rm(mem_tgt, seq_id, this->n_past, -1);
-        if (mem_dft) {
-            llama_memory_seq_rm(mem_dft, seq_id, this->n_past, -1);
+        // Drop any rejected draft tail from both KV caches. Nothing to drop when
+        // the target agreed with the whole draft, and seq_rm is not free on the
+        // HTP backend, so skip it then — same guard as the server's n_rollback.
+        if (n_accept < draft.size()) {
+            llama_memory_seq_rm(mem_tgt, seq_id, this->n_past, -1);
+            if (mem_dft) {
+                llama_memory_seq_rm(mem_dft, seq_id, this->n_past, -1);
+            }
         }
 
         id_last = ids.back();

--- a/sdk/plugins/llama_cpp/src/params.cpp
+++ b/sdk/plugins/llama_cpp/src/params.cpp
@@ -147,8 +147,11 @@ llama_context_params build_context_params(
 }
 
 ggml_threadpool_params build_threadpool_params(int n_threads, Device device) {
+    // Linux / NPU stays unpinned: strict-pinning 6 threads to cores 2-7 halves
+    // HTP decode throughput on Snapdragon X2 Elite (10.6 vs 20.1 tok/s), and
+    // llama.cpp's own Snapdragon Linux runs never pin.
     static const bool pin_matrix[3][3] = {
-        {false, true, true},    // Linux
+        {false, true, false},   // Linux
         {false, false, false},  // Windows
         {true, true, true}      // Android
     };

--- a/sdk/plugins/llama_cpp/src/params.cpp
+++ b/sdk/plugins/llama_cpp/src/params.cpp
@@ -3,6 +3,7 @@
 
 #include "params.h"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <sstream>
@@ -10,6 +11,7 @@
 #include <thread>
 
 #include "logging.h"
+#include "speculative.h"
 
 namespace geniex {
 
@@ -68,7 +70,29 @@ llama_model_params build_model_params(const geniex_ModelConfig& config, Device d
     return mpar;
 }
 
-llama_context_params build_context_params(const geniex_ModelConfig& config, int32_t n_ctx_default, Device device) {
+std::optional<common_params_speculative> build_speculative_params(const geniex_ModelConfig& config) {
+    if (!config.spec_type || config.spec_type[0] == '\0' || strcmp(config.spec_type, "none") == 0) {
+        return std::nullopt;
+    }
+
+    std::vector<common_speculative_type> types =
+        common_speculative_types_from_names(string_split<std::string>(config.spec_type, ','));
+    types.erase(std::remove(types.begin(), types.end(), COMMON_SPECULATIVE_TYPE_NONE), types.end());
+    if (types.empty()) {
+        GENIEX_LOG_ERROR("unrecognized --spec-type: '{}'", config.spec_type);
+        return std::nullopt;
+    }
+
+    common_params_speculative spar;
+    spar.types       = types;
+    spar.draft.n_max = config.spec_n_max > 0 ? config.spec_n_max : 3;
+    if (config.spec_n_min > 0) spar.draft.n_min = config.spec_n_min;
+    if (config.spec_p_min > 0) spar.draft.p_min = config.spec_p_min;
+    return spar;
+}
+
+llama_context_params build_context_params(
+    const geniex_ModelConfig& config, int32_t n_ctx_default, Device device, const common_params_speculative* spec) {
     static const uint32_t ubatch_matrix[3][3] = {
         {2048, 512, 1024},  // Linux
         {2048, 512, 1024},  // Windows
@@ -94,9 +118,18 @@ llama_context_params build_context_params(const geniex_ModelConfig& config, int3
     cpar.flash_attn_type      = static_cast<llama_flash_attn_type>(fa);
     cpar.no_perf              = false;
 
+    if (spec) {
+        cpar.n_rs_seq     = spec->need_n_rs_seq();
+        const auto limits = common_speculative_get_output_limits(
+            static_cast<int32_t>(cpar.n_batch), static_cast<int32_t>(cpar.n_seq_max), common_speculative_n_max(spec));
+        cpar.n_outputs_max         = std::max<int32_t>(1, limits.total);
+        cpar.n_outputs_max_per_seq = std::max<int32_t>(1, limits.per_seq);
+    }
+
     GENIEX_LOG_INFO(
         "[Optimise] context params: n_ctx={}, n_batch={}, n_ubatch={}, n_seq_max={}, n_threads={}, "
-        "n_threads_batch={}, flash_attn_type={}, swa_full={}, kv_unified={}, no_perf={}",
+        "n_threads_batch={}, flash_attn_type={}, swa_full={}, kv_unified={}, no_perf={}, n_rs_seq={}, "
+        "n_outputs_max={}, n_outputs_max_per_seq={}",
         cpar.n_ctx,
         cpar.n_batch,
         cpar.n_ubatch,
@@ -106,7 +139,10 @@ llama_context_params build_context_params(const geniex_ModelConfig& config, int3
         static_cast<int>(cpar.flash_attn_type),
         cpar.swa_full,
         cpar.kv_unified,
-        cpar.no_perf);
+        cpar.no_perf,
+        cpar.n_rs_seq,
+        cpar.n_outputs_max,
+        cpar.n_outputs_max_per_seq);
     return cpar;
 }
 


### PR DESCRIPTION
`--spec-type draft-mtp` decoded well below `llama-server` built from the same pinned `third-party/llama.cpp`. Per-phase timing inside `decode_speculative` showed no CPU-side overhead — the whole verification step was the target's `llama_decode`, and only *batched* forwards were slow (the single-token forward was already faster than llama.cpp's). That pointed at the build config rather than the plugin logic.

- **build ggml without OpenMP** — `GGML_OPENMP` defaulted to ON, so ggml-cpu ran its graphs in OpenMP parallel regions and ignored the threadpool the plugin attaches; `build_threadpool_params`' `n_threads=6` / `poll=1000` never applied. Dominant cost: 21.7 → 30.3 tok/s.
- **stop strict-pinning HTP worker threads to cores 2-7 on Linux** — 19.9 → 21.7 tok/s; driving `llama-server` with the same mask reproduces the slowdown.
- **mirror llama.cpp's speculative context construction** — `n_rs_seq` and the per-draft logits rows now come from the parsed spec config, and the draft context inherits the target's batch geometry instead of a hardcoded 64. Faithfulness fix; no measurable delta on gemma-4-26B.
- **only roll back the KV tail when a draft was actually rejected** — same guard as the server's `n_rollback > 0`.

`GGML_OPENMP=OFF` lands on the shared `snapdragon` and `cpu-only` presets, matching llama.cpp on all three platforms; the thread-pinning change is Linux/NPU only.

## Test plan

`gemma-4-26B-A4B-it` Q4_0 + its MTP head on Snapdragon X2 Elite (Debian 13, 4x HTP), greedy, thinking on, against `llama-server` at the same submodule revision.

- [x] 4267-tok prompt: decode **19.9 → 30.3 tok/s**, **+18% over `llama-server`** (25.7); prefill (638 → 632) and draft acceptance (94.1%) unchanged, so the win is entirely per-verification-step cost
- [x] Per-knob ablation attributes each commit: 19.9 (main) → 21.7 (no-pin + ctx params) → 30.3 (also no OpenMP)
- [x] Context sweep 260 / 4.3k / 7.3k / 14.8k / 29.5k-token prompts at ctx 8k-64k: geniex ahead on prefill everywhere and on decode from 4k up, and its per-step cost grows +31% across that range against llama.cpp's +64%
- [x] Non-speculative decode unaffected (13.1 vs llama.cpp 11.2 tok/s)
- [x] 260-tok prompt is the one regression vs llama.cpp: 23.9 vs 24.5 tok/s (acceptance matched at 58.9% vs 58.8%)
- [x] Windows ARM64 / Android not measured — `GGML_OPENMP=OFF` reaches them through the shared preset