### PR TITLE
refactor(sdk): guard ggml backend dir scan behind GGML_BACKEND_DL

### DIFF
--- a/sdk/plugins/llama_cpp/src/plugin.cpp
+++ b/sdk/plugins/llama_cpp/src/plugin.cpp
@@ -103,9 +103,12 @@ class LlamaPlugin : public Plugin {
                 GENIEX_LOG_WARN("Failed to set DLL search directory to {}", backend_dir.u8string());
             }
 #endif  // _WIN32
+#if defined(GGML_BACKEND_DL)
+            // Without DL, backends arrive via DT_NEEDED and self-register from GGML_USE_*.
             auto path = backend_dir.u8string();
             GENIEX_LOG_DEBUG("Loading GGML backend from path: {}", path);
             ggml_backend_load_all_from_path(path.c_str());
+#endif  // GGML_BACKEND_DL
         }
 
         llama_backend_init();


### PR DESCRIPTION
## Summary

`ggml_backend_load_all_from_path()` only has an effect when `GGML_BACKEND_DL` is
on. It is off in `sdk/plugins/llama_cpp/CMakeLists.txt`, and that flag is what
selects between two mutually exclusive discovery mechanisms in
`ggml/src/CMakeLists.txt`:

- **DL on** — backends build as `MODULE` libraries, `GGML_USE_*` is *not*
  defined, and nothing registers until something scans a directory and
  `dlopen`s them.
- **DL off** — backends build as `SHARED` libraries that `libggml.so` pulls in
  via `DT_NEEDED`, `GGML_USE_*` *is* defined, and `ggml_backend_registry`'s
  constructor calls `ggml_backend_cpu_reg()` / `ggml_backend_hexagon_reg()` /
  etc. directly.

So on every platform we ship, the backends are already registered by the time
the plugin constructor runs, and the scan walked the plugin directory once per
backend name with nothing to add. Guarding the call rather than deleting it
keeps the call site alive for whenever the flag is flipped back on — with DL on
and no scan, nothing registers at all.

`ADSP_LIBRARY_PATH` — which resolves the Hexagon HTP skels
(`libggml-htp-v*.so`) and has nothing to do with DL — and the Windows
`SetDllDirectoryW` call both sit outside the guard, unchanged.

## Test plan

- [x] Linux x86_64 (Release, `GGML_VULKAN=ON`) — builds; the
      `ggml_backend_load_all_from_path` undefined-symbol reference in
      `libgeniex_plugin.so` drops to 0; Vulkan still registers (RTX 4070 Ti
      SUPER enumerated); `geniex infer -c cpu` generates normally
- [x] Windows arm64 / Snapdragon X Elite (Release, `GGML_HEXAGON=ON`,
      `GGML_OPENCL=ON`) — builds; OpenCL (Adreno X1-85) and Hexagon v73 both
      register; the HTP skel still loads over FastRPC
      (`uri file:///libggml-htp-v73.so?...`), confirming `ADSP_LIBRARY_PATH` is
      intact; `geniex infer -c npu` generates normally
- [x] Android arm64 cross-compile (`arm64-android-snapdragon-debug`) — builds;
      symbol reference gone; `libggml.so` `DT_NEEDED` lists
      `libggml-{cpu,opencl,hexagon}.so` with matching `*_reg` undefined symbols,
      i.e. registration goes through the linker rather than a directory scan
- [x] Android on-device (SM8750 / Snapdragon 8 Elite, Android 16) — pushed the
      cross-compiled package and ran `geniex-bench` against a 2B Q4_0 gguf on
      both `--device cpu` and `--device npu`. Plugin loads, cpu/opencl/hexagon
      all register, and on `npu` the HTP skel still loads over FastRPC
      (`uri file:///libggml-htp-v79.so?...`) with `ADSP_LIBRARY_PATH` pointing
      where it should. Caveat: `geniex-bench` goes through `scan_plugins()` and
      therefore needs the `lib/<plugin>/` subdirectory layout, whereas an APK is
      flat and registers plugins from JNI instead — so this exercises the
      backend-registration path, not the APK path. Verifying that would need an
      AAR plus a host app, which no longer lives in this repo.

