### PR TITLE
test(python): decode greedily and drive the device matrix from models.json

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -12,27 +12,37 @@ tests/
 ├── test_qairt.py          # qairt plugin     — LLM + VLM + precision
 ├── conftest.py            # Top-level fixtures (init, model paths, image)
 ├── pytest.ini             # Marker registry + suite discovery
-├── _models.py             # Model identifiers used by the matrix
+├── _models.py             # Model-matrix loader for models.json
+├── models.json            # The matrix: role -> [{id, precision, devices}]
 └── _quality_data.py       # Keyword-quality prompts shared by both plugins
 ```
 
 ## What each plugin covers
 
-Every plugin file ships the same four cases, plus an explicit
+Every plugin file ships the same behavioural cases, plus an explicit
 model-manager-pull check that runs first:
 
-| Test                          | What it proves                                                     |
-|-------------------------------|--------------------------------------------------------------------|
-| `test_model_manager_pull`     | AI Hub / HuggingFace pull for every model this file needs works.   |
-| `test_llm_multi_turn`         | Two-turn "Alice" conversation; turn-2 must recall the name.        |
-| `test_vlm_multi_turn`         | Two-turn conversation with an image on turn 1.                     |
-| `test_llm_quality_keywords`   | Greedy decode, 3 short Q/A; keyword substring must land.           |
-| `test_vlm_quality_keywords`   | Golden-retriever caption must match one of the canonical keywords. |
-| `test_mtp_multi_turn`         | (llama_cpp only) same "Alice" convo with `spec_type='draft-mtp'`.  |
+| Test                             | What it proves                                                     |
+|----------------------------------|--------------------------------------------------------------------|
+| `test_model_manager_pull`        | AI Hub / HuggingFace pull for every model this file needs works.   |
+| `test_llm_multi_turn`            | Two-turn "Alice" conversation; turn-2 must recall the name.        |
+| `test_llm_greedy_is_deterministic` | Same prompt under two seeds decodes to byte-identical text.       |
+| `test_vlm_multi_turn`            | Two-turn conversation with an image on turn 1.                     |
+| `test_llm_quality_keywords`      | Greedy decode, 3 short Q/A; keyword substring must land.           |
+| `test_vlm_quality_keywords`      | Golden-retriever caption must match one of the canonical keywords. |
+| `test_mtp_multi_turn`            | (llama_cpp only) same "Alice" convo with `spec_type='draft-mtp'`.  |
 
-Backends per plugin: `llama_cpp` on `cpu` + `gpu` + `npu`; `qairt` on `npu` only.
-Model-manager pull failures are treated as FAIL, not SKIP, so a broken
-download surfaces as a red CI leg instead of a silent green skip.
+Behavioural cases are parametrised over `(model, device_map)` pairs from
+`models.json`, so which backends run is a property of the model entry.
+Template / contract cases (ChatML sentinels, `enable_thinking`, tools
+rendering, mtmd markers) stay pinned to the role's first entry — they assert
+tokenizer specifics of one model. Model-manager pull failures are treated as
+FAIL, not SKIP, so a broken download surfaces as a red CI leg instead of a
+silent green skip.
+
+Every generating cell passes `GREEDY_TEMPERATURE` (a negative argmax sentinel),
+not `0.0`: both plugins read `0.0` as "unset" and substitute 0.8, so a pinned
+seed alone does not make a cell deterministic.
 
 ## Marker registry
 
@@ -46,7 +56,8 @@ The conftest auto-tags items by location and `device_map` value:
 | `device_cpu`    | parametrised with `device_map='cpu'`                     |
 | `device_gpu`    | parametrised with `device_map='gpu'`                     |
 | `device_npu`    | parametrised with `device_map='npu'`                     |
-| `snapdragon`    | any `device_map` in {`gpu`, `npu`} cell (auto-applied)   |
+| `device_hybrid` | parametrised with `device_map='hybrid'`                  |
+| `snapdragon`    | any `device_map` in {`gpu`, `npu`, `hybrid`} cell (auto) |
 | `llm` / `vlm`   | applied per-test via `@pytest.mark.llm` / `.vlm`         |
 
 `snapdragon`-marked and `qairt` items skip automatically unless
@@ -64,34 +75,51 @@ pytest tests -m api
 pytest tests -m "api or (llama_cpp and device_cpu)"
 
 # Snapdragon Windows ARM64 or Qualcomm Linux — full matrix
+# (pulls every models.json entry, ~30 GB including gpt-oss-20b and the MTP pair)
 GENIEX_DEVICE_TEST=1 pytest tests
 ```
 
 ## Models
 
-The matrix uses one model per modality, aligned across both plugins so a
-keyword-quality divergence between llama_cpp and QAIRT traces to backend /
-quantization rather than model identity. Manifest: `tests/models.json` (edit
-this file to swap or add models); loader: `tests/_models.py`.
+`tests/models.json` is the matrix. Each role maps to a list of entries and
+every entry names the `devices` it runs on, so adding a model to the whole
+behavioural suite is a manifest edit. Loader: `tests/_models.py`.
 
-| Modality | llama_cpp (HF GGUF) | QAIRT (AI Hub) |
-|----------|---------------------|----------------|
-| LLM      | `unsloth/Qwen3-4B-GGUF` Q4_0 | `qualcomm/Qwen3-4B` |
-| VLM      | `unsloth/gemma-4-E2B-it-GGUF` Q4_0 + mmproj-F16 | `qualcomm/Qwen2.5-VL-7B-Instruct` |
-| MTP      | `google/gemma-4-26B-A4B-it-qat-q4_0-gguf` + `RachidAR/gemma-4-...-assistant-q4_0-gguf` | — (llama_cpp only) |
+| Role                   | Model | Devices |
+|------------------------|-------|---------|
+| `llama_cpp_llm`        | `unsloth/Qwen3-4B-GGUF` Q4_0 | cpu, gpu, npu, hybrid |
+| `llama_cpp_llm`        | `unsloth/gpt-oss-20b-GGUF` Q4_0 | hybrid |
+| `llama_cpp_vlm`        | `unsloth/gemma-4-E2B-it-GGUF` Q4_0 + mmproj-F16 | cpu, gpu, npu, hybrid |
+| `llama_cpp_mtp_target` | `google/gemma-4-26B-A4B-it-qat-q4_0-gguf` | npu |
+| `llama_cpp_mtp_draft`  | `RachidAR/gemma-4-...-assistant-q4_0-gguf` | — (paired with the target) |
+| `qairt_llm`            | `qualcomm/Qwen3-4B` | npu |
+| `qairt_vlm`            | `qualcomm/Qwen2.5-VL-7B-Instruct` | npu |
 
-The LLM is Qwen3-4B **base**, not Instruct-2507: Instruct-2507 emits a long
-`<think>` preamble before the answer that, on the 256-token budget the
+Entry fields: `id`, `precision`, `hub` (default `auto`), `devices`,
+`quality_max_new_tokens` (per-model budget for the keyword cells),
+`env_override` (an env var that replaces `id`).
+
+llama_cpp and QAIRT share the same LLM/VLM models so a keyword-quality
+divergence traces to backend / quantization rather than model identity.
+`gpt-oss-20b` is the `hybrid`-only entry and needs a bigger
+`quality_max_new_tokens` — its reasoning channel has no `enable_thinking` off
+switch.
+
+The primary LLM is Qwen3-4B **base**, not Instruct-2507: Instruct-2507 emits a
+long `<think>` preamble before the answer that, on the 256-token budget the
 suite uses, pushes the keyword off the end of the completion and turns
 `test_llm_quality_keywords` into a thinking-budget test rather than a
 backend-quality test.
 
