### PR TITLE
fix(sdk): keep sibling chunks alive when one chunk download fails

### DIFF
--- a/sdk/model-manager/crates/core/src/executor/mod.rs
+++ b/sdk/model-manager/crates/core/src/executor/mod.rs
@@ -78,6 +78,25 @@ fn env_usize(key: &str) -> Option<usize> {
         .filter(|v| *v > 0)
 }
 
+#[derive(Clone)]
+struct StopSignals {
+    user: CancellationToken,
+    failed: CancellationToken,
+}
+
+impl StopSignals {
+    fn new() -> Self {
+        Self {
+            user: CancellationToken::new(),
+            failed: CancellationToken::new(),
+        }
+    }
+
+    fn halt_new_work(&self) -> bool {
+        self.user.is_cancelled() || self.failed.is_cancelled()
+    }
+}
+
 struct FileState {
     name: String,
     total_bytes: AtomicU64,
@@ -140,7 +159,7 @@ impl Executor {
             })
             .collect();
 
-        let cancel = CancellationToken::new();
+        let stop = StopSignals::new();
         let file_sem = Arc::new(Semaphore::new(self.cfg.file_concurrency));
         let chunk_sem = Arc::new(Semaphore::new(self.cfg.chunk_concurrency));
 
@@ -153,13 +172,13 @@ impl Executor {
             let chunk_sem = chunk_sem.clone();
             let transport = transport.clone();
             let dest_dir = dest_owned.clone();
-            let cancel = cancel.clone();
+            let stop = stop.clone();
             file_tasks.spawn(async move {
                 let _permit = file_sem
                     .acquire_owned()
                     .await
                     .map_err(|e| Error::Http(format!("file semaphore closed: {e}")))?;
-                run_one(spec, state, &dest_dir, transport, chunk_sem, cancel).await
+                run_one(spec, state, &dest_dir, transport, chunk_sem, stop).await
             });
         }
 
@@ -176,11 +195,11 @@ impl Executor {
                         None => break,
                         Some(Ok(Ok(()))) => {}
                         Some(Ok(Err(e))) => {
-                            cancel.cancel();
+                            stop.failed.cancel();
                             first_err.get_or_insert(e);
                         }
                         Some(Err(join_err)) => {
-                            cancel.cancel();
+                            stop.failed.cancel();
                             first_err.get_or_insert(Error::Http(format!("join: {join_err}")));
                         }
                     }
@@ -190,7 +209,7 @@ impl Executor {
                         let snaps: Vec<FileProgress> =
                             states.iter().map(|s| s.snapshot()).collect();
                         if !(cb)(&snaps) {
-                            cancel.cancel();
+                            stop.user.cancel();
                         }
                     }
                 }
