### PR TITLE
fix(cli): restore the local precision picker for infer

### DIFF
--- a/cli/cmd/geniex/BUILD.bazel
+++ b/cli/cmd/geniex/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "@com_github_spf13_viper//:viper",
         "@org_golang_x_mod//semver",
         "@org_golang_x_sync//errgroup",
+        "@org_golang_x_term//:term",
     ],
 )
 

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -114,7 +114,7 @@ func infer() *cobra.Command {
 		GroupID: "inference",
 		Use:     "infer <model-name>[:<precision>]",
 		Short:   "Infer with a model",
-		Long:    "Run inference with a specified model. The model must be downloaded and cached locally. Append ':<precision>' to pick a specific precision; otherwise you'll be prompted to choose one.",
+		Long:    "Run inference with a specified model. The model must be downloaded and cached locally. Append ':<precision>' to pick a specific precision; otherwise you'll be prompted to choose one when several are cached.",
 	}
 
 	inferCmd.Args = cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
@@ -126,6 +126,14 @@ func infer() *cobra.Command {
 
 	inferCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		name, precision := geniex_sdk.SplitNamePrecision(args[0])
+
+		if precision == "" {
+			chosen, err := pickCachedPrecision(name)
+			if err != nil {
+				return err
+			}
+			precision = chosen
+		}
 
 		paths, err := ensureModelAvailable(cmd.Context(), name, precision)
 		if err != nil {
@@ -186,6 +194,44 @@ func ensureModelAvailable(ctx context.Context, name, quant string) (*geniex_sdk.
 		paths, err = geniex_sdk.ModelGetPaths(key)
 	}
 	return paths, err
+}
+
+// pickCachedPrecision asks which of a cached model's downloaded precisions to
+// run, returning "" when there is nothing to disambiguate.
+func pickCachedPrecision(name string) (string, error) {
+	m, err := geniex_sdk.ModelGetDetailed(name)
+	if err != nil {
+		return "", nil
+	}
+	precisions := downloadedPrecisions(*m, true)
+	if len(precisions) < 2 {
+		return "", nil
+	}
+
+	// ModelGetPaths on the bare name resolves the SDK's own pick; choosePrecision
+	// pre-selects the head, so that pick has to land there.
+	def, err := geniex_sdk.ModelGetPaths(name)
+	if err != nil {
+		return "", err
+	}
+	// Size is left unset: ModelDetail.TotalSize aggregates every downloaded
+	// precision, and the SDK does not expose the per-precision figure its
+	// manifest already holds.
+	candidates := make([]geniex_sdk.PrecisionCandidate, len(precisions))
+	head := 0
+	for i, p := range precisions {
+		candidates[i].Precision = p
+		mp, err := geniex_sdk.ModelGetPaths(name + ":" + p)
+		if err != nil {
+			continue
+		}
+		if mp.ModelPath == def.ModelPath {
+			head = i
+		}
+	}
+	candidates[0], candidates[head] = candidates[head], candidates[0]
+
+	return choosePrecision("Select a precision from local folder", candidates)
 }
 
 // resolveDraftModel maps a --draft-model value to a GGUF path the SDK can load.

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -20,6 +20,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
 	"github.com/qualcomm/GenieX/cli/internal/render"
@@ -427,7 +428,7 @@ func setTypeCmd() *cobra.Command {
 	}
 }
 