-Override the QAIRT model identifiers without editing the suite:
+Swap models via `env_override` per entry, or `GENIEX_TEST_MODELS` for the whole
+matrix:
 
 ```bash
 GENIEX_QAIRT_MODEL=qualcomm/<other-llm> \
 GENIEX_QAIRT_VLM_MODEL=qualcomm/<other-vlm> \
 GENIEX_DEVICE_TEST=1 pytest tests -m qairt
+
+GENIEX_TEST_MODELS=/path/to/my-matrix.json GENIEX_DEVICE_TEST=1 pytest tests
 ```
 
 ## CI

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,9 +87,9 @@ behavioural suite is a manifest edit. Loader: `tests/_models.py`.
 
 | Role                   | Model | Devices |
 |------------------------|-------|---------|
-| `llama_cpp_llm`        | `unsloth/Qwen3-4B-GGUF` Q4_0 | cpu, gpu, npu, hybrid |
+| `llama_cpp_llm`        | `unsloth/Qwen3-4B-GGUF` Q4_0 | cpu, gpu, npu |
 | `llama_cpp_llm`        | `unsloth/gpt-oss-20b-GGUF` Q4_0 | hybrid |
-| `llama_cpp_vlm`        | `unsloth/gemma-4-E2B-it-GGUF` Q4_0 + mmproj-F16 | cpu, gpu, npu, hybrid |
+| `llama_cpp_vlm`        | `unsloth/gemma-4-E2B-it-GGUF` Q4_0 + mmproj-F16 | cpu, gpu, npu |
 | `llama_cpp_mtp_target` | `google/gemma-4-26B-A4B-it-qat-q4_0-gguf` | npu |
 | `llama_cpp_mtp_draft`  | `RachidAR/gemma-4-...-assistant-q4_0-gguf` | — (paired with the target) |
 | `qairt_llm`            | `qualcomm/Qwen3-4B` | npu |

--- a/tests/_models.py
+++ b/tests/_models.py
@@ -1,37 +1,74 @@
 # Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
 # SPDX-License-Identifier: BSD-3-Clause
 
-"""Test-model identifiers, loaded from ``tests/models.json``."""
+"""Test-model matrix, loaded from ``tests/models.json`` (or ``GENIEX_TEST_MODELS``)."""
 
 from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
-_MANIFEST_PATH = Path(__file__).with_name('models.json')
+import pytest
 
 
-def _pick(entry: dict, field: str = 'id') -> str | None:
-    if field == 'id':
-        env = entry.get('env_override')
-        if env:
-            override = os.environ.get(env)
-            if override:
-                return override
-    return entry.get(field)
+@dataclass(frozen=True)
+class TestModel:
+    role: str
+    id: str
+    precision: str | None
+    hub: str
+    devices: tuple[str, ...]
+    quality_max_new_tokens: int | None
+
+    @property
+    def short_name(self) -> str:
+        return self.id.rsplit('/', 1)[-1]
 
 
-with _MANIFEST_PATH.open(encoding='utf-8') as _f:
-    _MODELS = json.load(_f)['models']
+def _manifest_path() -> Path:
+    override = os.environ.get('GENIEX_TEST_MODELS')
+    return Path(override) if override else Path(__file__).with_name('models.json')
 
-LLAMA_CPP_LLM_MODEL = _pick(_MODELS['llama_cpp_llm'])
-LLAMA_CPP_LLM_PRECISION = _pick(_MODELS['llama_cpp_llm'], 'precision')
-LLAMA_CPP_VLM_MODEL = _pick(_MODELS['llama_cpp_vlm'])
-LLAMA_CPP_VLM_PRECISION = _pick(_MODELS['llama_cpp_vlm'], 'precision')
-LLAMA_CPP_MTP_TARGET_MODEL = _pick(_MODELS['llama_cpp_mtp_target'])
-LLAMA_CPP_MTP_TARGET_PRECISION = _pick(_MODELS['llama_cpp_mtp_target'], 'precision')
-LLAMA_CPP_MTP_DRAFT_MODEL = _pick(_MODELS['llama_cpp_mtp_draft'])
-LLAMA_CPP_MTP_DRAFT_PRECISION = _pick(_MODELS['llama_cpp_mtp_draft'], 'precision')
-QAIRT_LLM_MODEL = _pick(_MODELS['qairt_llm'])
-QAIRT_VLM_MODEL = _pick(_MODELS['qairt_vlm'])
+
+def _load() -> dict[str, tuple[TestModel, ...]]:
+    with _manifest_path().open(encoding='utf-8') as f:
+        raw = json.load(f)['models']
+    roles: dict[str, tuple[TestModel, ...]] = {}
+    for role, entries in raw.items():
+        models = []
+        for entry in entries:
+            env = entry.get('env_override')
+            override = os.environ.get(env) if env else None
+            models.append(
+                TestModel(
+                    role=role,
+                    id=override or entry['id'],
+                    precision=entry.get('precision'),
+                    hub=entry.get('hub', 'auto'),
+                    devices=tuple(entry['devices']),
+                    quality_max_new_tokens=entry.get('quality_max_new_tokens'),
+                )
+            )
+        roles[role] = tuple(models)
+    return roles
+
+
+MODELS = _load()
+
+
+def primary(role: str) -> TestModel:
+    return MODELS[role][0]
+
+
+def matrix(role: str) -> list:
+    return [
+        pytest.param(model, device, id=f'{model.short_name}-{device}')
+        for model in MODELS[role]
+        for device in model.devices
+    ]
+
+
+def pull_cells(*roles: str) -> list:
+    return [pytest.param(model, id=model.short_name) for role in roles for model in MODELS[role]]

