### PR TITLE
fix(cli): hide already-downloaded precisions from the pull picker

### DIFF
--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -480,7 +480,20 @@ func pullModel(ctx context.Context, name, quant string) error {
 		if err != nil {
 			return err
 		}
-		if chosen, err := choosePrecision("Choose a precision version to download", q.Candidates); err != nil {
+		// Offer what isn't cached yet; when everything is, keep the full list
+		// rather than bailing out, as a re-pull is how you repair a truncated
+		// file, pick up an upstream requantization, or refetch an AI Hub bundle
+		// for another chipset (the store is keyed by name, not chipset).
+		candidates := q.Candidates
+		cached := cachedPrecisions(name, candidates)
+		if pending := skipDownloaded(candidates, cached); len(pending) > 0 {
+			candidates = pending
+		} else if len(cached) > 0 {
+			fmt.Println(render.GetTheme().Info.Sprint("Every precision is already downloaded; pick one to re-download."))
+		}
+		slog.Debug("pull precisions", "remote", len(q.Candidates), "cached", cached, "offered", len(candidates))
+
+		if chosen, err := choosePrecision("Choose a precision version to download", candidates); err != nil {
 			return err
 		} else {
 			in.Precision = chosen
@@ -545,6 +558,34 @@ func pullModel(ctx context.Context, name, quant string) error {
 		fmt.Println(render.GetTheme().Info.Sprintf("   Precision: %s", quant))
 	}
 	return nil
+}
+
+// cachedPrecisions returns the candidates that already resolve on disk for
+// name. Resolution goes through the SDK, so a canonicalized name (a bare AI Hub
+// id, an ai-hub-models/ prefix) matches its own cache entry, as the pull does.
+func cachedPrecisions(name string, candidates []geniex_sdk.PrecisionCandidate) []string {
+	if _, err := geniex_sdk.ModelGetPaths(name); err != nil {
+		return nil
+	}
+	var cached []string
+	for _, c := range candidates {
+		if _, err := geniex_sdk.ModelGetPaths(name + ":" + c.Precision); err == nil {
+			cached = append(cached, c.Precision)
+		}
+	}
+	return cached
+}
+
+// skipDownloaded drops the already-cached candidates, so the picker only offers
+// something worth downloading.
+func skipDownloaded(candidates []geniex_sdk.PrecisionCandidate, cached []string) []geniex_sdk.PrecisionCandidate {
+	if len(cached) == 0 {
+		return candidates
+	}
+	return slices.DeleteFunc(slices.Clone(candidates), func(c geniex_sdk.PrecisionCandidate) bool {
+		// GGUF quant labels match case-insensitively, as the SDK does.
+		return slices.ContainsFunc(cached, func(p string) bool { return strings.EqualFold(p, c.Precision) })
+	})
 }
 
 // hasTerminal reports whether a picker can be drawn: keys come from stdin, and

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -480,18 +480,21 @@ func pullModel(ctx context.Context, name, quant string) error {
 		if err != nil {
 			return err
 		}
-		// Offer what isn't cached yet; when everything is, keep the full list
-		// rather than bailing out, as a re-pull is how you repair a truncated
-		// file, pick up an upstream requantization, or refetch an AI Hub bundle
-		// for another chipset (the store is keyed by name, not chipset).
+		// Only the picker hides cached precisions: without a terminal the head
+		// wins, and filtering would make a repeated `geniex pull <model>` walk
+		// the list instead of resolving to the recommended one every time.
 		candidates := q.Candidates
-		cached := cachedPrecisions(name, candidates)
-		if pending := skipDownloaded(candidates, cached); len(pending) > 0 {
-			candidates = pending
-		} else if len(cached) > 0 {
-			fmt.Println(render.GetTheme().Info.Sprint("Every precision is already downloaded; pick one to re-download."))
+		if hasTerminal() {
+			cached := cachedPrecisions(name, candidates)
+			if pending := skipDownloaded(candidates, cached); len(pending) > 0 {
+				candidates = pending
+			} else if len(cached) > 0 {
+				// A re-pull still repairs a truncated file or refetches a
+				// requantized or per-chipset bundle (the store is keyed by name).
+				fmt.Println(render.GetTheme().Info.Sprint("Every precision is already downloaded; pick one to re-download."))
+			}
+			slog.Debug("pull precisions", "remote", len(q.Candidates), "cached", cached, "offered", len(candidates))
 		}
-		slog.Debug("pull precisions", "remote", len(q.Candidates), "cached", cached, "offered", len(candidates))
 
 		if chosen, err := choosePrecision("Choose a precision version to download", candidates); err != nil {
 			return err
@@ -560,9 +563,8 @@ func pullModel(ctx context.Context, name, quant string) error {
 	return nil
 }
 
-// cachedPrecisions returns the candidates that already resolve on disk for
-// name. Resolution goes through the SDK, so a canonicalized name (a bare AI Hub
-// id, an ai-hub-models/ prefix) matches its own cache entry, as the pull does.
+// cachedPrecisions returns the candidates already on disk. The SDK canonicalizes
+// the name, so a bare AI Hub id or an ai-hub-models/ prefix hits its own entry.
 func cachedPrecisions(name string, candidates []geniex_sdk.PrecisionCandidate) []string {
 	if _, err := geniex_sdk.ModelGetPaths(name); err != nil {
 		return nil
@@ -576,8 +578,6 @@ func cachedPrecisions(name string, candidates []geniex_sdk.PrecisionCandidate) [
 	return cached
 }
 
-// skipDownloaded drops the already-cached candidates, so the picker only offers
-// something worth downloading.
 func skipDownloaded(candidates []geniex_sdk.PrecisionCandidate, cached []string) []geniex_sdk.PrecisionCandidate {
 	if len(cached) == 0 {
 		return candidates

--- a/cli/cmd/geniex/model_test.go
+++ b/cli/cmd/geniex/model_test.go
@@ -113,3 +113,37 @@ func TestPrintListCSV(t *testing.T) {
 		}
 	}
 }
+
+func TestSkipDownloaded(t *testing.T) {
+	candidates := []geniex_sdk.PrecisionCandidate{
+		{Precision: "Q4_0", Size: 100},
+		{Precision: "Q4_K_M", Size: 200},
+		{Precision: "Q8_0", Size: 300},
+	}
+	tests := []struct {
+		name   string
+		cached []string
+		want   []string
+	}{
+		{"nothing cached keeps every candidate", nil, []string{"Q4_0", "Q4_K_M", "Q8_0"}},
+		{"cached precision is dropped", []string{"Q4_0"}, []string{"Q4_K_M", "Q8_0"}},
+		{"matching is case-insensitive", []string{"q4_k_m"}, []string{"Q4_0", "Q8_0"}},
+		{"all cached leaves nothing to pull", []string{"Q8_0", "Q4_0", "Q4_K_M"}, nil},
+		{"a cached precision the remote lost is ignored", []string{"Q2_K"}, []string{"Q4_0", "Q4_K_M", "Q8_0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := skipDownloaded(candidates, tt.cached)
+			var names []string
+			for _, c := range got {
+				names = append(names, c.Precision)
+			}
+			if !slices.Equal(names, tt.want) {
+				t.Errorf("skipDownloaded(%v) = %v, want %v", tt.cached, names, tt.want)
+			}
+			if len(candidates) != 3 {
+				t.Errorf("input mutated: %v", candidates)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The precision picker lists every candidate the hub offers, including the ones already sitting in the cache. Pulling `unsloth/Qwen3.5-2B-GGUF` with `Q4_0` and `Q4_K_M` already downloaded offers all 22 remote quants; picking a cached one means waiting on a download that resolves to a no-op.

Pre-[#828](https://github.com/qcom-ai-hub/geniex/pull/828) the CLI filtered these out in `chooseQuantFiles` (`73300d3f12^:cli/cmd/geniex/model.go:700-710`). That filtering was dropped when model management moved to the SDK; the picker survived, its "only offer what's worth downloading" semantics did not.

`cachedPrecisions` asks the SDK to resolve `name:<precision>` for each candidate rather than matching `ModelDetail.Name` against the raw argument. That matters: `Store::get_paths` canonicalizes (`store.rs:247`), so a bare AI Hub id (`llama_v3_2_3b_instruct` → `qualcomm/…`) or an `ai-hub-models/` prefix matches its own cache entry, which a string compare against the user's argument would miss — and miss silently, leaving the feature a no-op for exactly the QAIRT naming forms the docs advertise.

**I deliberately did not restore pre-828's `Already downloaded all precisions` early return.** It is wrong under the SDK's pull: when every candidate is cached, the full list is kept (with a note) instead of returning nil, because a re-pull is the only way to

- repair a truncated or manually deleted file,
- pick up an upstream requantization behind the same quant label,
- refetch an AI Hub bundle for another chipset — `Store::model_dir` is keyed by name alone, the manifest carries no chipset, and the AI Hub plan yields exactly one candidate, so the old short-circuit would have made `config set chipset` + re-pull a silent no-op with `model remove` as the only way out.

It also keeps an empty remote candidate list (an ONNX- or `.geniex`-only repo passes `manifest_builder.rs:76` but populates `model_file` only from GGUFs) reporting `no precision available for this model` instead of falsely claiming everything is downloaded, and stops `--model-type` from being silently dropped by an early return.

## Test plan

- [x] New `TestSkipDownloaded`: nothing cached, one cached, case-insensitive match, everything cached, a cached precision the remote no longer lists; asserts the input slice is not mutated
- [x] `bazelisk test //cli/cmd/geniex:geniex_test` — passes
- [x] Live against `unsloth/Qwen3.5-2B-GGUF` (`Q4_0` + `Q4_K_M` cached), new debug line: `pull precisions remote=22 cached="[Q4_0 Q4_K_M]" offered=20`
- [x] Confirmed `Store::get_paths` canonicalizes (`sdk/model-manager/crates/core/src/store.rs:247`), so the bare-id form resolves


Closes [qcom-ai-hub/geniex#1492](https://github.com/qcom-ai-hub/geniex/issues/1492).
