### PR TITLE
fix(cli): match pre-run skip lists on the top-level command

### DIFF
--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -41,13 +41,21 @@ func RootCmd() *cobra.Command {
 			// Re-apply now that --log is parsed; the main() call only saw GENIEX_LOG.
 			common.ApplyLogLevel()
 
-			subCmd := cmd.CalledAs()
+			// Cobra passes the leaf command being executed, so CalledAs() would
+			// yield `get` for `geniex config get`. "" is the bare `geniex`.
+			subCmd := ""
+			for c := cmd; c.HasParent(); c = c.Parent() {
+				if !c.Parent().HasParent() {
+					subCmd = c.Name()
+					break
+				}
+			}
 
 			// Skip ModelInit for commands that don't touch the model manager
 			if !slices.Contains([]string{
-				"geniex",
+				"",
 				"version", "update",
-				"help", "completion",
+				"help", "completion", cobra.ShellCompRequestCmd,
 			}, subCmd) {
 				s := store.Get()
 				if err := geniex_sdk.ModelInit(s.DataPath()); err != nil {
@@ -58,16 +66,20 @@ func RootCmd() *cobra.Command {
 			if !skipUpdate {
 				// `update` fetches and prints the latest version itself; the
 				// cached notify banner would be redundant and possibly stale.
-				if subCmd != "update" {
+				// Completion writes to stdout, which the shell parses.
+				if !slices.Contains([]string{
+					"update",
+					"completion", cobra.ShellCompRequestCmd,
+				}, subCmd) {
 					notifyUpdate()
 				}
 				// skip network probe for quick commands
 				if !slices.Contains([]string{
-					"geniex",
-					"remove", "rm", "clean", "list", "ls", "model",
+					"",
+					"remove", "clean", "list", "model",
 					"config",
 					"version", "update",
-					"help", "completion",
+					"help", "completion", cobra.ShellCompRequestCmd,
 				}, subCmd) {
 					go checkUpdate()
 				}


### PR DESCRIPTION
## Summary

`cmd.CalledAs()` in the root `PersistentPreRun` returns the **leaf** command cobra
is executing, not the top-level one, so neither skip list ever matched a nested
subcommand:

| Command | `CalledAs()` | Before |
|---|---|---|
| `geniex config get chipset` | `get` | update network probe |
| `geniex model set-type foo llm` | `set-type` | update network probe |
| `geniex completion zsh` | `zsh` | `ModelInit` + probe, banner could land in the generated script |
| `geniex model list` | `list` | skipped only by collision with top-level `list` |

Walk the parent chain to the top-level name instead, with `""` for the bare
`geniex`. The names are canonical now, so the `rm` / `ls` alias entries are gone,
and `__complete` joins the lists — shell completion must not touch the store, and
`notifyUpdate` writes to stdout, the stream the shell parses for candidates.

Behaviour is otherwise unchanged: bare `geniex`, `--version`, `version` and the
quick commands still show the cached update banner.

## Test plan

- [x] `bazelisk coverage //cli/... --combined_report=lcov --test_env=PATH --action_env=PATH` — 15 passed / 6 skipped
- [x] `geniex config get chipset` / `geniex model set-type ...` — no update probe
- [x] `geniex completion zsh` — first line is `#compdef geniex`, no banner
- [x] `geniex __complete config get ''` — candidates only (`chipset` + `:4`)
- [x] bare `geniex`, `geniex --version`, `geniex config get chipset` — banner still shown
- [x] `geniex rm` / `geniex ls` still resolve (canonical names cover the aliases)

Closes qcom-ai-hub/geniex#1512