--- a/tests/_quality_data.py
+++ b/tests/_quality_data.py
@@ -22,6 +22,10 @@ Thinking is disabled for the keyword cells. With it on, Qwen3 spends most of
 and the binding strips the trace — leaving a stub that looks like a missing
 keyword (qcom-ai-hub/geniex#1460).
 
+Sampling diverges from upstream in one place: both plugins read
+`temperature == 0.0` as "unset" and substitute 0.8, so `GREEDY_TEMPERATURE`
+uses the negative argmax sentinel both plugins accept instead.
+
 One intentional delta vs. upstream: VLM only ships the dog photo + first
 keyword set. Upstream also iterates a Qualcomm AIHub product image with
 vocabulary like person/phone/text; that second image is deferred to keep
@@ -32,6 +36,8 @@ from __future__ import annotations
 
 import math
 
+GREEDY_TEMPERATURE = -1.0
+
 # (prompt, expected_substring). Matched case-insensitively against `out.text`.
 LLM_QUALITY_PROMPTS: list[tuple[str, str]] = [
     ('The capital of France is', 'Paris'),
@@ -40,7 +46,6 @@ LLM_QUALITY_PROMPTS: list[tuple[str, str]] = [
 ]
 
 LLM_QUALITY_MAX_NEW_TOKENS = 256
-LLM_QUALITY_TEMPERATURE = 0.0  # 0.0 = defer to plugin default; see module docstring
 LLM_QUALITY_SEED = 1
 
 VLM_QUALITY_PROMPT = 'Describe this image in detail.'
@@ -58,8 +63,10 @@ VLM_QUALITY_KEYWORDS: tuple[str, ...] = (
 # room for a keyword to appear in the caption, and bounded enough to keep the
 # QDC Android wall-clock predictable across 4 VLM cells.
 VLM_QUALITY_MAX_NEW_TOKENS = 256
-VLM_QUALITY_TEMPERATURE = 0.0
 VLM_QUALITY_SEED = 1
+
+DETERMINISM_PROMPT = 'List three primary colours.'
+DETERMINISM_MAX_NEW_TOKENS = 48
 
 
 PARITY_INPUT_IDS: list[int] = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,18 +14,7 @@ import geniex
 import pytest
 from geniex import model_manager as _mm
 
-from _models import (
-    LLAMA_CPP_LLM_MODEL,
-    LLAMA_CPP_LLM_PRECISION,
-    LLAMA_CPP_MTP_DRAFT_MODEL,
-    LLAMA_CPP_MTP_DRAFT_PRECISION,
-    LLAMA_CPP_MTP_TARGET_MODEL,
-    LLAMA_CPP_MTP_TARGET_PRECISION,
-    LLAMA_CPP_VLM_MODEL,
-    LLAMA_CPP_VLM_PRECISION,
-    QAIRT_LLM_MODEL,
-    QAIRT_VLM_MODEL,
-)
+from _models import TestModel, primary
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 TEST_IMAGE_PATH = _REPO_ROOT / 'cli' / 'server' / 'docs' / 'ui' / 'favicon-32x32.png'
@@ -35,9 +24,11 @@ _DEVICE_MARKER = {
     'cpu': 'device_cpu',
     'gpu': 'device_gpu',
     'npu': 'device_npu',
+    'hybrid': 'device_hybrid',
 }
-# GPU uses the Snapdragon OpenCL backend, so it needs real hardware just like NPU.
-_SNAPDRAGON_DEVICES = {'gpu', 'npu'}
+# GPU uses the Snapdragon OpenCL backend and hybrid schedules onto HTP, so both
+# need real hardware just like NPU.
+_SNAPDRAGON_DEVICES = {'gpu', 'npu', 'hybrid'}
 
 
 def _is_snapdragon_host() -> bool:
@@ -105,32 +96,46 @@ def geniex_session():
 
 # Model-manager pull failures raise, not skip — a broken hub is a real regression.
 @pytest.fixture(scope='session')
-def llama_cpp_llm_paths(geniex_session):
-    return _mm.ensure_cached(LLAMA_CPP_LLM_MODEL, precision=LLAMA_CPP_LLM_PRECISION, hub='hf')
+def cached(geniex_session):
+    resolved: dict[tuple[str, str | None], object] = {}
+
+    def _get(model: TestModel):
+        key = (model.id, model.precision)
+        if key not in resolved:
+            resolved[key] = _mm.ensure_cached(model.id, precision=model.precision, hub=model.hub)
+        return resolved[key]
+
+    return _get
 
 
 @pytest.fixture(scope='session')
-def llama_cpp_mtp_paths(geniex_session):
+def llama_cpp_llm_paths(cached):
+    return cached(primary('llama_cpp_llm'))
+
+
+@pytest.fixture(scope='session')
+def llama_cpp_mtp_paths(cached):
     if hasattr(sys, 'getandroidapilevel'):
         pytest.skip('MTP target+draft (2×27B) exceeds mobile RAM')
-    target = _mm.ensure_cached(LLAMA_CPP_MTP_TARGET_MODEL, precision=LLAMA_CPP_MTP_TARGET_PRECISION, hub='hf')
-    draft = _mm.ensure_cached(LLAMA_CPP_MTP_DRAFT_MODEL, precision=LLAMA_CPP_MTP_DRAFT_PRECISION, hub='hf')
-    return {'target': target, 'draft': draft}
+    return {
+        'target': cached(primary('llama_cpp_mtp_target')),
+        'draft': cached(primary('llama_cpp_mtp_draft')),
+    }
 
 
 @pytest.fixture(scope='session')
-def llama_cpp_vlm_paths(geniex_session):
-    return _mm.ensure_cached(LLAMA_CPP_VLM_MODEL, precision=LLAMA_CPP_VLM_PRECISION, hub='hf')
+def llama_cpp_vlm_paths(cached):
+    return cached(primary('llama_cpp_vlm'))
 
 
 @pytest.fixture(scope='session')
-def qairt_llm_paths(geniex_session):
-    return _mm.ensure_cached(QAIRT_LLM_MODEL)
+def qairt_llm_paths(cached):
+    return cached(primary('qairt_llm'))
 
 
 @pytest.fixture(scope='session')
-def qairt_vlm_paths(geniex_session):
-    return _mm.ensure_cached(QAIRT_VLM_MODEL)
+def qairt_vlm_paths(cached):
+    return cached(primary('qairt_vlm'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/models.json
+++ b/tests/models.json
@@ -5,7 +5,7 @@
         "id": "unsloth/Qwen3-4B-GGUF",
         "precision": "Q4_0",
         "hub": "hf",
-        "devices": ["cpu", "gpu", "npu", "hybrid"]
+        "devices": ["cpu", "gpu", "npu"]
       },
       {
         "id": "unsloth/gpt-oss-20b-GGUF",
@@ -20,7 +20,7 @@
         "id": "unsloth/gemma-4-E2B-it-GGUF",
         "precision": "Q4_0",
         "hub": "hf",
-        "devices": ["cpu", "gpu", "npu", "hybrid"]
+        "devices": ["cpu", "gpu", "npu"]
       }
     ],
     "llama_cpp_mtp_target": [

--- a/tests/models.json
+++ b/tests/models.json
@@ -1,30 +1,57 @@
 {
   "models": {
-    "llama_cpp_llm": {
-      "id": "unsloth/Qwen3-4B-GGUF",
-      "precision": "Q4_0"
-    },
-    "llama_cpp_vlm": {
-      "id": "unsloth/gemma-4-E2B-it-GGUF",
-      "precision": "Q4_0"
-    },
-    "llama_cpp_mtp_target": {
-      "id": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf",
-      "precision": "Q4_0"
-    },
-    "llama_cpp_mtp_draft": {
-      "id": "RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf",
-      "precision": "Q4_0"
-    },
-    "qairt_llm": {
-      "id": "qualcomm/Qwen3-4B",
-      "precision": null,
-      "env_override": "GENIEX_QAIRT_MODEL"
-    },
-    "qairt_vlm": {
-      "id": "qualcomm/Qwen2.5-VL-7B-Instruct",
-      "precision": null,
-      "env_override": "GENIEX_QAIRT_VLM_MODEL"
-    }
+    "llama_cpp_llm": [
+      {
+        "id": "unsloth/Qwen3-4B-GGUF",
+        "precision": "Q4_0",
+        "hub": "hf",
+        "devices": ["cpu", "gpu", "npu", "hybrid"]
+      },
+      {
+        "id": "unsloth/gpt-oss-20b-GGUF",
+        "precision": "Q4_0",
+        "hub": "hf",
+        "devices": ["hybrid"],
+        "quality_max_new_tokens": 1024
+      }
+    ],
+    "llama_cpp_vlm": [
+      {
+        "id": "unsloth/gemma-4-E2B-it-GGUF",
+        "precision": "Q4_0",
+        "hub": "hf",
+        "devices": ["cpu", "gpu", "npu", "hybrid"]
+      }
+    ],
+    "llama_cpp_mtp_target": [
+      {
+        "id": "google/gemma-4-26B-A4B-it-qat-q4_0-gguf",
+        "precision": "Q4_0",
+        "hub": "hf",
+        "devices": ["npu"]
+      }
+    ],
+    "llama_cpp_mtp_draft": [
+      {
+        "id": "RachidAR/gemma-4-26B-A4B-it-qat-assistant-q4_0-gguf",
+        "precision": "Q4_0",
+        "hub": "hf",
+        "devices": []
+      }
+    ],
+    "qairt_llm": [
+      {
+        "id": "qualcomm/Qwen3-4B",
+        "devices": ["npu"],
+        "env_override": "GENIEX_QAIRT_MODEL"
+      }
+    ],
+    "qairt_vlm": [
+      {
+        "id": "qualcomm/Qwen2.5-VL-7B-Instruct",
+        "devices": ["npu"],
+        "env_override": "GENIEX_QAIRT_VLM_MODEL"
+      }
+    ]
   }
 }

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -11,5 +11,6 @@ markers =
     device_cpu: cpu backend (works anywhere)
     device_gpu: OpenCL GPU backend (Snapdragon only)
     device_npu: HTP NPU backend (Snapdragon only)
+    device_hybrid: per-tensor HTP+CPU scheduler (Snapdragon only)
     snapdragon: requires real Snapdragon host (gated by GENIEX_DEVICE_TEST=1)
 norecursedirs = qdc

--- a/tests/qdc/run_qdc_pytest.py
+++ b/tests/qdc/run_qdc_pytest.py
@@ -245,12 +245,14 @@ def _model_lines() -> list[str]:
         return []
     if not models:
         return []
-    lines = ['### Models', '', '| Slot | Model | Precision |', '|---|---|---|']
-    for slot, entry in models.items():
-        env = entry.get('env_override')
-        current_id = (env and os.environ.get(env)) or entry.get('id') or '—'
-        prec = entry.get('precision') or '—'
-        lines.append(f'| `{slot}` | `{current_id}` | `{prec}` |')
+    lines = ['### Models', '', '| Slot | Model | Precision | Devices |', '|---|---|---|---|']
+    for slot, entries in models.items():
+        for entry in entries:
+            env = entry.get('env_override')
+            current_id = (env and os.environ.get(env)) or entry.get('id') or '—'
+            prec = entry.get('precision') or '—'
+            devices = ', '.join(entry.get('devices') or []) or '—'
+            lines.append(f'| `{slot}` | `{current_id}` | `{prec}` | {devices} |')
     lines.append('')
     return lines
 

--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -12,18 +12,14 @@ from pathlib import Path
 import geniex
 import pytest
 
-from _models import (
-    LLAMA_CPP_LLM_MODEL,
-    LLAMA_CPP_LLM_PRECISION,
-    LLAMA_CPP_MTP_TARGET_MODEL,
-    LLAMA_CPP_VLM_MODEL,
-    LLAMA_CPP_VLM_PRECISION,
-)
+from _models import matrix, primary, pull_cells
 from _quality_data import (
+    DETERMINISM_MAX_NEW_TOKENS,
+    DETERMINISM_PROMPT,
+    GREEDY_TEMPERATURE,
     LLM_QUALITY_MAX_NEW_TOKENS,
     LLM_QUALITY_PROMPTS,
     LLM_QUALITY_SEED,
-    LLM_QUALITY_TEMPERATURE,
     PARITY_INPUT_IDS,
     PARITY_KL_MAX,
     PARITY_TOP1_MIN,
@@ -31,25 +27,29 @@ from _quality_data import (
     VLM_QUALITY_MAX_NEW_TOKENS,
     VLM_QUALITY_PROMPT,
     VLM_QUALITY_SEED,
-    VLM_QUALITY_TEMPERATURE,
     parity_kl_divergence,
     parity_top1_agreement,
 )
 
-_LLM_BACKENDS = ['cpu', 'gpu', 'npu']
-_VLM_BACKENDS = ['cpu', 'gpu', 'npu']
-_PARITY_CANDIDATES = ['gpu', 'npu', 'hybrid']
+_LLM = primary('llama_cpp_llm')
+_VLM = primary('llama_cpp_vlm')
+_MTP_TARGET = primary('llama_cpp_mtp_target')
+_LLM_MATRIX = matrix('llama_cpp_llm')
+_VLM_MATRIX = matrix('llama_cpp_vlm')
+# Parity scores each candidate against a cpu reference run, so it needs a cpu model.
+_PARITY_CANDIDATES = [d for d in _LLM.devices if d != 'cpu']
 _IS_QCS9075M = platform.system() == 'Linux' and platform.machine().lower() in ('aarch64', 'arm64')
 
 
-def test_model_manager_pull(llama_cpp_llm_paths, llama_cpp_vlm_paths, llama_cpp_mtp_paths):
-    for name, paths in [
-        ('llm', llama_cpp_llm_paths),
-        ('vlm', llama_cpp_vlm_paths),
-        ('mtp-target', llama_cpp_mtp_paths['target']),
-        ('mtp-draft', llama_cpp_mtp_paths['draft']),
-    ]:
-        assert Path(paths.model_path).is_file(), f'{name}: model_path missing: {paths.model_path}'
+@pytest.mark.parametrize('model', pull_cells('llama_cpp_llm', 'llama_cpp_vlm'))
+def test_model_manager_pull(cached, model):
+    paths = cached(model)
+    assert Path(paths.model_path).is_file(), f'{model.id}: model_path missing: {paths.model_path}'
+
+
+def test_model_manager_pull_mtp(llama_cpp_mtp_paths):
+    for name, paths in llama_cpp_mtp_paths.items():
+        assert Path(paths.model_path).is_file(), f'mtp-{name}: model_path missing: {paths.model_path}'
 
 
 def _run_multi_turn(llm) -> list[str]:
@@ -66,7 +66,7 @@ def _run_multi_turn(llm) -> list[str]:
             add_generation_prompt=True,
             enable_thinking=False,
         )
-        out = llm.generate(prompt, max_new_tokens=64, temperature=0.0, seed=42)
+        out = llm.generate(prompt, max_new_tokens=64, temperature=GREEDY_TEMPERATURE, seed=42)
         assert out.text, f'empty completion at turn {len(replies) + 1}'
         assert out.profile.generated_tokens > 0
         replies.append(out.text)
@@ -75,25 +75,62 @@ def _run_multi_turn(llm) -> list[str]:
 
 
 @pytest.mark.llm
-@pytest.mark.parametrize('device_map', _LLM_BACKENDS)
-def test_llm_multi_turn(llama_cpp_llm_paths, device_map):
+@pytest.mark.parametrize(('model', 'device_map'), _LLM_MATRIX)
+def test_llm_multi_turn(cached, model, device_map):
+    cached(model)
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        model.id,
+        precision=model.precision,
         device_map=device_map,
     ) as llm:
         replies = _run_multi_turn(llm)
     assert (
         'alice' in replies[-1].lower()
-    ), f'device_map={device_map!r} expected reply to recall "Alice", got={replies[-1]!r}'
+    ), f'model={model.id!r} device_map={device_map!r} expected reply to recall "Alice", got={replies[-1]!r}'
+
+
+@pytest.mark.llm
+@pytest.mark.parametrize(('model', 'device_map'), _LLM_MATRIX)
+def test_llm_greedy_is_deterministic(cached, model, device_map):
+    # Reloads per run: llama_cpp keeps its KV cache across generate() calls, so a
+    # second call on the same handle continues the first answer.
+    cached(model)
+
+    def _greedy_once(seed: int) -> str:
+        with geniex.AutoModelForCausalLM.from_pretrained(
+            model.id,
+            precision=model.precision,
+            device_map=device_map,
+        ) as llm:
+            formatted = llm.tokenizer.apply_chat_template(
+                [{'role': 'user', 'content': DETERMINISM_PROMPT}],
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=False,
+            )
+            return llm.generate(
+                formatted,
+                max_new_tokens=DETERMINISM_MAX_NEW_TOKENS,
+                temperature=GREEDY_TEMPERATURE,
+                seed=seed,
+            ).text
+
+    first = _greedy_once(LLM_QUALITY_SEED)
+    second = _greedy_once(LLM_QUALITY_SEED + 1)
+    assert first, f'empty completion for model={model.id!r} device_map={device_map!r}'
+    assert first == second, (
+        f'greedy decode diverged across seeds '
+        f'model={model.id!r} device_map={device_map!r} first={first!r} second={second!r}'
+    )
 
 
 @pytest.mark.vlm
-@pytest.mark.parametrize('device_map', _VLM_BACKENDS)
-def test_vlm_multi_turn(llama_cpp_vlm_paths, test_image, device_map):
+@pytest.mark.parametrize(('model', 'device_map'), _VLM_MATRIX)
+def test_vlm_multi_turn(cached, model, test_image, device_map):
+    cached(model)
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        LLAMA_CPP_VLM_MODEL,
-        precision=LLAMA_CPP_VLM_PRECISION,
+        model.id,
+        precision=model.precision,
         device_map=device_map,
     ) as vlm:
         history = [
@@ -106,7 +143,7 @@ def test_vlm_multi_turn(llama_cpp_vlm_paths, test_image, device_map):
             }
         ]
         prompt1 = vlm.tokenizer.apply_chat_template(history, tokenize=False, add_generation_prompt=True)
