### PR TITLE
feat(sdk): add geniex_model_get_detailed for single-model lookups

### DIFF
--- a/bindings/android/app/src/main/cpp/model_manager_jni.cpp
+++ b/bindings/android/app/src/main/cpp/model_manager_jni.cpp
@@ -477,6 +477,22 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_com_geniex_sdk_jni_ModelManager_l
     return arr;
 }
 
+extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_ModelManager_getDetailed(
+    JNIEnv* env, jobject /*thiz*/, jstring jModelName) {
+    std::string name = jstring2str(env, jModelName);
+    if (name.empty()) return nullptr;
+
+    geniex_ModelDetail d{};
+    int32_t            rc = geniex_model_get_detailed(name.c_str(), &d);
+    if (rc != GENIEX_SUCCESS) {
+        LOGe("[ModelManager JNI] getDetailed(%s) failed rc=%d", name.c_str(), rc);
+        return nullptr;
+    }
+    jobject item = build_model_detail(env, d);
+    geniex_model_detail_free(&d);
+    return item;
+}
+
 extern "C" JNIEXPORT jobject JNICALL Java_com_geniex_sdk_jni_ModelManager_query(
     JNIEnv* env, jobject /*thiz*/, jobject inputObj) {
     if (!inputObj) {

--- a/bindings/android/app/src/main/java/com/geniex/sdk/jni/ModelManager.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/jni/ModelManager.kt
@@ -44,6 +44,15 @@ internal class ModelManager {
     external fun listDetailed(): Array<ModelDetail>
 
     /**
+     * One cached model's metadata, without listing the whole store.
+     * [modelName] takes the same loose forms as [getPaths]: a bare AI Hub id is
+     * canonicalized to `qualcomm/<id>`, and any `:<precision>` suffix is
+     * ignored since the detail covers every downloaded precision.
+     * @return `null` if the model is not cached.
+     */
+    external fun getDetailed(modelName: String): ModelDetail?
+
+    /**
      * Resolve a model's remote candidate quantizations without downloading.
      * @return `null` if the model cannot be planned.
      */

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -239,16 +239,36 @@ func ModelListDetailed() ([]ModelDetail, error) {
 	models := unsafe.Slice(out.models, int(out.count))
 	result := make([]ModelDetail, out.count)
 	for i, m := range models {
-		result[i] = ModelDetail{
-			Name:       C.GoString(m.name),
-			ModelName:  C.GoString(m.model_name),
-			RuntimeID:  C.GoString(m.plugin_id),
-			ModelType:  ModelType(m.model_type),
-			TotalSize:  int64(m.total_size),
-			Precisions: cCharArrayToSlice(m.precisions, m.precision_count),
-		}
+		result[i] = goModelDetail(m)
 	}
 	return result, nil
+}
+
+// ModelGetDetailed returns one cached model's metadata without listing the
+// whole store. name takes the same loose forms as ModelGetPaths: a bare AI Hub
+// id is canonicalized to "qualcomm/<id>" in the SDK, and any ":precision"
+// suffix is ignored since the detail covers every downloaded precision.
+func ModelGetDetailed(name string) (*ModelDetail, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+	var out C.geniex_ModelDetail
+	if res := C.geniex_model_get_detailed(cName, &out); res != C.GENIEX_SUCCESS {
+		return nil, modelError(res)
+	}
+	defer C.geniex_model_detail_free(&out)
+	d := goModelDetail(out)
+	return &d, nil
+}
+
+func goModelDetail(m C.geniex_ModelDetail) ModelDetail {
+	return ModelDetail{
+		Name:       C.GoString(m.name),
+		ModelName:  C.GoString(m.model_name),
+		RuntimeID:  C.GoString(m.plugin_id),
+		ModelType:  ModelType(m.model_type),
+		TotalSize:  int64(m.total_size),
+		Precisions: cCharArrayToSlice(m.precisions, m.precision_count),
+	}
 }
 
 // ChipsetInfo mirrors geniex_ChipsetInfo.

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -27,6 +27,7 @@ from ._types import (
     geniex_LlmGenerateInput,
     geniex_LlmGenerateOutput,
     geniex_LlmModelInfo,
+    geniex_ModelDetail,
     geniex_ModelListDetailedOutput,
     geniex_ModelPaths,
     geniex_ModelPullInput,
@@ -274,6 +275,12 @@ def _bind_all() -> None:
 
     lib.geniex_model_list_detailed_free.argtypes = [POINTER(geniex_ModelListDetailedOutput)]
     lib.geniex_model_list_detailed_free.restype = None
+
+    lib.geniex_model_get_detailed.argtypes = [c_char_p, POINTER(geniex_ModelDetail)]
+    lib.geniex_model_get_detailed.restype = c_int32
+
+    lib.geniex_model_detail_free.argtypes = [POINTER(geniex_ModelDetail)]
+    lib.geniex_model_detail_free.restype = None
 
     lib.geniex_model_query.argtypes = [
         POINTER(geniex_ModelPullInput),

--- a/bindings/python/geniex/model_manager.py
+++ b/bindings/python/geniex/model_manager.py
@@ -22,6 +22,7 @@ from ._ffi._types import (
     geniex_ChipsetList,
     geniex_download_progress_cb,
     geniex_HubModelList,
+    geniex_ModelDetail,
     geniex_ModelListDetailedOutput,
     geniex_ModelPaths,
     geniex_ModelPullInput,
@@ -40,6 +41,7 @@ __all__ = [
     'pull',
     'list_models',
     'list_detailed',
+    'get_detailed',
     'last_error_message',
     'query',
     'remove',
@@ -322,22 +324,39 @@ def list_detailed() -> list[ModelDetail]:
     out = geniex_ModelListDetailedOutput()
     _check(lib.geniex_model_list_detailed(byref(out)))
     try:
-        models = []
-        for i in range(out.count):
-            d = out.models[i]
-            models.append(
-                ModelDetail(
-                    name=d.name.decode() if d.name else '',
-                    model_name=d.model_name.decode() if d.model_name else '',
-                    runtime=d.plugin_id.decode() if d.plugin_id else '',
-                    model_type=_type_str(d.model_type),
-                    total_size=d.total_size,
-                    precisions=[d.precisions[j].decode() for j in range(d.precision_count)],
-                )
-            )
-        return models
+        return [_model_detail(out.models[i]) for i in range(out.count)]
     finally:
         lib.geniex_model_list_detailed_free(byref(out))
+
+
+def get_detailed(name: str) -> ModelDetail:
+    """Return one cached model's metadata, without listing the whole store.
+
+    ``name`` takes the same loose forms as :func:`get_paths`: a bare AI Hub id
+    is canonicalized to ``qualcomm/<id>`` by the SDK, and any ``:<precision>``
+    suffix is ignored since the detail covers every downloaded precision.
+
+    Raises :class:`GenieXError` if the model is not cached.
+    """
+    _ensure_init()
+    lib = load_library()
+    out = geniex_ModelDetail()
+    _check(lib.geniex_model_get_detailed(name.encode(), byref(out)))
+    try:
+        return _model_detail(out)
+    finally:
+        lib.geniex_model_detail_free(byref(out))
+
+
+def _model_detail(d: geniex_ModelDetail) -> ModelDetail:
+    return ModelDetail(
+        name=d.name.decode() if d.name else '',
+        model_name=d.model_name.decode() if d.model_name else '',
+        runtime=d.plugin_id.decode() if d.plugin_id else '',
+        model_type=_type_str(d.model_type),
+        total_size=d.total_size,
+        precisions=[d.precisions[j].decode() for j in range(d.precision_count)],
+    )
 
 
 def query(

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -534,13 +534,8 @@ func pullModel(ctx context.Context, name string, quant string) error {
 	if quant != "" {
 		key = name + ":" + quant
 	}
-	if models, err := geniex_sdk.ModelListDetailed(); err == nil {
-		for _, m := range models {
-			if m.Name == name && m.TotalSize > 0 {
-				fmt.Println(render.GetTheme().Info.Sprintf("   Size:      %s", humanize.IBytes(uint64(m.TotalSize))))
-				break
-			}
-		}
+	if m, err := geniex_sdk.ModelGetDetailed(name); err == nil && m.TotalSize > 0 {
+		fmt.Println(render.GetTheme().Info.Sprintf("   Size:      %s", humanize.IBytes(uint64(m.TotalSize))))
 	}
 	if paths, err := geniex_sdk.ModelGetPaths(key); err == nil && paths.ModelPath != "" {
 		fmt.Println(render.GetTheme().Info.Sprintf("   Location:  %s", filepath.Dir(paths.ModelPath)))

--- a/cli/server/handler/model.go
+++ b/cli/server/handler/model.go
@@ -44,33 +44,36 @@ func ListModels(c *gin.Context) {
 func RetrieveModel(c *gin.Context) {
 	name, quant := geniex_sdk.SplitNamePrecision(strings.TrimPrefix(c.Param("model"), "/"))
 
-	models, err := geniex_sdk.ModelListDetailed()
+	// ModelGetDetailed canonicalizes the name in the SDK, so an alias form the
+	// store never records under (a bare AI Hub id) still resolves.
+	m, err := geniex_sdk.ModelGetDetailed(name)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		if geniex_sdk.IsModelNotFound(err) {
+			c.JSON(http.StatusNotFound, nil)
+		} else {
+			c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		}
 		return
 	}
-
-	idx := slices.IndexFunc(models, func(m geniex_sdk.ModelDetail) bool { return m.Name == name })
-	if idx < 0 {
-		c.JSON(http.StatusNotFound, nil)
-		return
-	}
-	m := models[idx]
 
 	if quant == "" {
-		precisions := slices.Clone(m.Precisions)
-		slices.Sort(precisions)
+		precisions := slices.Sorted(slices.Values(m.Precisions))
 		if len(precisions) == 0 {
 			c.JSON(http.StatusNotFound, nil)
 			return
 		}
 		quant = precisions[0]
-	} else if !slices.ContainsFunc(m.Precisions, func(p string) bool { return strings.EqualFold(p, quant) }) {
+	} else if i := slices.IndexFunc(m.Precisions, func(p string) bool {
+		return strings.EqualFold(p, quant)
+	}); i < 0 {
 		c.JSON(http.StatusNotFound, nil)
 		return
+	} else {
+		// echo the precision as the store spells it, not as the caller cased it
+		quant = m.Precisions[i]
 	}
 
-	id := name
+	id := m.Name
 	if quant != geniex_sdk.PrecisionNA {
 		id += ":" + quant
 	}

--- a/sdk/model-manager/crates/core/src/store.rs
+++ b/sdk/model-manager/crates/core/src/store.rs
@@ -238,6 +238,36 @@ impl Store {
         })
     }
 
+    /// Read one cached model's manifest, accepting the same loose name forms as
+    /// [`Self::get_paths`]: a non-canonical name is canonicalized and any
+    /// ":quant" suffix is dropped, since a manifest covers every precision.
+    ///
+    /// Canonicalization runs first so a pasted HuggingFace URL still resolves:
+    /// `split_quant` would otherwise cut at the colon in "https:".
+    pub fn resolve_manifest(&self, name_with_quant: &str) -> Result<ModelManifest> {
+        let canonical = canonicalize_model_name(name_with_quant);
+        let (name, _) = split_quant(&canonical);
+        validate_model_name(name)?;
+        self.get_manifest(name)
+    }
+
+    /// Read one cached model's manifest for reporting, skipping a model whose
+    /// directory holds an in-progress pull so this agrees with [`Self::list`].
+    /// The load path ([`Self::get_paths`] / [`Self::get_model_type`]) keeps
+    /// resolving the already-cached precisions while another one is pulling.
+    pub fn resolve_detail_manifest(&self, name_with_quant: &str) -> Result<ModelManifest> {
+        let manifest = self.resolve_manifest(name_with_quant)?;
+        if self
+            .cfg
+            .model_dir(&manifest.name)
+            .join(INFLIGHT_DIR)
+            .exists()
+        {
+            return Err(Error::ModelNotFound(manifest.name));
+        }
+        Ok(manifest)
+    }
+
     /// Resolve a model name (with optional ":quant" suffix) to ModelPaths.
     ///
     /// Accepts a bare name (no '/') and canonicalises it to `qualcomm/<name>`
@@ -407,6 +437,51 @@ mod tests {
         store.write_manifest(&m).unwrap();
         let loaded = store.get_manifest("TestOrg/TestRepo").unwrap();
         assert_eq!(loaded.name, "TestOrg/TestRepo");
+    }
+
+    #[test]
+    fn resolve_manifest_canonicalizes_and_drops_quant() {
+        let (store, _tmp) = make_store();
+        store
+            .write_manifest(&sample_manifest("qualcomm/Bare"))
+            .unwrap();
+        // bare name -> qualcomm/<name>, and the ":quant" suffix is ignored
+        assert_eq!(
+            store.resolve_manifest("Bare").unwrap().name,
+            "qualcomm/Bare"
+        );
+        assert_eq!(
+            store.resolve_manifest("Bare:Q4_K_M").unwrap().name,
+            "qualcomm/Bare"
+        );
+        assert!(store.resolve_manifest("Org/Missing").is_err());
+    }
+
+    #[test]
+    fn resolve_manifest_accepts_a_pasted_hf_url() {
+        let (store, _tmp) = make_store();
+        store
+            .write_manifest(&sample_manifest("ggml-org/Qwen3"))
+            .unwrap();
+        assert_eq!(
+            store
+                .resolve_manifest("https://huggingface.co/ggml-org/Qwen3")
+                .unwrap()
+                .name,
+            "ggml-org/Qwen3"
+        );
+    }
+
+    #[test]
+    fn resolve_detail_manifest_skips_inflight() {
+        let (store, _tmp) = make_store();
+        store
+            .write_manifest(&sample_manifest("Org/Pulling"))
+            .unwrap();
+        fs::create_dir_all(store.cfg.model_dir("Org/Pulling").join(INFLIGHT_DIR)).unwrap();
+        // hidden from list + get_detailed, but still loadable through get_paths
+        assert!(store.resolve_detail_manifest("Org/Pulling").is_err());
+        assert!(store.resolve_manifest("Org/Pulling").is_ok());
     }
 
     #[test]

--- a/sdk/model-manager/crates/core/src/store.rs
+++ b/sdk/model-manager/crates/core/src/store.rs
@@ -224,8 +224,7 @@ impl Store {
     }
 
     pub fn get_model_type(&self, name: &str) -> Result<ModelType> {
-        let name = canonicalize_model_name(name);
-        Ok(self.get_manifest(&name)?.model_type)
+        Ok(self.resolve_manifest(name)?.model_type)
     }
 
     pub fn set_model_type(&self, name: &str, model_type: ModelType) -> Result<()> {
@@ -491,6 +490,19 @@ mod tests {
         store.write_manifest(&sample_manifest("Org/B")).unwrap();
         let list = store.list().unwrap();
         assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn get_model_type_tolerates_a_precision_suffix() {
+        let (store, _tmp) = make_store();
+        store
+            .write_manifest(&sample_manifest("qualcomm/Typed"))
+            .unwrap();
+        // get_paths accepts "<name>:<quant>"; get_type must not diverge
+        assert_eq!(
+            store.get_model_type("Typed:Q4_K_M").unwrap(),
+            ModelType::Llm
+        );
     }
 
     #[test]

--- a/sdk/model-manager/crates/ffi/src/store.rs
+++ b/sdk/model-manager/crates/ffi/src/store.rs
@@ -3,7 +3,7 @@
 
 use std::os::raw::c_char;
 
-use model_manager_core::manifest::ModelType;
+use model_manager_core::manifest::{ModelManifest, ModelType};
 
 use crate::init::get_store;
 use crate::types::*;
@@ -93,6 +93,41 @@ pub unsafe extern "C" fn geniex_model_paths_free(paths: *mut GenieXModelPaths) {
     *paths = GenieXModelPaths::null();
 }
 
+/// Build the C view of one manifest: every heap member is owned by the caller
+/// and reclaimed by [`free_detail`].
+fn detail_from_manifest(m: &ModelManifest) -> GenieXModelDetail {
+    let downloaded = m
+        .model_file
+        .iter()
+        .filter(|(_, fi)| fi.downloaded)
+        .map(|(q, _)| str_to_cptr(q))
+        .collect();
+    let (precisions, precision_count) = into_c_array(downloaded);
+    GenieXModelDetail {
+        name: str_to_cptr(&m.name),
+        model_name: str_to_cptr(&m.model_name),
+        plugin_id: str_to_cptr(&m.plugin_id),
+        model_type: to_ffi_type(m.model_type.clone()),
+        total_size: m.total_size(),
+        precisions,
+        precision_count,
+    }
+}
+
+/// # Safety
+/// `d` must have been produced by [`detail_from_manifest`] and not freed yet.
+unsafe fn free_detail(d: &mut GenieXModelDetail) {
+    free_cptr(d.name);
+    free_cptr(d.model_name);
+    free_cptr(d.plugin_id);
+    if let Some(precs) = from_c_array(d.precisions, d.precision_count) {
+        for p in precs {
+            free_cptr(p);
+        }
+    }
+    *d = GenieXModelDetail::null();
+}
+
 /* ---- geniex_model_remove / clean ---- */
 
 #[no_mangle]
@@ -167,6 +202,20 @@ pub struct GenieXModelDetail {
     pub precision_count: i32,
 }
 
+impl GenieXModelDetail {
+    fn null() -> Self {
+        Self {
+            name: std::ptr::null_mut(),
+            model_name: std::ptr::null_mut(),
+            plugin_id: std::ptr::null_mut(),
+            model_type: GenieXModelType::Llm,
+            total_size: 0,
+            precisions: std::ptr::null_mut(),
+            precision_count: 0,
+        }
+    }
+}
+
 #[repr(C)]
 pub struct GenieXModelListDetailedOutput {
     pub models: *mut GenieXModelDetail,
@@ -180,28 +229,7 @@ pub extern "C" fn geniex_model_list_detailed(output: *mut GenieXModelListDetaile
             return Err(GENIEX_ERROR_COMMON_INVALID_INPUT);
         }
         let manifests = get_store()?.list().map_err(|e| report(&e))?;
-        let details: Vec<GenieXModelDetail> = manifests
-            .iter()
-            .map(|m| {
-                let downloaded: Vec<&str> = m
-                    .model_file
-                    .iter()
-                    .filter(|(_, fi)| fi.downloaded)
-                    .map(|(q, _)| q.as_str())
-                    .collect();
-                let precs: Vec<*mut c_char> = downloaded.iter().map(|q| str_to_cptr(q)).collect();
-                let (precisions, precision_count) = into_c_array(precs);
-                GenieXModelDetail {
-                    name: str_to_cptr(&m.name),
-                    model_name: str_to_cptr(&m.model_name),
-                    plugin_id: str_to_cptr(&m.plugin_id),
-                    model_type: to_ffi_type(m.model_type.clone()),
-                    total_size: m.total_size(),
-                    precisions,
-                    precision_count,
-                }
-            })
-            .collect();
+        let details: Vec<GenieXModelDetail> = manifests.iter().map(detail_from_manifest).collect();
         let (models, count) = into_c_array(details);
         unsafe {
             (*output).models = models;
@@ -221,14 +249,7 @@ pub unsafe extern "C" fn geniex_model_list_detailed_free(
     let o = &mut *output;
     if let Some(mut details) = from_c_array(o.models, o.count) {
         for d in details.iter_mut() {
-            free_cptr(d.name);
-            free_cptr(d.model_name);
-            free_cptr(d.plugin_id);
-            if let Some(precs) = from_c_array(d.precisions, d.precision_count) {
-                for p in precs {
-                    free_cptr(p);
-                }
-            }
+            free_detail(d);
         }
     }
     o.models = std::ptr::null_mut();

--- a/sdk/model-manager/crates/ffi/src/store.rs
+++ b/sdk/model-manager/crates/ffi/src/store.rs
@@ -128,6 +128,34 @@ unsafe fn free_detail(d: &mut GenieXModelDetail) {
     *d = GenieXModelDetail::null();
 }
 
+/* ---- geniex_model_get_detailed ---- */
+
+#[no_mangle]
+pub extern "C" fn geniex_model_get_detailed(
+    model_name: *const c_char,
+    out: *mut GenieXModelDetail,
+) -> i32 {
+    ffi_guard(|| {
+        if out.is_null() {
+            return Err(GENIEX_ERROR_COMMON_INVALID_INPUT);
+        }
+        let name = unsafe { cstr_to_str(model_name) }?;
+        let manifest = get_store()?
+            .resolve_detail_manifest(name)
+            .map_err(|e| report(&e))?;
+        unsafe { *out = detail_from_manifest(&manifest) };
+        Ok(GENIEX_SUCCESS)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn geniex_model_detail_free(detail: *mut GenieXModelDetail) {
+    if detail.is_null() {
+        return;
+    }
+    free_detail(&mut *detail);
+}
+
 /* ---- geniex_model_remove / clean ---- */
 
 #[no_mangle]

--- a/sdk/model-manager/include/geniex_model.h
+++ b/sdk/model-manager/include/geniex_model.h
@@ -190,7 +190,8 @@ GENIEX_API int32_t geniex_model_clean(int32_t* removed_count);
 
 /**
  * @brief Get the model type of a cached model.
- * @param model_name  "org/repo" format.
+ * @param model_name  "org/repo", a bare AI Hub id, or a HuggingFace URL, each
+ *                    with an optional ":<quant>" suffix that is ignored.
  * @param out_type    Set on success.
  * @return GENIEX_SUCCESS, or a negative geniex_ErrorCode.
  */

--- a/sdk/model-manager/include/geniex_model.h
+++ b/sdk/model-manager/include/geniex_model.h
@@ -125,7 +125,8 @@ GENIEX_API void geniex_model_paths_free(geniex_ModelPaths* paths);
  * @brief Detailed metadata for one cached model.
  *
  * All non-NULL char* fields (and the `precisions` array) are heap-allocated;
- * free the enclosing output with geniex_model_list_detailed_free().
+ * free the enclosing output with geniex_model_list_detailed_free(), or a
+ * standalone detail with geniex_model_detail_free().
  */
 typedef struct {
     char*            name;       /**< "org/repo".                          */
@@ -151,6 +152,27 @@ GENIEX_API int32_t geniex_model_list_detailed(geniex_ModelListDetailedOutput* ou
 
 /** Free every model's strings + precisions array, then zero the struct. */
 GENIEX_API void geniex_model_list_detailed_free(geniex_ModelListDetailedOutput* output);
+
+/**
+ * @brief Look up one cached model's metadata, without listing the whole store.
+ *
+ * The single-model counterpart of geniex_model_list_detailed(): it reads that
+ * model's manifest directly instead of walking every cached model. @p
+ * model_name takes the same loose forms as geniex_model_get_paths() — a bare
+ * name is canonicalized to `qualcomm/<name>`, and any `:<quant>` suffix is
+ * ignored, since the detail covers every downloaded precision. Like the
+ * listing, a model with an in-progress pull is reported as not cached.
+ *
+ * @param model_name  "org/repo", a bare AI Hub id, or a HuggingFace URL, each
+ *                    with an optional ":<quant>" suffix.
+ * @param out         Populated on success. Call geniex_model_detail_free() when done.
+ * @return GENIEX_SUCCESS, or a negative geniex_ErrorCode
+ *         (GENIEX_ERROR_COMMON_FILE_NOT_FOUND when the model is not cached).
+ */
+GENIEX_API int32_t geniex_model_get_detailed(const char* model_name, geniex_ModelDetail* out);
+
+/** Free one detail's strings + precisions array, then zero the struct. */
+GENIEX_API void geniex_model_detail_free(geniex_ModelDetail* detail);
 
 /**
  * @brief Delete a cached model from disk.

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -36,6 +36,8 @@ if(WIN32)
         geniex_model_set_type
         geniex_model_list_detailed
         geniex_model_list_detailed_free
+        geniex_model_get_detailed
+        geniex_model_detail_free
         geniex_model_query
         geniex_model_query_free
         geniex_model_resolve_alias


### PR DESCRIPTION
## Summary

`RetrieveModel` and the `pull` summary each needed one model's metadata and got
it by listing the whole store, matching on `m.Name == name` — which misses any
alias the store never records under, so a bare AI Hub id 404'd on a cached model.

Adds `geniex_model_get_detailed` / `geniex_model_detail_free`, the single-model
counterpart of the listing, and routes both call sites through it.
Canonicalization now happens in the SDK, so every binding gets the loose name
forms (`org/repo`, bare AI Hub id, HuggingFace URL, optional `:<quant>`) without
re-implementing the alias table.

Six commits: an ffi refactor to share the detail C view; the new SDK pair;
`geniex_model_get_type` routed through the same resolver (it required strict
`org/repo` while `get_paths` did not); the Go/Python/Android bindings plus the two
Windows exports; `RetrieveModel` through the SDK, echoing the store's spelling of
the precision and keeping `500` for failures that are not a cache miss; and the
`pull` summary's `Size:` line.

The new lookup skips a model with an in-flight pull so it agrees with the
listing. The load path (`get_paths` / `get_model_type`) deliberately does not —
an already-cached precision stays loadable while another one downloads.

## Test plan

- [x] `cargo test` in `sdk/model-manager` — 174 passed; each SDK commit builds and
      passes on its own (170 → 173 → 174)
- [x] `bazelisk build //cli`, `bazelisk test //cli/server/...` — 6 passed,
      3 windows-skipped
- [x] E2E against `serve` on an isolated `--data-dir`: `/v1/models` and
      `/v1/models/X` agree both with and without `.inflight`; a lowercase
      `:q4_k_m` request echoes back `Q4_K_M`; an uncached model 404s
- [x] `geniex_model_get_type` via `ctypes`: plain name, `:Q4_K_M`, HF URL, and
      URL+suffix all resolve; uncached returns `GENIEX_ERROR_COMMON_FILE_NOT_FOUND`
      (the header previously named a non-existent `GENIEX_ERROR_MODEL_NOT_FOUND`)
- [x] `cargo fmt --check`, `gofmt`, `clang-format`, `ruff check` clean

Closes [qcom-ai-hub/geniex#1495](https://github.com/qcom-ai-hub/geniex/issues/1495).

Out of scope: two pre-existing precision-resolution bugs found while reviewing
this — [qcom-ai-hub/geniex#1494](https://github.com/qcom-ai-hub/geniex/issues/1494).
