### PR TITLE
fix(cli): release model resources when serve shuts down

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -4,10 +4,16 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -15,6 +21,8 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/render"
 	"github.com/qualcomm/GenieX/cli/server/service"
 )
+
+const shutdownTimeout = 30 * time.Second
 
 // hostBindingHint suggests --host 0.0.0.0 when bound to loopback, else "".
 // Malformed hosts are treated as non-loopback — better silent than misleading.
@@ -48,13 +56,11 @@ func Serve() {
 	RegisterSwagger(engine)
 
 	cfg := config.Get()
-	var err error
+	certFile := cfg.CertFile
+	keyFile := cfg.KeyFile
 
 	// Determine whether to serve over HTTPS
 	if cfg.HTTPS {
-		certFile := cfg.CertFile
-		keyFile := cfg.KeyFile
-
 		// Verify that certificate and key files exist
 		if _, err := os.Stat(certFile); os.IsNotExist(err) {
 			fmt.Println(render.GetTheme().Error.Sprintf("HTTPS Certificate file not found: %s", certFile))
@@ -67,19 +73,42 @@ func Serve() {
 
 		fmt.Println(render.GetTheme().Info.Sprintf("HTTPS enabled: cert=%s key=%s", certFile, keyFile))
 		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on https://%s/", cfg.Host))
-		if hint := hostBindingHint(cfg.Host); hint != "" {
-			fmt.Println(render.GetTheme().Info.Sprint(hint))
-		}
-		err = engine.RunTLS(cfg.Host, certFile, keyFile)
 	} else {
 		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on http://%s/", cfg.Host))
-		if hint := hostBindingHint(cfg.Host); hint != "" {
-			fmt.Println(render.GetTheme().Info.Sprint(hint))
-		}
-		err = engine.Run(cfg.Host)
+	}
+	if hint := hostBindingHint(cfg.Host); hint != "" {
+		fmt.Println(render.GetTheme().Info.Sprint(hint))
 	}
 
-	if err != nil {
-		fmt.Println(render.GetTheme().Error.Sprintf("HTTP/HTTPS Server Error: %v", err))
+	// Without this the runtime kills the process on Ctrl+C, skipping the
+	// deferred DeInit and leaking the model's NPU buffers until reboot.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	srv := &http.Server{Addr: cfg.Host, Handler: engine}
+	errCh := make(chan error, 1)
+	go func() {
+		if cfg.HTTPS {
+			errCh <- srv.ListenAndServeTLS(certFile, keyFile)
+		} else {
+			errCh <- srv.ListenAndServe()
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			fmt.Println(render.GetTheme().Error.Sprintf("HTTP/HTTPS Server Error: %v", err))
+		}
+	case <-ctx.Done():
+		// Restore the default disposition so a second Ctrl+C can still abort a
+		// teardown that a stuck request would otherwise hold up.
+		stop()
+		fmt.Println(render.GetTheme().Info.Sprint("Shutting down, releasing model resources..."))
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			fmt.Println(render.GetTheme().Warning.Sprintf("Server shutdown: %v", err))
+		}
 	}
 }

--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -13,7 +12,6 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -21,8 +19,6 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/render"
 	"github.com/qualcomm/GenieX/cli/server/service"
 )
-
-const shutdownTimeout = 30 * time.Second
 
 // hostBindingHint suggests --host 0.0.0.0 when bound to loopback, else "".
 // Malformed hosts are treated as non-loopback — better silent than misleading.
@@ -56,59 +52,42 @@ func Serve() {
 	RegisterSwagger(engine)
 
 	cfg := config.Get()
-	certFile := cfg.CertFile
-	keyFile := cfg.KeyFile
+	srv := &http.Server{Addr: cfg.Host, Handler: engine}
+	listen := srv.ListenAndServe
+	scheme := "http"
 
-	// Determine whether to serve over HTTPS
 	if cfg.HTTPS {
-		// Verify that certificate and key files exist
-		if _, err := os.Stat(certFile); os.IsNotExist(err) {
-			fmt.Println(render.GetTheme().Error.Sprintf("HTTPS Certificate file not found: %s", certFile))
-			return
+		for _, path := range []string{cfg.CertFile, cfg.KeyFile} {
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				fmt.Println(render.GetTheme().Error.Sprintf("HTTPS cert/key file not found: %s", path))
+				return
+			}
 		}
-		if _, err := os.Stat(keyFile); os.IsNotExist(err) {
-			fmt.Println(render.GetTheme().Error.Sprintf("HTTPS Key file not found: %s", keyFile))
-			return
-		}
+		listen = func() error { return srv.ListenAndServeTLS(cfg.CertFile, cfg.KeyFile) }
+		scheme = "https"
 
-		fmt.Println(render.GetTheme().Info.Sprintf("HTTPS enabled: cert=%s key=%s", certFile, keyFile))
-		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on https://%s/", cfg.Host))
-	} else {
-		fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on http://%s/", cfg.Host))
+		fmt.Println(render.GetTheme().Info.Sprintf("HTTPS enabled: cert=%s key=%s", cfg.CertFile, cfg.KeyFile))
 	}
+
+	fmt.Println(render.GetTheme().Info.Sprintf("Local hosting on %s://%s/", scheme, cfg.Host))
 	if hint := hostBindingHint(cfg.Host); hint != "" {
 		fmt.Println(render.GetTheme().Info.Sprint(hint))
 	}
 
-	// Without this the runtime kills the process on Ctrl+C, skipping the
-	// deferred DeInit and leaking the model's NPU buffers until reboot.
+	// Unhandled, Ctrl+C skips the deferred DeInit and pins NPU buffers till reboot.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
-	srv := &http.Server{Addr: cfg.Host, Handler: engine}
 	errCh := make(chan error, 1)
-	go func() {
-		if cfg.HTTPS {
-			errCh <- srv.ListenAndServeTLS(certFile, keyFile)
-		} else {
-			errCh <- srv.ListenAndServe()
-		}
-	}()
+	go func() { errCh <- listen() }()
 
+	// stop() first in both arms, so a second Ctrl+C kills instead of being swallowed.
 	select {
-	case err := <-errCh:
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			fmt.Println(render.GetTheme().Error.Sprintf("HTTP/HTTPS Server Error: %v", err))
-		}
+	case err := <-errCh: // listen only returns on failure here
+		stop()
+		fmt.Println(render.GetTheme().Error.Sprintf("HTTP/HTTPS Server Error: %v", err))
 	case <-ctx.Done():
-		// Restore the default disposition so a second Ctrl+C can still abort a
-		// teardown that a stuck request would otherwise hold up.
 		stop()
 		fmt.Println(render.GetTheme().Info.Sprint("Shutting down, releasing model resources..."))
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			fmt.Println(render.GetTheme().Warning.Sprintf("Server shutdown: %v", err))
-		}
+		srv.Shutdown(context.Background())
 	}
 }

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -107,6 +107,7 @@ type keepAliveService struct {
 	param        types.ModelParam // params the cache keys on
 	lastActivity time.Time        // when the last model request finished
 	stopCh       chan struct{}
+	doneCh       chan struct{} // closed once the sweep goroutine has freed the model
 }
 
 // keepable is a model the cache can free; keepResetable can also be reset.