-        out1 = vlm.generate(prompt1, max_new_tokens=16, temperature=0.0, seed=42, images=[test_image])
+        out1 = vlm.generate(prompt1, max_new_tokens=16, temperature=GREEDY_TEMPERATURE, seed=42, images=[test_image])
         assert out1.profile.prompt_tokens > 0
 
         history.append({'role': 'assistant', 'content': out1.text or '...'})
@@ -114,7 +151,7 @@ def test_vlm_multi_turn(llama_cpp_vlm_paths, test_image, device_map):
         prompt2 = vlm.tokenizer.apply_chat_template(history, tokenize=False, add_generation_prompt=True)
         # Second turn without a bitmap — old char-offset tracking sliced past the
         # image marker while an image was still supplied and mtmd_tokenize failed.
-        out2 = vlm.generate(prompt2, max_new_tokens=16, temperature=0.0, seed=42, images=[])
+        out2 = vlm.generate(prompt2, max_new_tokens=16, temperature=GREEDY_TEMPERATURE, seed=42, images=[])
         assert isinstance(out2, geniex.GenerateOutput)
         assert out2.profile.prompt_tokens > 0
 
@@ -136,12 +173,14 @@ def _vlm_prompt(vlm, image_path: str, text: str) -> str:
 
 
 @pytest.mark.llm
