### PR TITLE
fix(server): honour deprecated max_tokens in chat completions

### DIFF
--- a/cli/server/docs/swagger.yaml
+++ b/cli/server/docs/swagger.yaml
@@ -329,6 +329,11 @@ components:
           minimum: 1
           description: An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.
           default: 2048
+        max_tokens:
+          type: integer
+          minimum: 1
+          description: "Deprecated alias for `max_completion_tokens`, accepted for compatibility with older OpenAI clients. Ignored when `max_completion_tokens` is also present."
+          deprecated: true
         temperature:
           type: number
           format: float

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -60,7 +60,8 @@ func defaultChatCompletionRequest() ChatCompletionRequest {
 	cfg := config.Get()
 	return ChatCompletionRequest{
 		ChatCompletionNewParams: ChatCompletionNewParams{
-			MaxCompletionTokens: param.NewOpt[int64](2048),
+			// On the deprecated alias, so an explicit max_completion_tokens wins.
+			MaxTokens: param.NewOpt[int64](2048),
 		},
 		Stream: false,
 
@@ -76,17 +77,6 @@ func defaultChatCompletionRequest() ChatCompletionRequest {
 	}
 }
 
-func isWarmupRequest(param ChatCompletionRequest) bool {
-	if len(param.Messages) == 0 {
-		return true
-	}
-	if len(param.Messages) != 1 {
-		return false
-	}
-	r := param.Messages[0].GetRole()
-	return r != nil && *r == "system"
-}
-
 func ChatCompletions(c *gin.Context) {
 	param := defaultChatCompletionRequest()
 	if err := c.ShouldBindJSON(&param); err != nil {
@@ -94,6 +84,8 @@ func ChatCompletions(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, map[string]any{"error": err.Error()})
 		return
 	}
+	// max_tokens is the deprecated alias; below reads MaxCompletionTokens only.
+	param.MaxCompletionTokens = openai.Int(param.MaxCompletionTokens.Or(param.MaxTokens.Value))
 
 	slog.Info("ChatCompletions", "param", param)
 	name, _ := geniex_sdk.SplitNamePrecision(param.Model)
@@ -221,7 +213,7 @@ func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param C
 			PromptUTF8: prompt,
 			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
-				MaxTokens:      int32(param.MaxCompletionTokens.Value),
+				MaxTokens:     int32(param.MaxCompletionTokens.Value),
 				SamplerConfig: sampler,
 				ImagePaths:    images,
 				AudioPaths:    audios,
@@ -253,7 +245,12 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 	if writeKeepAliveError(c, err) {
 		return
 	}
-	if isWarmupRequest(param) {
+	// Warm-up: no messages, or a lone system message — model loaded, nothing to generate.
+	var role *string
+	if len(param.Messages) == 1 {
+		role = param.Messages[0].GetRole()
+	}
+	if len(param.Messages) == 0 || role != nil && *role == "system" {
 		c.JSON(http.StatusOK, nil)
 		return
 	}

--- a/cli/server/handler/chat_test.go
+++ b/cli/server/handler/chat_test.go
@@ -4,6 +4,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -52,4 +53,30 @@ func TestSinks(t *testing.T) {
 			t.Errorf("content = %q, want raw inline", got)
 		}
 	})
+}
+
+// Mirrors the alias collapse ChatCompletions applies after binding.
+func TestMaxCompletionTokensAlias(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int64
+	}{
+		{"no cap in body falls back to default", `{}`, 2048},
+		{"max_completion_tokens honoured", `{"max_completion_tokens":512}`, 512},
+		{"deprecated max_tokens honoured", `{"max_tokens":512}`, 512},
+		{"max_completion_tokens wins over max_tokens", `{"max_tokens":512,"max_completion_tokens":128}`, 128},
+		{"explicit null falls back to default", `{"max_tokens":null}`, 2048},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := defaultChatCompletionRequest()
+			if err := json.Unmarshal([]byte(tc.body), &p); err != nil {
+				t.Fatalf("unmarshal %s: %v", tc.body, err)
+			}
+			if got := p.MaxCompletionTokens.Or(p.MaxTokens.Value); got != tc.want {
+				t.Errorf("cap = %d, want %d", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`serve` silently ignored `max_tokens` on `/v1/chat/completions`. A user benchmarking gemma4-e4b on QAIRT sent `max_tokens: 512` and got completions of ~1300 tokens.

`defaultChatCompletionRequest` pre-filled `MaxCompletionTokens`, so that field was always `Valid()` and won the priority chain — a body setting only `max_tokens` (OpenAI's deprecated alias, still sent by plenty of clients) never got a look in, and the cap fell back to the 2048 default. The `NCtx` floor at `chat.go:131` was bypassed the same way.

`param.Opt` has only two states, so a pre-filled field is indistinguishable from an explicit one — which effectively promotes the default to that field's priority. The fix moves the default onto `MaxTokens`, the *lower*-priority field, where merging is lossless: an explicit `max_tokens` overrides it, and an explicit `max_completion_tokens` still wins over both. The chain then collapses to one line via `Opt.Or()`, and `MaxCompletionTokens` remains the only cap field the rest of the handler reads.

Drive-by: inlined `isWarmupRequest` into its single call site, and one pre-existing gofmt misalignment in `prepareVLM`.

Reported against v0.4.1-alpha.2 (QCS9075 EVK, QAIRT 2.45.0.260326). Note this only fixes the CLI side — whether the cap is enforced also depends on the plugin honouring `GenerationConfig.max_tokens`, which the llama.cpp path can be used to isolate.

## Test plan

- [x] `bazelisk test //cli/server/...` — 6 passed, 3 windows-skipped
- [x] New `TestMaxCompletionTokensAlias`: default, each spelling alone, both present (`max_completion_tokens` wins), explicit `null`
- [x] Reverse-verified the test catches the original bug — restoring the pre-filled `MaxCompletionTokens` fails `deprecated max_tokens honoured` with `cap = 2048, want 512`
- [x] `gofmt` clean


Closes [qcom-ai-hub/geniex#1483](https://github.com/qcom-ai-hub/geniex/issues/1483).