-func pullModel(ctx context.Context, name string, quant string) error {
+func pullModel(ctx context.Context, name, quant string) error {
 	slog.Debug("pullModel", "name", name, "quant", quant)
 
 	hub, err := resolveHub()
@@ -479,7 +480,7 @@ func pullModel(ctx context.Context, name string, quant string) error {
 		if err != nil {
 			return err
 		}
-		if chosen, err := choosePrecision(q.Candidates); err != nil {
+		if chosen, err := choosePrecision("Choose a precision version to download", q.Candidates); err != nil {
 			return err
 		} else {
 			in.Precision = chosen
@@ -546,31 +547,44 @@ func pullModel(ctx context.Context, name string, quant string) error {
 	return nil
 }
 
-// choosePrecision picks a precision from the remote candidates: the only one
-// when there's a single option, otherwise an interactive picker pre-filled
-// with candidates[0] (the SDK sorts by priority, so head is the recommended
-// pick).
-func choosePrecision(candidates []geniex_sdk.PrecisionCandidate) (string, error) {
+// hasTerminal reports whether a picker can be drawn: keys come from stdin, and
+// huh draws on stderr, so both have to be a terminal.
+func hasTerminal() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stderr.Fd()))
+}
+
+// choosePrecision picks a precision from candidates, whose head must be the
+// recommended pick: it is taken as-is when it is the only option or there is no
+// terminal to draw on, otherwise the picker pre-selects it.
+func choosePrecision(title string, candidates []geniex_sdk.PrecisionCandidate) (string, error) {
 	if len(candidates) == 0 {
 		return "", fmt.Errorf("no precision available for this model")
 	}
-	if len(candidates) == 1 {
+	if len(candidates) == 1 || !hasTerminal() {
 		return candidates[0].Precision, nil
 	}
 
+	// Sizes come from the remote query; a local pick has none, so drop the
+	// column rather than render a row of placeholders.
+	withSize := slices.ContainsFunc(candidates, func(c geniex_sdk.PrecisionCandidate) bool {
+		return c.Size > 0
+	})
 	options := make([]huh.Option[string], 0, len(candidates))
 	for _, c := range candidates {
-		sz := "—"
-		if c.Size > 0 {
-			sz = humanize.IBytes(uint64(c.Size))
+		label := c.Precision
+		if withSize {
+			sz := "—"
+			if c.Size > 0 {
+				sz = humanize.IBytes(uint64(c.Size))
+			}
+			label = fmt.Sprintf("%-10s [%7s]", c.Precision, sz)
 		}
-		label := fmt.Sprintf("%-10s [%7s]", c.Precision, sz)
 		options = append(options, huh.NewOption(label, c.Precision))
 	}
 
 	chosen := candidates[0].Precision
 	if err := huh.NewSelect[string]().
-		Title("Choose a precision version to download").
+		Title(title).
 		Options(options...).
 		Value(&chosen).
 		Run(); err != nil {


### PR DESCRIPTION
> Stacked on #1386 — it uses `geniex_model_get_detailed`, added there. Base is
> `feat/model-get-detailed`; review that one first.

## Summary

`infer` used to prompt *"Select a precision from local folder"* when a cached
model had more than one quant downloaded.
[#828](https://github.com/qcom-ai-hub/geniex/pull/828) (`73300d3f12`, routing
model management through the SDK model-manager) deleted `selectQuant` along with
the CLI's own manifest handling and nothing took its place — since then
`geniex infer <model>` silently runs whichever quant `QUANT_PRIORITY` heads, with
no way to pick short of spelling out `:<precision>`.

The deletion looks accidental: the hint for `ErrPrecisionNotFound`
(`common/error.go:105`, predating that PR) still tells users to *"Drop the
':\<precision\>' suffix to be prompted from what's already downloaded."*

This reuses pull's picker rather than reviving a second one. `choosePrecision`
takes a title and keeps one contract — **`candidates[0]` is the recommended
pick** — so `pickCachedPrecision` moves the precision the SDK resolves on its own
to the head, and a bare enter reproduces today's non-interactive default.

`hasTerminal()` guards the draw: huh renders its TUI on **stderr**
(`huh/form.go:112` passes `tea.WithOutput(os.Stderr)`), so both stdin and stderr
have to be a terminal — `geniex infer m 2>run.log` would otherwise send the whole
TUI into the log and look like an unexplained hang. That guard also fixes `pull`,
which had none: `geniex model pull org/repo` without `:<precision>` died with
`huh: could not open a new TTY` wherever there is no controlling terminal (CI).
`os.ModeCharDevice` is not usable here — `/dev/null` is a character device —
hence `term.IsTerminal`.

Behaviour to flag:

- Piping stdin into `model pull` no longer prompts; it takes the SDK's
  recommended precision.
- A one-shot `infer` **on a terminal** (`--prompt` / `--input` / `--token-file`)
  does prompt when several precisions are cached. Only the absence of a terminal
  suppresses the picker.

## Test plan

- [x] `bazelisk build //cli`; `bazelisk test //cli/cmd/... //cli/server/...` —
      8 passed, 5 windows-skipped
- [x] `gofmt` clean
- [ ] Interactive paths need re-verification after the rebase onto #1386
      (`pickCachedPrecision` now resolves through `ModelGetDetailed` instead of
      walking the store): picker selects a non-head precision; bare enter takes
      the SDK default; `2>log` takes the default without prompting; `model pull`
      under `< /dev/null` takes the head instead of failing on the TTY

Closes [qcom-ai-hub/geniex#1490](https://github.com/qcom-ai-hub/geniex/issues/1490).