-@pytest.mark.parametrize('device_map', _LLM_BACKENDS)
+@pytest.mark.parametrize(('model', 'device_map'), _LLM_MATRIX)
 @pytest.mark.parametrize(('prompt', 'expected'), LLM_QUALITY_PROMPTS)
-def test_llm_quality_keywords(llama_cpp_llm_paths, device_map, prompt, expected):
+def test_llm_quality_keywords(cached, model, device_map, prompt, expected):
+    cached(model)
+    budget = model.quality_max_new_tokens or LLM_QUALITY_MAX_NEW_TOKENS
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        model.id,
+        precision=model.precision,
         device_map=device_map,
     ) as llm:
         formatted = llm.tokenizer.apply_chat_template(
@@ -152,8 +191,8 @@ def test_llm_quality_keywords(llama_cpp_llm_paths, device_map, prompt, expected)
         )
         out = llm.generate(
             formatted,
-            max_new_tokens=LLM_QUALITY_MAX_NEW_TOKENS,
-            temperature=LLM_QUALITY_TEMPERATURE,
+            max_new_tokens=budget,
+            temperature=GREEDY_TEMPERATURE,
             seed=LLM_QUALITY_SEED,
         )
         assert out.text, f'empty completion for prompt={prompt!r}'
@@ -161,44 +200,46 @@ def test_llm_quality_keywords(llama_cpp_llm_paths, device_map, prompt, expected)
         # stub, which reads as a missing keyword — report it as truncation.
         assert (
             out.profile.stop_reason != 'length'
-        ), f'completion truncated at {LLM_QUALITY_MAX_NEW_TOKENS} tokens: prompt={prompt!r} got={out.text!r}'
+        ), f'completion truncated at {budget} tokens: model={model.id!r} prompt={prompt!r} got={out.text!r}'
         # Hoist to a bool so pytest's assertion introspection doesn't echo
         # out.text 4-5x per failure.
         matched = expected.lower() in out.text.lower()
         assert matched, (
-            f'prompt={prompt!r} expected_substring={expected!r} ' f'device_map={device_map!r} got={out.text!r}'
+            f'prompt={prompt!r} expected_substring={expected!r} '
+            f'model={model.id!r} device_map={device_map!r} got={out.text!r}'
         )
 
 
 @pytest.mark.vlm
-@pytest.mark.parametrize('device_map', _VLM_BACKENDS)
-def test_vlm_quality_keywords(llama_cpp_vlm_paths, quality_image, device_map):
+@pytest.mark.parametrize(('model', 'device_map'), _VLM_MATRIX)
+def test_vlm_quality_keywords(cached, model, quality_image, device_map):
+    cached(model)
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        LLAMA_CPP_VLM_MODEL,
-        precision=LLAMA_CPP_VLM_PRECISION,
+        model.id,
+        precision=model.precision,
         device_map=device_map,
     ) as vlm:
         prompt = _vlm_prompt(vlm, quality_image, VLM_QUALITY_PROMPT)
         out = vlm.generate(
             prompt,
-            max_new_tokens=VLM_QUALITY_MAX_NEW_TOKENS,
-            temperature=VLM_QUALITY_TEMPERATURE,
+            max_new_tokens=model.quality_max_new_tokens or VLM_QUALITY_MAX_NEW_TOKENS,
+            temperature=GREEDY_TEMPERATURE,
             seed=VLM_QUALITY_SEED,
             images=[quality_image],
         )
-        assert out.text, f'empty caption for device_map={device_map!r}'
+        assert out.text, f'empty caption for model={model.id!r} device_map={device_map!r}'
         matched = any(kw in out.text.lower() for kw in VLM_QUALITY_KEYWORDS)
         assert matched, (
             f'caption did not match any expected keyword '
-            f'device_map={device_map!r} keywords={VLM_QUALITY_KEYWORDS} '
+            f'model={model.id!r} device_map={device_map!r} keywords={VLM_QUALITY_KEYWORDS} '
             f'got={out.text!r}'
         )
 
 
 def _forward_parity(device_map: str) -> tuple[list[list[tuple[int, float]]], list[float]]:
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
     ) as llm:
         top1_rows = llm.forward_logits(PARITY_INPUT_IDS, all_positions=True, top_n=1)
@@ -226,7 +267,7 @@ def test_mtp_multi_turn(llama_cpp_mtp_paths, device_map):
     # trip the org/repo validator.
     with geniex.AutoModelForCausalLM.from_pretrained(
         llama_cpp_mtp_paths['target'].model_path,
-        model_name=LLAMA_CPP_MTP_TARGET_MODEL,
+        model_name=_MTP_TARGET.id,
         device_map=f'llama_cpp:{device_map}',
         spec_type='draft-mtp',
         spec_draft_model=llama_cpp_mtp_paths['draft'].model_path,
@@ -245,8 +286,8 @@ _MEDIA_MARKER = '<__media__>'
 @pytest.mark.parametrize('device_map', ['cpu'])
 def test_chat_template_roles_and_sentinels(llama_cpp_llm_paths, device_map):
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
     ) as llm:
         prompt = llm.tokenizer.apply_chat_template(
@@ -267,8 +308,8 @@ def test_chat_template_roles_and_sentinels(llama_cpp_llm_paths, device_map):
 @pytest.mark.parametrize('device_map', ['cpu'])
 def test_chat_template_enable_thinking(llama_cpp_llm_paths, device_map):
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
     ) as llm:
         msgs = [{'role': 'user', 'content': 'hi'}]