@@ -123,8 +124,10 @@ type keepResetable interface {
 func (keepAlive *keepAliveService) start() {
 	keepAlive.lastActivity = time.Now()
 	keepAlive.stopCh = make(chan struct{})
+	keepAlive.doneCh = make(chan struct{})
 
 	go func() {
+		defer close(keepAlive.doneCh)
 		t := time.NewTicker(5 * time.Second)
 		for {
 			select {
@@ -242,7 +245,9 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 	return t, nil
 }
 
-// stop signals the sweep goroutine to terminate.
+// stop signals the sweep goroutine to terminate and waits for it to free the
+// cached model — returning earlier would race the SDK deinit against destroy.
 func (keepAlive *keepAliveService) stop() {
-	keepAlive.stopCh <- struct{}{}
+	close(keepAlive.stopCh)
+	<-keepAlive.doneCh
 }

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -107,7 +107,6 @@ type keepAliveService struct {
 	param        types.ModelParam // params the cache keys on
 	lastActivity time.Time        // when the last model request finished
 	stopCh       chan struct{}
-	doneCh       chan struct{} // closed once the sweep goroutine has freed the model
 }
 
 // keepable is a model the cache can free; keepResetable can also be reset.
@@ -124,17 +123,12 @@ type keepResetable interface {
 func (keepAlive *keepAliveService) start() {
 	keepAlive.lastActivity = time.Now()
 	keepAlive.stopCh = make(chan struct{})
-	keepAlive.doneCh = make(chan struct{})
 
 	go func() {
-		defer close(keepAlive.doneCh)
 		t := time.NewTicker(5 * time.Second)
 		for {
 			select {
 			case <-keepAlive.stopCh:
-				middleware.GILock.Lock()
-				keepAlive.destroy()
-				middleware.GILock.Unlock()
 				return
 
 			case <-t.C:
@@ -245,9 +239,11 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 	return t, nil
 }
 
-// stop signals the sweep goroutine to terminate and waits for it to free the
-// cached model — returning earlier would race the SDK deinit against destroy.
+// stop ends the sweep goroutine and frees the cached model — here rather than in
+// the goroutine, so it lands before the SDK deinit that follows.
 func (keepAlive *keepAliveService) stop() {
 	close(keepAlive.stopCh)
-	<-keepAlive.doneCh
+	middleware.GILock.Lock()
+	defer middleware.GILock.Unlock()
+	keepAlive.destroy()
 }


### PR DESCRIPTION
## Summary

`geniex serve` installed no signal handler, so Ctrl+C left the Go runtime to terminate the process with its default disposition. `Serve()`'s only teardown is a deferred `service.DeInit()`, which the runtime never runs, so `keepAlive.destroy()` -> `geniex_llm_destroy` and `geniex_deinit` were both skipped and the loaded model's HTP allocations stayed pinned until reboot (#1482). The next `serve` was then OOM-killed while loading, or returned `500 SDKError(Model loading failed)` on every request - as reported against the `v0.5.1-alpha.1` Linux ARM64 release.

Serve on an `http.Server` driven by `signal.NotifyContext` instead, so SIGINT/SIGTERM drains in-flight requests and then falls through to the existing deferred teardown. The handler restores the default disposition once triggered, so a second Ctrl+C still aborts if a stuck request holds up the drain.

Also fixes a race on the same path: `keepAlive.stop()` sent on an unbuffered channel whose receiver only calls `destroy()` *after* that send completes, so `DeInit()` returned while the model was still being freed and `geniex_deinit()` could race `geniex_llm_destroy()`. `stop()` now waits for the sweep goroutine to finish.

## Test plan

Snapdragon X2 Elite / Debian 13, `gemma-4-26B-A4B-it-qat-q4_0` across 4 HTP devices, device rebooted first so the baseline is clean. CLI built natively on the device (aarch64, Go 1.25.9) against the release `libgeniex.so`.

- [x] Ctrl+C releases the model: `used` 17 541 -> 589 MB (idle baseline 532 MB), exit status 0, `Shutting down, releasing model resources...` logged. Before the fix: 17 566 -> 15 153 MB, killed by signal 2, nothing logged.
- [x] A second `serve` after Ctrl+C answers 200 with no reboot in between; before the fix it was OOM-killed mid-load (`Out of memory: Killed process 1602 (geniex) total-vm:18921216kB`).
- [x] Shutdown with no model ever loaded exits in 2 s.
- [x] TLS branch serves HTTPS (302 on `/`) and shuts down cleanly - see the note below on how this had to be exercised.