@@ -205,7 +224,7 @@ impl Executor {
         if let Some(e) = first_err {
             return Err(e);
         }
-        if cancel.is_cancelled() {
+        if stop.user.is_cancelled() {
             return Err(Error::Cancelled);
         }
         Ok(())
@@ -218,7 +237,7 @@ async fn run_one(
     dest_dir: &Path,
     transport: Arc<dyn HttpTransport>,
     chunk_sem: Arc<Semaphore>,
-    cancel: CancellationToken,
+    stop: StopSignals,
 ) -> Result<()> {
     match spec.bytes.clone() {
         BytesSource::Http { url, auth } => {
@@ -229,7 +248,7 @@ async fn run_one(
                     state,
                     transport,
                     chunk_sem,
-                    cancel,
+                    stop,
                     url,
                     auth,
                     base_offset: 0,
@@ -253,7 +272,7 @@ async fn run_one(
                     state,
                     transport,
                     chunk_sem,
-                    cancel,
+                    stop,
                     url,
                     auth,
                     base_offset: offset,
@@ -277,7 +296,7 @@ async fn run_one(
                     offset,
                     state,
                     transport,
-                    cancel,
+                    stop,
                     url,
                     auth,
                 },
@@ -447,7 +466,7 @@ struct RangeJob {
     state: Arc<FileState>,
     transport: Arc<dyn HttpTransport>,
     chunk_sem: Arc<Semaphore>,
-    cancel: CancellationToken,
+    stop: StopSignals,
     url: url::Url,
     auth: Option<String>,
     /// Added to every range request. `Http` uses 0; `HttpRange` uses the
@@ -466,7 +485,7 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
         state,
         transport,
         chunk_sem,
-        cancel,
+        stop,
         url,
         auth,
         base_offset,
@@ -497,7 +516,7 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
 
     let mut chunk_tasks: JoinSet<Result<()>> = JoinSet::new();
     for range in pending {
-        if cancel.is_cancelled() {
+        if stop.halt_new_work() {
             break;
         }
         let sem = chunk_sem.clone();
@@ -507,15 +526,18 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
         let output_path = output_path.clone();
         let marker_path = marker_path.clone();
         let state = state.clone();
-        let cancel = cancel.clone();
+        let stop = stop.clone();
         chunk_tasks.spawn(async move {
-            if cancel.is_cancelled() {
+            if stop.halt_new_work() {
                 return Err(Error::Cancelled);
             }
             let _permit = sem
                 .acquire_owned()
                 .await
                 .map_err(|e| Error::Http(format!("chunk semaphore closed: {e}")))?;
+            if stop.halt_new_work() {
+                return Err(Error::Cancelled);
+            }
 
             let mut file = OpenOptions::new()
                 .write(true)
@@ -534,7 +556,7 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
             );
             tokio::select! {
                 biased;
-                _ = cancel.cancelled() => return Err(Error::Cancelled),
+                _ = stop.user.cancelled() => return Err(Error::Cancelled),
                 res = fetch => res?,
             }
             drop(counted);
@@ -546,20 +568,16 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
         });
     }
 
-    // Let every spawned chunk task run to completion instead of cancelling
-    // siblings on the first error — chunks that are already in flight are
-    // typically about to succeed, and cancelling them would discard bytes
-    // that were already downloaded before they get a chance to persist
-    // their bit in the `.progress` bitmap. Only a real cooperative cancel
-    // (via the progress callback) should preempt in-flight chunks.
     let mut first_err: Option<Error> = None;
     while let Some(res) = chunk_tasks.join_next().await {
         match res {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
+                stop.failed.cancel();
                 first_err.get_or_insert(e);
             }
             Err(join_err) => {
+                stop.failed.cancel();
                 first_err.get_or_insert(Error::Http(format!("chunk join: {join_err}")));
             }
         }
@@ -568,7 +586,7 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
     if let Some(e) = first_err {
         return Err(e);
     }
-    if cancel.is_cancelled() {
+    if stop.user.is_cancelled() {
         return Err(Error::Cancelled);
     }
     Ok(())
@@ -582,7 +600,7 @@ struct DeflateJob {
     offset: u64,
     state: Arc<FileState>,
     transport: Arc<dyn HttpTransport>,
-    cancel: CancellationToken,
+    stop: StopSignals,
     url: url::Url,
     auth: Option<String>,
 }
@@ -599,7 +617,7 @@ async fn download_http_deflate(job: DeflateJob, dest_dir: &Path) -> Result<()> {
         offset,
         state,
         transport,
-        cancel,
+        stop,
         url,
         auth,
     } = job;
@@ -628,7 +646,7 @@ async fn download_http_deflate(job: DeflateJob, dest_dir: &Path) -> Result<()> {
         }
     }
 
-    if cancel.is_cancelled() {
+    if stop.halt_new_work() {
         return Err(Error::Cancelled);
     }
 
@@ -654,12 +672,12 @@ async fn download_http_deflate(job: DeflateJob, dest_dir: &Path) -> Result<()> {
             transport.get_range(&url, auth.as_deref(), offset, compressed_len, &mut counted);
         tokio::select! {
             biased;
-            _ = cancel.cancelled() => return Err(Error::Cancelled),
+            _ = stop.user.cancelled() => return Err(Error::Cancelled),
             res = fetch => res?,
         }
     }
 
-    if cancel.is_cancelled() {
+    if stop.user.is_cancelled() {
         return Err(Error::Cancelled);
     }
 

--- a/sdk/model-manager/crates/core/src/executor/mod.rs
+++ b/sdk/model-manager/crates/core/src/executor/mod.rs
@@ -546,16 +546,20 @@ async fn download_range_based(job: RangeJob, dest_dir: &Path) -> Result<()> {
         });
     }
 
+    // Let every spawned chunk task run to completion instead of cancelling
+    // siblings on the first error — chunks that are already in flight are
+    // typically about to succeed, and cancelling them would discard bytes
+    // that were already downloaded before they get a chance to persist
+    // their bit in the `.progress` bitmap. Only a real cooperative cancel
+    // (via the progress callback) should preempt in-flight chunks.
     let mut first_err: Option<Error> = None;
     while let Some(res) = chunk_tasks.join_next().await {
         match res {
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
-                cancel.cancel();
                 first_err.get_or_insert(e);
             }
             Err(join_err) => {
-                cancel.cancel();
                 first_err.get_or_insert(Error::Http(format!("chunk join: {join_err}")));
             }
         }

--- a/sdk/model-manager/crates/core/tests/executor.rs
+++ b/sdk/model-manager/crates/core/tests/executor.rs
@@ -278,6 +278,65 @@ async fn cancel_via_callback_returns_cancelled() {
     assert!(calls.load(Ordering::SeqCst) >= 1);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn chunk_failure_stops_queued_chunks_from_starting() {
+    std::env::set_var("GENIEX_DL_CHUNK_SIZE", "16384");
+
+    let server = MockServer::start().await;
+    let body = make_body(32 * 16 * 1024, 0x5C);
+    let total_chunks = 32;
+
+    Mock::given(method("HEAD"))
+        .and(path("/org/repo/resolve/main/flaky.bin"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("Content-Length", body.len().to_string())
+                .append_header("Accept-Ranges", "bytes"),
+        )
+        .mount(&server)
+        .await;
+
+    let get_hits = Arc::new(AtomicUsize::new(0));
+    let get_hits_cl = get_hits.clone();
+    let body_arc = Arc::new(body.clone());
+    Mock::given(method("GET"))
+        .and(path("/org/repo/resolve/main/flaky.bin"))
+        .respond_with(move |req: &Request| {
+            get_hits_cl.fetch_add(1, Ordering::SeqCst);
+            let (start, len) = parse_range(req);
+            if start == 0 {
+                return ResponseTemplate::new(500);
+            }
+            let slice = body_arc[start as usize..(start + len) as usize].to_vec();
+            ResponseTemplate::new(206).set_body_bytes(slice)
+        })
+        .mount(&server)
+        .await;
+
+    let cfg = ExecutorConfig {
+        file_concurrency: 1,
+        chunk_concurrency: 2,
+        progress_interval: Duration::from_millis(100),
+    };
+    let tmp = tempdir().unwrap();
+    let files = vec![http_spec(
+        "flaky.bin",
+        Url::parse(&format!("{}/org/repo/resolve/main/flaky.bin", server.uri())).unwrap(),
+    )];
+
+    Executor::with_config(fast_transport(), cfg)
+        .run(&files, tmp.path(), None)
+        .await
+        .expect_err("the chunk failure must surface");
+
+    let hits = get_hits.load(Ordering::SeqCst);
+    assert!(
+        hits < total_chunks,
+        "queued chunks should bail once a chunk failed, but all {total_chunks} were attempted ({hits} GETs)",
+    );
+    std::env::remove_var("GENIEX_DL_CHUNK_SIZE");
+}
+
 #[tokio::test]
 async fn http_deflate_decodes_and_marks_done() {
     // Build a deflate-compressed body, serve it as a byte range, and


### PR DESCRIPTION
## Summary

`pull_resumes_after_mid_download_failure` fails in CI with `bitmap must be
partial; got 0/4 done` ([example
run](https://github.com/qualcomm/GenieX/actions/runs/32844092583/job/97789893909)).
It reproduces locally in roughly 40 of 50 runs, so it is a real race, not infra
flake. This is a bug on `main`, not something the PR that hit it introduced.

In `download_range_based`, chunks are spawned as concurrent tasks and each one
raced its own fetch against a single `CancellationToken` shared by every chunk of
every file:

```rust
tokio::select! {
    biased;
    _ = cancel.cancelled() => return Err(Error::Cancelled),
    res = fetch => res?,
}
```

The collector loop called `cancel.cancel()` the moment *any* chunk errored. The
in-process notify reliably beats still-pending network IO, so siblings that were
about to succeed returned `Cancelled` before reaching `chunk::mark_chunk_done`.
The bytes they had already written to the preallocated file were never recorded
in the `.progress` bitmap — what the test sees as `0/4`.

The user-visible cost is worse than the test name suggests: one transient 500 on
one chunk of a multi-GB GGUF discarded the progress of every other in-flight
chunk, so the retry refetched far more than the chunk that actually failed,
defeating the point of chunk-granular resume. `Executor::run` did the same thing
at file granularity — one file's error discarded other files' in-flight chunk
progress.

Regression from the change that made chunk downloads cancellable mid-stream (for
responsive Ctrl-C). Before it, cancellation was only checked at chunk-task start,
so a started fetch always ran to completion and a sibling's error could not
preempt it.

### Why one token was not enough

Simply dropping the `cancel.cancel()` calls fixes the bitmap but regresses
failure behaviour: with nothing gating the queue, every remaining chunk still
starts after a failure. On a 128-chunk model at the production transport defaults
(`retries: 3`) that is ~512 doomed requests aimed at an upstream that is already
failing or rate-limiting, and a much slower report of the error. The added test
`chunk_failure_stops_queued_chunks_from_starting` fails that way — 32/32 chunks
attempted — if the gates are removed.

So the single token is split into the two signals it was conflating:

| Signal | Set by | In-flight transfers | New work |
|---|---|---|---|
| `user` | progress callback returns `false` | preempted mid-stream | blocked |
| `failed` | any chunk or file error | left to finish and persist | blocked |

`failed` is never raced inside the fetch `select!`; it is only checked where new
work starts, including a re-check after a chunk clears the concurrency semaphore
(where a queued chunk can otherwise sit for a long time before starting a fetch
that is already known to be pointless).

Net effect: a transient failure keeps the bytes it already has, stops the queue
about as promptly as before, and `Error::Cancelled` still means only a real user
cancel.

## Test plan

- [x] `cargo test -p model-manager-core --test pull_resume` — 50/50 green; the
      same loop on the parent commit failed ~40/50
- [x] `chunk_failure_stops_queued_chunks_from_starting` (new) — verified it fails
      (`all 32 were attempted`) with the `halt_new_work` gates removed, so it
      actually guards the queue behaviour
- [x] `cargo test` across the `sdk/model-manager` workspace — 12/12 binaries
      green, no warnings
- [x] `cancel_via_callback_returns_cancelled` still passes — progress-callback
      cancel is still prompt and still surfaces `Error::Cancelled`
- [x] `resume_skips_completed_chunks` still passes — resume still refetches only
      the missing chunks