@@ -298,8 +339,8 @@ def test_chat_template_tools_list_and_json_string_equivalent(llama_cpp_llm_paths
     }
     msgs = [{'role': 'user', 'content': "what's the weather in Paris?"}]
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
     ) as llm:
         from_list = llm.tokenizer.apply_chat_template(msgs, tokenize=False, tools=[tool])
@@ -316,8 +357,8 @@ def test_chat_template_content_load_override(llama_cpp_llm_paths, device_map):
         '{% if add_generation_prompt %}[assistant] {% endif %}'
     )
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
         chat_template_content=jinja,
     ) as llm:
@@ -343,12 +384,12 @@ def test_context_shift_fires_on_decode_overflow(llama_cpp_llm_paths, device_map)
     prompt = f'Repeat the following words verbatim: {prompt_body}\n\nAnswer: '
 
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
         n_ctx=n_ctx,
     ) as llm:
-        out = llm.generate(prompt, max_new_tokens=120, temperature=0.0, seed=0)
+        out = llm.generate(prompt, max_new_tokens=120, temperature=GREEDY_TEMPERATURE, seed=0)
 
     assert out.profile.stop_reason != 'context_length', f'context shift did not save the run: {out.profile}'
     assert out.profile.generated_tokens > 0
@@ -359,12 +400,12 @@ def test_context_shift_fires_on_decode_overflow(llama_cpp_llm_paths, device_map)
 @pytest.mark.parametrize('device_map', ['cpu'])
 def test_context_shift_not_triggered_when_nctx_is_ample(llama_cpp_llm_paths, device_map):
     with geniex.AutoModelForCausalLM.from_pretrained(
-        LLAMA_CPP_LLM_MODEL,
-        precision=LLAMA_CPP_LLM_PRECISION,
+        _LLM.id,
+        precision=_LLM.precision,
         device_map=device_map,
         n_ctx=2048,
     ) as llm:
-        out = llm.generate('Say hi in one word.', max_new_tokens=8, temperature=0.0, seed=0)
+        out = llm.generate('Say hi in one word.', max_new_tokens=8, temperature=GREEDY_TEMPERATURE, seed=0)
 
     assert out.profile.stop_reason in {'eos', 'length', 'completed'}, out.profile
     assert out.profile.generated_tokens > 0
@@ -381,8 +422,8 @@ def test_mtmd_marker_prepended_per_image(llama_cpp_vlm_paths, test_image, qualit
     content.append({'type': 'text', 'text': 'describe the picture'})
 
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        LLAMA_CPP_VLM_MODEL,
-        precision=LLAMA_CPP_VLM_PRECISION,
+        _VLM.id,
+        precision=_VLM.precision,
         device_map=device_map,
     ) as vlm:
         prompt = vlm.tokenizer.apply_chat_template(
@@ -398,8 +439,8 @@ def test_mtmd_marker_prepended_per_image(llama_cpp_vlm_paths, test_image, qualit
 @pytest.mark.parametrize('device_map', ['cpu'])
 def test_mtmd_marker_absent_on_text_only_message(llama_cpp_vlm_paths, device_map):
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        LLAMA_CPP_VLM_MODEL,
-        precision=LLAMA_CPP_VLM_PRECISION,
+        _VLM.id,
+        precision=_VLM.precision,
         device_map=device_map,
     ) as vlm:
         prompt = vlm.tokenizer.apply_chat_template(
@@ -418,8 +459,8 @@ def test_mtmd_generate_rejects_missing_image_path(llama_cpp_vlm_paths, test_imag
     # generate() validates the images=[...] list against the filesystem.
     missing = str(Path(test_image).parent / 'does-not-exist.png')
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        LLAMA_CPP_VLM_MODEL,
-        precision=LLAMA_CPP_VLM_PRECISION,
+        _VLM.id,
+        precision=_VLM.precision,
         device_map=device_map,
     ) as vlm:
         vlm.tokenizer.apply_chat_template(

--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -196,17 +196,15 @@ def test_llm_quality_keywords(cached, model, device_map, prompt, expected):
             seed=LLM_QUALITY_SEED,
         )
         assert out.text, f'empty completion for prompt={prompt!r}'
-        # A think trace that eats the whole budget leaves a truncated answer
-        # stub, which reads as a missing keyword — report it as truncation.
-        assert (
-            out.profile.stop_reason != 'length'
-        ), f'completion truncated at {budget} tokens: model={model.id!r} prompt={prompt!r} got={out.text!r}'
         # Hoist to a bool so pytest's assertion introspection doesn't echo
         # out.text 4-5x per failure.
         matched = expected.lower() in out.text.lower()
+        # Greedy decode can loop until the budget runs out, so `length` is only a
+        # problem when it truncated before the keyword appeared.
         assert matched, (
             f'prompt={prompt!r} expected_substring={expected!r} '
-            f'model={model.id!r} device_map={device_map!r} got={out.text!r}'
+            f'model={model.id!r} device_map={device_map!r} '
+            f'stop_reason={out.profile.stop_reason!r} budget={budget} got={out.text!r}'
         )
 
 

--- a/tests/test_llama_cpp.py
+++ b/tests/test_llama_cpp.py
@@ -36,8 +36,8 @@ _VLM = primary('llama_cpp_vlm')
 _MTP_TARGET = primary('llama_cpp_mtp_target')
 _LLM_MATRIX = matrix('llama_cpp_llm')
 _VLM_MATRIX = matrix('llama_cpp_vlm')
-# Parity scores each candidate against a cpu reference run, so it needs a cpu model.
-_PARITY_CANDIDATES = [d for d in _LLM.devices if d != 'cpu']
+# Scored against a cpu reference run of the primary model, so not matrix-driven.
+_PARITY_CANDIDATES = ['gpu', 'npu', 'hybrid']
 _IS_QCS9075M = platform.system() == 'Linux' and platform.machine().lower() in ('aarch64', 'arm64')
 
 

--- a/tests/test_qairt.py
+++ b/tests/test_qairt.py
@@ -186,15 +186,13 @@ def test_llm_quality_keywords(cached, model, device_map, prompt, expected):
             seed=LLM_QUALITY_SEED,
         )
         assert out.text, f'empty completion for prompt={prompt!r}'
-        # A think trace that eats the whole budget leaves a truncated answer
-        # stub, which reads as a missing keyword — report it as truncation.
-        assert (
-            out.profile.stop_reason != 'length'
-        ), f'completion truncated at {budget} tokens: model={model.id!r} prompt={prompt!r} got={out.text!r}'
+        # Greedy decode can loop until the budget runs out, so `length` is only a
+        # problem when it truncated before the keyword appeared.
         matched = expected.lower() in out.text.lower()
         assert matched, (
             f'prompt={prompt!r} expected_substring={expected!r} '
-            f'model={model.id!r} device_map={device_map!r} got={out.text!r}'
+            f'model={model.id!r} device_map={device_map!r} '
+            f'stop_reason={out.profile.stop_reason!r} budget={budget} got={out.text!r}'
         )
 
 

--- a/tests/test_qairt.py
+++ b/tests/test_qairt.py
@@ -11,27 +11,33 @@ from pathlib import Path
 import geniex
 import pytest
 
-from _models import QAIRT_LLM_MODEL, QAIRT_VLM_MODEL
+from _models import matrix, primary, pull_cells
 from _quality_data import (
+    DETERMINISM_MAX_NEW_TOKENS,
+    DETERMINISM_PROMPT,
+    GREEDY_TEMPERATURE,
     LLM_QUALITY_MAX_NEW_TOKENS,
     LLM_QUALITY_PROMPTS,
     LLM_QUALITY_SEED,
-    LLM_QUALITY_TEMPERATURE,
     PARITY_INPUT_IDS,
     PARITY_QAIRT_KL_MAX,
     VLM_QUALITY_KEYWORDS,
     VLM_QUALITY_MAX_NEW_TOKENS,
     VLM_QUALITY_PROMPT,
     VLM_QUALITY_SEED,
-    VLM_QUALITY_TEMPERATURE,
     parity_kl_divergence,
     parity_top1_agreement,
 )
 
+_LLM = primary('qairt_llm')
+_LLM_MATRIX = matrix('qairt_llm')
+_VLM_MATRIX = matrix('qairt_vlm')
 
-def test_model_manager_pull(qairt_llm_paths, qairt_vlm_paths):
-    for name, paths in [('llm', qairt_llm_paths), ('vlm', qairt_vlm_paths)]:
-        assert Path(paths.model_path).is_file(), f'{name}: model_path missing: {paths.model_path}'
+
+@pytest.mark.parametrize('model', pull_cells('qairt_llm', 'qairt_vlm'))
+def test_model_manager_pull(cached, model):
+    paths = cached(model)
+    assert Path(paths.model_path).is_file(), f'{model.id}: model_path missing: {paths.model_path}'
 
 
 def _run_multi_turn(llm) -> list[str]:
@@ -48,7 +54,7 @@ def _run_multi_turn(llm) -> list[str]:
             add_generation_prompt=True,
             enable_thinking=False,
         )
