### PR TITLE
feat(cli): warn when a second Ctrl+C aborts serve's teardown

### DIFF
--- a/cli/server/server.go
+++ b/cli/server/server.go
@@ -75,19 +75,23 @@ func Serve() {
 	}
 
 	// Unhandled, Ctrl+C skips the deferred DeInit and pins NPU buffers till reboot.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 
 	errCh := make(chan error, 1)
 	go func() { errCh <- listen() }()
 
-	// stop() first in both arms, so a second Ctrl+C kills instead of being swallowed.
 	select {
 	case err := <-errCh: // listen only returns on failure here
-		stop()
 		fmt.Println(render.GetTheme().Error.Sprintf("HTTP/HTTPS Server Error: %v", err))
-	case <-ctx.Done():
-		stop()
+	case <-sigCh:
 		fmt.Println(render.GetTheme().Info.Sprint("Shutting down, releasing model resources..."))
+		// Escape hatch for a teardown a stuck request holds up; the buffers leak.
+		go func() {
+			<-sigCh
+			fmt.Println(render.GetTheme().Warning.Sprint("Received second interrupt, terminating immediately. Model resources stay reserved until reboot."))
+			os.Exit(1)
+		}()
 		srv.Shutdown(context.Background())
 	}
 }


### PR DESCRIPTION
- The second SIGINT/SIGTERM is now handled instead of falling through to the default disposition: it prints `Received second interrupt, terminating immediately. Model resources stay reserved until reboot.` and `os.Exit(1)`.
- Exit status for that path changes from 130 (killed by SIGINT) to 1, matching llama-server, which also does `exit(1)` on the second interrupt.
- Single Ctrl+C is unchanged — still a full graceful teardown.

## Test plan

- [x] 390 SIGINTs over 2 s with a model loaded → warning printed, `rc=1`
- [x] single Ctrl+C with the 26B model loaded → 17 532 MB → 683 MB, `rc=0` (full release, unchanged)
- [x] Ctrl+C mid-generation, second one 3 s later → warning within 3.2 s, `rc=1`, and `free -m` confirms 14.5 GB stays pinned — exactly what the message claims