### PR TITLE
fix(cli): report a precision typo on infer instead of a generic SDK error

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -184,6 +185,9 @@ func ensureModelAvailable(ctx context.Context, name, quant string) (*geniex_sdk.
 	key := name
 	if quant != "" {
 		key = name + ":" + quant
+		if err := checkPrecisionDownloaded(name, quant); err != nil {
+			return nil, err
+		}
 	}
 	paths, err := geniex_sdk.ModelGetPaths(key)
 	if geniex_sdk.IsModelNotFound(err) {
@@ -194,6 +198,29 @@ func ensureModelAvailable(ctx context.Context, name, quant string) (*geniex_sdk.
 		paths, err = geniex_sdk.ModelGetPaths(key)
 	}
 	return paths, err
+}
+
+// checkPrecisionDownloaded reports ErrPrecisionNotFound when a cached model has
+// no such precision, so the sentinel's hint (list / pull / drop the suffix)
+// reaches the user instead of the SDK's generic invalid-input error. A model
+// that isn't cached at all passes: the caller pulls it.
+func checkPrecisionDownloaded(name, quant string) error {
+	m, err := geniex_sdk.ModelGetDetailed(name)
+	if err != nil {
+		return nil
+	}
+	precisions := downloadedPrecisions(*m, true)
+	// Nothing to match against (a runtime like qairt reports only N/A), so let
+	// the SDK judge the key.
+	if len(precisions) == 0 {
+		return nil
+	}
+	// GGUF quant labels are matched case-insensitively by the SDK.
+	if slices.ContainsFunc(precisions, func(p string) bool { return strings.EqualFold(p, quant) }) {
+		return nil
+	}
+	return fmt.Errorf("%w: %s has %s, not %q",
+		common.ErrPrecisionNotFound, name, strings.Join(precisions, ", "), quant)
 }
 
 // pickCachedPrecision asks which of a cached model's downloaded precisions to


### PR DESCRIPTION
## Summary

`common.ErrPrecisionNotFound` is dead code. It is declared at `cli/cmd/geniex/common/error.go:124` and its hint is registered at `:149`, but **nothing in the tree returns it** — [#828](https://github.com/qcom-ai-hub/geniex/pull/828) (`73300d3f12`) deleted infer's manifest check for an explicit `:<precision>` along with the CLI's own manifest handling.

So a typo currently produces the SDK's generic error, with none of the guidance the hint was written to give:

```
$ geniex infer unsloth/Qwen3.5-2B-GGUF:Q9_NOPE -p hi
Error: SDKError(Invalid input parameters or handle), quantization 'Q9_NOPE' not found for model 'unsloth/Qwen3.5-2B-GGUF'
```

`checkPrecisionDownloaded` restores the check against the SDK's own cached-precision list, so no manifest parsing moves back into the CLI. It reads `ModelGetDetailed` and reuses `downloadedPrecisions`, sharing one notion of "downloaded precision" with the picker #1381 restored. Precisions are compared with `EqualFold`, matching the SDK's case-insensitive handling of GGUF quant labels. Two cases pass through untouched: a model that isn't cached at all (so `infer <uncached>:<precision>` still pulls), and a cached model with no real precision labels — qairt reports only `N/A` — where there is nothing to match against and the SDK judges the key.

Now:

```
Error: precision not found: unsloth/Qwen3.5-2B-GGUF has Q4_0, Q4_K_M, not "Q9_NOPE"

⚠️ The requested precision is not available locally.

👉 Try these:
- Run 'geniex list' to see what's been downloaded for this model.
- Run 'geniex pull <model>:<precision>' to download it.
- Drop the ':<precision>' suffix to be prompted from what's already downloaded.
```

All three hint lines are actionable now that #1381 has landed on `main` (`9914c1ab6b`) with infer's precision picker; this branch is rebased on top of it.

## Test plan

Against `unsloth/Qwen3.5-2B-GGUF`, cached with `Q4_0` + `Q4_K_M`:

- [x] `:Q9_NOPE` → `precision not found: ... has Q4_0, Q4_K_M, not "Q9_NOPE"` plus the full hint block
- [x] `:q4_k_m` (lower case) → not rejected, loads `Qwen3.5-2B-Q4_K_M.gguf`
- [x] `no-such-org/no-such-model:Q4_0` → still prints `Model is not currently cached, downloading...` and fails in the pull, i.e. the check does not intercept uncached models
- [x] `bazelisk test //cli/...` — 15 passed, 6 skipped

Closes [qcom-ai-hub/geniex#1491](https://github.com/qcom-ai-hub/geniex/issues/1491).