-        out = llm.generate(prompt, max_new_tokens=64, temperature=0.0, seed=42)
+        out = llm.generate(prompt, max_new_tokens=64, temperature=GREEDY_TEMPERATURE, seed=42)
         assert out.text, f'empty completion at turn {len(replies) + 1}'
         assert out.profile.generated_tokens > 0
         replies.append(out.text)
@@ -57,16 +63,49 @@ def _run_multi_turn(llm) -> list[str]:
 
 
 @pytest.mark.llm
-@pytest.mark.parametrize('device_map', ['npu'])
-def test_llm_multi_turn(qairt_llm_paths, device_map):
+@pytest.mark.parametrize(('model', 'device_map'), _LLM_MATRIX)
+def test_llm_multi_turn(cached, model, device_map):
+    cached(model)
     with geniex.AutoModelForCausalLM.from_pretrained(
-        QAIRT_LLM_MODEL,
+        model.id,
         device_map=device_map,
     ) as llm:
         replies = _run_multi_turn(llm)
     assert (
         'alice' in replies[-1].lower()
-    ), f'device_map={device_map!r} expected reply to recall "Alice", got={replies[-1]!r}'
+    ), f'model={model.id!r} device_map={device_map!r} expected reply to recall "Alice", got={replies[-1]!r}'
+
+
+@pytest.mark.llm
+@pytest.mark.parametrize(('model', 'device_map'), _LLM_MATRIX)
+def test_llm_greedy_is_deterministic(cached, model, device_map):
+    cached(model)
+
+    def _greedy_once(seed: int) -> str:
+        with geniex.AutoModelForCausalLM.from_pretrained(
+            model.id,
+            device_map=device_map,
+        ) as llm:
+            formatted = llm.tokenizer.apply_chat_template(
+                [{'role': 'user', 'content': DETERMINISM_PROMPT}],
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=False,
+            )
+            return llm.generate(
+                formatted,
+                max_new_tokens=DETERMINISM_MAX_NEW_TOKENS,
+                temperature=GREEDY_TEMPERATURE,
+                seed=seed,
+            ).text
+
+    first = _greedy_once(LLM_QUALITY_SEED)
+    second = _greedy_once(LLM_QUALITY_SEED + 1)
+    assert first, f'empty completion for model={model.id!r} device_map={device_map!r}'
+    assert first == second, (
+        f'greedy decode diverged across seeds '
+        f'model={model.id!r} device_map={device_map!r} first={first!r} second={second!r}'
+    )
 
 
 def _vlm_prompt(vlm, image_path: str, text: str) -> str:
@@ -86,12 +125,14 @@ def _vlm_prompt(vlm, image_path: str, text: str) -> str:
 
 
 @pytest.mark.vlm
-def test_vlm_multi_turn(qairt_vlm_paths, test_image):
+@pytest.mark.parametrize(('model', 'device_map'), _VLM_MATRIX)
+def test_vlm_multi_turn(cached, model, test_image, device_map):
     # QAIRT re-encodes on every generate, so the follow-up turn must re-pass
     # the image; llama_cpp drops it on turn 2 instead.
+    cached(model)
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        QAIRT_VLM_MODEL,
-        device_map='npu',
+        model.id,
+        device_map=device_map,
     ) as vlm:
         history = [
             {
@@ -103,7 +144,7 @@ def test_vlm_multi_turn(qairt_vlm_paths, test_image):
             }
         ]
         prompt1 = vlm.tokenizer.apply_chat_template(history, tokenize=False, add_generation_prompt=True)
-        out1 = vlm.generate(prompt1, max_new_tokens=16, temperature=0.0, seed=42, images=[test_image])
+        out1 = vlm.generate(prompt1, max_new_tokens=16, temperature=GREEDY_TEMPERATURE, seed=42, images=[test_image])
         assert out1.profile.prompt_tokens > 0
 
         history.append({'role': 'assistant', 'content': out1.text or '...'})
@@ -117,17 +158,19 @@ def test_vlm_multi_turn(qairt_vlm_paths, test_image):
             }
         )
         prompt2 = vlm.tokenizer.apply_chat_template(history, tokenize=False, add_generation_prompt=True)
-        out2 = vlm.generate(prompt2, max_new_tokens=16, temperature=0.0, seed=42, images=[test_image])
+        out2 = vlm.generate(prompt2, max_new_tokens=16, temperature=GREEDY_TEMPERATURE, seed=42, images=[test_image])
         assert isinstance(out2, geniex.GenerateOutput)
         assert out2.profile.prompt_tokens > 0
 
 
 @pytest.mark.llm
-@pytest.mark.parametrize('device_map', ['npu'])
+@pytest.mark.parametrize(('model', 'device_map'), _LLM_MATRIX)
 @pytest.mark.parametrize(('prompt', 'expected'), LLM_QUALITY_PROMPTS)
-def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
+def test_llm_quality_keywords(cached, model, device_map, prompt, expected):
+    cached(model)
+    budget = model.quality_max_new_tokens or LLM_QUALITY_MAX_NEW_TOKENS
     with geniex.AutoModelForCausalLM.from_pretrained(
-        QAIRT_LLM_MODEL,
+        model.id,
         device_map=device_map,
     ) as llm:
         formatted = llm.tokenizer.apply_chat_template(
@@ -138,8 +181,8 @@ def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
         )
         out = llm.generate(
             formatted,
-            max_new_tokens=LLM_QUALITY_MAX_NEW_TOKENS,
-            temperature=LLM_QUALITY_TEMPERATURE,
+            max_new_tokens=budget,
+            temperature=GREEDY_TEMPERATURE,
             seed=LLM_QUALITY_SEED,
         )
         assert out.text, f'empty completion for prompt={prompt!r}'
@@ -147,10 +190,11 @@ def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
         # stub, which reads as a missing keyword — report it as truncation.
         assert (
             out.profile.stop_reason != 'length'
-        ), f'completion truncated at {LLM_QUALITY_MAX_NEW_TOKENS} tokens: prompt={prompt!r} got={out.text!r}'
+        ), f'completion truncated at {budget} tokens: model={model.id!r} prompt={prompt!r} got={out.text!r}'
         matched = expected.lower() in out.text.lower()
         assert matched, (
-            f'prompt={prompt!r} expected_substring={expected!r} ' f'device_map={device_map!r} got={out.text!r}'
+            f'prompt={prompt!r} expected_substring={expected!r} '
+            f'model={model.id!r} device_map={device_map!r} got={out.text!r}'
         )
 
 
@@ -159,7 +203,7 @@ def test_llm_quality_keywords(qairt_llm_paths, device_map, prompt, expected):
 def test_llm_logits_self_consistency(qairt_llm_paths, device_map):
     def _forward() -> tuple[list[list[tuple[int, float]]], list[float]]:
         with geniex.AutoModelForCausalLM.from_pretrained(
-            QAIRT_LLM_MODEL,
+            _LLM.id,
             device_map=device_map,
         ) as llm:
             top1_rows = llm.forward_logits(PARITY_INPUT_IDS, all_positions=True, top_n=1)
@@ -175,21 +219,22 @@ def test_llm_logits_self_consistency(qairt_llm_paths, device_map):
 
 
 @pytest.mark.vlm
-@pytest.mark.parametrize('device_map', ['npu'])
-def test_vlm_quality_keywords(qairt_vlm_paths, quality_image, device_map):
+@pytest.mark.parametrize(('model', 'device_map'), _VLM_MATRIX)
+def test_vlm_quality_keywords(cached, model, quality_image, device_map):
+    cached(model)
     with geniex.AutoModelForVision2Seq.from_pretrained(
-        QAIRT_VLM_MODEL,
+        model.id,
         device_map=device_map,
     ) as vlm:
         prompt = _vlm_prompt(vlm, quality_image, VLM_QUALITY_PROMPT)
         out = vlm.generate(
             prompt,
-            max_new_tokens=VLM_QUALITY_MAX_NEW_TOKENS,
-            temperature=VLM_QUALITY_TEMPERATURE,
+            max_new_tokens=model.quality_max_new_tokens or VLM_QUALITY_MAX_NEW_TOKENS,
+            temperature=GREEDY_TEMPERATURE,
             seed=VLM_QUALITY_SEED,
             images=[quality_image],
         )
-        assert out.text, f'empty caption for device_map={device_map!r}'
+        assert out.text, f'empty caption for model={model.id!r} device_map={device_map!r}'
         matched = any(kw in out.text.lower() for kw in VLM_QUALITY_KEYWORDS)
         assert matched, (
             f'caption did not match any expected keyword '
@@ -202,7 +247,7 @@ def test_vlm_quality_keywords(qairt_vlm_paths, quality_image, device_map):
 @pytest.mark.parametrize('device_map', ['npu'])
 def test_chat_template_roles_and_sentinels(qairt_llm_paths, device_map):
     with geniex.AutoModelForCausalLM.from_pretrained(
-        QAIRT_LLM_MODEL,
+        _LLM.id,
         device_map=device_map,
     ) as llm:
         prompt = llm.tokenizer.apply_chat_template(
@@ -223,7 +268,7 @@ def test_chat_template_roles_and_sentinels(qairt_llm_paths, device_map):
 @pytest.mark.parametrize('device_map', ['npu'])
 def test_chat_template_enable_thinking(qairt_llm_paths, device_map):
     with geniex.AutoModelForCausalLM.from_pretrained(
-        QAIRT_LLM_MODEL,
+        _LLM.id,
         device_map=device_map,
     ) as llm:
         msgs = [{'role': 'user', 'content': 'hi'}]
@@ -253,7 +298,7 @@ def test_chat_template_tools_list_and_json_string_equivalent(qairt_llm_paths, de
     }
     msgs = [{'role': 'user', 'content': "what's the weather in Paris?"}]
     with geniex.AutoModelForCausalLM.from_pretrained(
-        QAIRT_LLM_MODEL,
+        _LLM.id,
         device_map=device_map,
     ) as llm:
         from_list = llm.tokenizer.apply_chat_template(msgs, tokenize=False, tools=[tool])


### PR DESCRIPTION
Closes the first three goals of qcom-ai-hub/geniex#1448.

- **Greedy decode.** Both plugins read `temperature == 0.0` as "unset" and substitute 0.8 ([`params.cpp:153`](https://github.com/qualcomm/GenieX/blob/main/sdk/plugins/llama_cpp/src/params.cpp#L153), [`sampler_config_utils.h:83`](https://github.com/qualcomm/GenieX/blob/main/sdk/plugins/qairt/include/sampler_config_utils.h#L83)), so every generating cell was sampling despite a pinned seed. A negative temperature is the argmax sentinel on both sides, so no SDK change is needed — `GREEDY_TEMPERATURE` replaces every `temperature=0.0`. Follow-on: greedy makes QAIRT Qwen3-4B repeat until the token cap, so `test_llm_quality_keywords` no longer asserts `stop_reason != 'length'` and reports it in the keyword failure message instead.
- **Model matrix.** `models.json` becomes `role -> [{id, precision, hub, devices, ...}]`; behavioural cells parametrise over `(model, device_map)` pairs from it. Template / contract cells stay pinned to `primary(role)`. `GENIEX_TEST_MODELS` swaps the whole matrix.
- **`hybrid` coverage.** `unsloth/gpt-oss-20b-GGUF` joins the matrix as a hybrid-only entry; the other models keep cpu/gpu/npu. New `device_hybrid` marker, and `hybrid` folded into the Snapdragon gate, which previously let `test_llm_logits_parity[hybrid]` run on non-Snapdragon hosts.

Collected count 60 → 73. `gpt-oss-20b` Q4_0 is ~12 GB, so both QDC legs get a longer cold run. Audio / ASR (the issue's fourth goal) is deferred — no audio-capable model in the catalogue and no audio asset to feed `generate(audios=[...])`.

## Test plan

Verified on a Snapdragon X Elite Windows ARM64 host. HuggingFace is firewalled there, so the matrix was pointed at already-cached models via `GENIEX_TEST_MODELS`.

- [x] `temperature=0.0` is nondeterministic across seeds on cpu / npu / hybrid; `-1.0` is identical on all three — measured, see comment.
- [x] Greedy comparison needs two *fresh* loads: on one handle the second `generate()` resumed the first answer instead of restarting.
- [x] `GENIEX_TEST_MODELS=<other>.json` re-parametrises every cell.
- [x] `primary(role)` resolves to the same ids / precisions as `main`'s `LLAMA_CPP_*` / `QAIRT_*` constants, so primary-pinned cells are unchanged.
- [x] Marker gate: `-m device_hybrid` → 6 cells, all `snapdragon`-marked; `-m "api or (llama_cpp and device_cpu)"` stays CPU-only (32 → 33).
- [x] QDC run 32839388090: all 5 `gpt-oss-20b-GGUF-hybrid` cells and every gpu cell pass on windows (SC8480XP, 57/58, 0 skipped) and android (SM8850); linux (QCS9075M) green. The one failure was the QAIRT truncation guard fixed above.
