### PR TITLE
fix(cli): harden the model-manager call surface

### DIFF
--- a/bindings/go/BUILD.bazel
+++ b/bindings/go/BUILD.bazel
@@ -34,6 +34,7 @@ go_cgo_test(
     name = "geniex_sdk_go_test",
     srcs = [
         "common_test.go",
+        "model_manager_test.go",
     ],
     embed = [":geniex_sdk_go"],
 )

--- a/bindings/go/common.go
+++ b/bindings/go/common.go
@@ -97,11 +97,11 @@ func freeSamplerConfig(cPtr *C.geniex_SamplerConfig) {
 // LCOV_EXCL_STOP
 
 type GenerationConfig struct {
-	MaxTokens      int32
-	Stop           []string
-	SamplerConfig  *SamplerConfig
-	ImagePaths     []string
-	AudioPaths     []string
+	MaxTokens     int32
+	Stop          []string
+	SamplerConfig *SamplerConfig
+	ImagePaths    []string
+	AudioPaths    []string
 
 	// Opt-in ring-buffer context eviction (qairt only).
 	SlidingWindow      bool

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -21,8 +21,8 @@ import (
 
 // LCOV_EXCL_START
 
-// PrecisionNA is the precision placeholder the SDK records for non-quantized
-// (e.g. QAIRT) models.
+// PrecisionNA is the key the SDK records while a model's precision is still
+// undetermined: it means "unknown", not "unquantized".
 const PrecisionNA = "N/A"
 
 // ModelType mirrors geniex_ModelType.
@@ -73,6 +73,15 @@ func SplitNamePrecision(arg string) (string, string) {
 		return name, ""
 	}
 	return name, precision
+}
+
+// JoinNamePrecision builds the "name:precision" key the SDK accepts. Inverse of
+// SplitNamePrecision minus its URL strip; PrecisionNA is a label like any other.
+func JoinNamePrecision(name, precision string) string {
+	if precision == "" {
+		return name
+	}
+	return name + ":" + precision
 }
 
 // HubSource mirrors geniex_HubSource.

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -102,6 +102,19 @@ func ResolveHub(name string, hub HubSource) (HubSource, error) {
 	return HubSource(out), nil
 }
 
+// ResolveAlias expands a short alias (e.g. "qwen3") to "org/repo[:precision]".
+// pull / get_paths never consult the table, so resolve first to let an alias win.
+func ResolveAlias(alias string) (string, bool) {
+	cAlias := C.CString(alias)
+	defer C.free(unsafe.Pointer(cAlias))
+	var out *C.char
+	if res := C.geniex_model_resolve_alias(cAlias, &out); res != C.GENIEX_SUCCESS {
+		return "", false
+	}
+	defer free(unsafe.Pointer(out))
+	return C.GoString(out), true
+}
+
 // FileProgress mirrors geniex_FileProgress.
 type FileProgress struct {
 	FileName        string

--- a/bindings/go/model_manager_test.go
+++ b/bindings/go/model_manager_test.go
@@ -1,0 +1,23 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package geniex_sdk
+
+import "testing"
+
+// No ModelInit: the alias table is static, so no store is involved.
+func TestResolveAlias(t *testing.T) {
+	got, ok := ResolveAlias("qwen3")
+	if !ok {
+		t.Fatal("qwen3 is the SDK's alias fixture")
+	}
+	if want := "ggml-org/Qwen3-1.7B-GGUF:Q4_K_M"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	for _, alias := range []string{"", "no-such-alias-xyz-9999", "ggml-org/Qwen3-1.7B-GGUF"} {
+		if got, ok := ResolveAlias(alias); ok {
+			t.Errorf("ResolveAlias(%q): expected miss, got %q", alias, got)
+		}
+	}
+}

--- a/bindings/go/model_manager_test.go
+++ b/bindings/go/model_manager_test.go
@@ -21,3 +21,22 @@ func TestResolveAlias(t *testing.T) {
 		}
 	}
 }
+
+func TestJoinNamePrecision(t *testing.T) {
+	cases := []struct{ name, precision, want string }{
+		{"org/repo", "Q4_0", "org/repo:Q4_0"},
+		{"org/repo", "", "org/repo"},
+		// N/A is a manifest key like any other; hiding it is the caller's job.
+		{"org/repo", PrecisionNA, "org/repo:N/A"},
+	}
+	for _, c := range cases {
+		if got := JoinNamePrecision(c.name, c.precision); got != c.want {
+			t.Errorf("JoinNamePrecision(%q, %q) = %q, want %q", c.name, c.precision, got, c.want)
+		}
+	}
+	// Round-trips with the splitter it mirrors.
+	name, precision := SplitNamePrecision("org/repo:Q4_0")
+	if got := JoinNamePrecision(name, precision); got != "org/repo:Q4_0" {
+		t.Errorf("round-trip: got %q", got)
+	}
+}

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -180,10 +180,7 @@ func infer() *cobra.Command {
 // ensureModelAvailable resolves a model's on-disk paths, pulling it first if it
 // isn't cached. An empty quant lets the SDK pick among the downloaded ones.
 func ensureModelAvailable(ctx context.Context, name, quant string) (*geniex_sdk.ModelPaths, error) {
-	key := name
-	if quant != "" {
-		key = name + ":" + quant
-	}
+	key := geniex_sdk.JoinNamePrecision(name, quant)
 	paths, err := geniex_sdk.ModelGetPaths(key)
 	if geniex_sdk.IsModelNotFound(err) {
 		fmt.Println(render.GetTheme().Info.Sprintf("Model is not currently cached, downloading..."))

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -84,6 +84,11 @@ func RootCmd() *cobra.Command {
 			}
 			return nil
 		},
+		// Mirrors the ModelInit above. Unchecked: the SDK's deinit is a no-op that
+		// never fails, the same reason Cobra skipping it on error is free.
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			geniex_sdk.ModelDeinit()
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if showVer, _ := cmd.Flags().GetBool("version"); showVer {
 				runVersion()

--- a/cli/cmd/geniex/main.go
+++ b/cli/cmd/geniex/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"runtime"
@@ -35,7 +34,7 @@ func RootCmd() *cobra.Command {
 		Use:           "geniex",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// Re-apply now that --log is parsed; the main() call only saw GENIEX_LOG.
 			common.ApplyLogLevel()
 
@@ -58,7 +57,8 @@ func RootCmd() *cobra.Command {
 			}, subCmd) {
 				s := store.Get()
 				if err := geniex_sdk.ModelInit(s.DataPath()); err != nil {
-					slog.Error("failed to initialize model manager", "err", err)
+					// Carrying on fails every later call as NOT_INITIALIZED.
+					return fmt.Errorf("initialize model manager at %s: %w", s.DataPath(), err)
 				}
 			}
 
@@ -82,6 +82,7 @@ func RootCmd() *cobra.Command {
 					go checkUpdate()
 				}
 			}
+			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if showVer, _ := cmd.Flags().GetBool("version"); showVer {

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -119,10 +119,7 @@ func remove() *cobra.Command {
 		var errs []error
 		for _, arg := range args {
 			name, quant := geniex_sdk.SplitNamePrecision(arg)
-			key := name
-			if quant != "" {
-				key = name + ":" + quant
-			}
+			key := geniex_sdk.JoinNamePrecision(name, quant)
 			if err := geniex_sdk.ModelRemove(key); err != nil {
 				errs = append(errs, fmt.Errorf("remove %s: %w", key, err))
 				continue
@@ -545,10 +542,7 @@ func pullModel(ctx context.Context, name, quant string) error {
 
 	fmt.Println(render.GetTheme().Success.Sprint("✔  Download success"))
 
-	key := name
-	if quant != "" {
-		key = name + ":" + quant
-	}
+	key := geniex_sdk.JoinNamePrecision(name, quant)
 	if m, err := geniex_sdk.ModelGetDetailed(name); err == nil && m.TotalSize > 0 {
 		fmt.Println(render.GetTheme().Info.Sprintf("   Size:      %s", humanize.IBytes(uint64(m.TotalSize))))
 	}

--- a/cli/cmd/geniex/run.go
+++ b/cli/cmd/geniex/run.go
@@ -69,10 +69,7 @@ func run() *cobra.Command {
 
 	runCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		name, quant := geniex_sdk.SplitNamePrecision(args[0])
-		fullName := name
-		if quant != "" {
-			fullName = name + ":" + quant
-		}
+		fullName := geniex_sdk.JoinNamePrecision(name, quant)
 
 		client = openai.NewClient(
 			option.WithBaseURL(fmt.Sprintf("http://%s/v1", config.Get().Host)),

--- a/cli/internal/store/BUILD.bazel
+++ b/cli/internal/store/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//bindings/go:geniex_sdk_go",
         "//cli/internal/config",
+        "//cli/internal/render",
         "@com_github_bytedance_sonic//:sonic",
     ],
 )

--- a/cli/internal/store/manager.go
+++ b/cli/internal/store/manager.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/qualcomm/GenieX/cli/internal/config"
+	"github.com/qualcomm/GenieX/cli/internal/render"
 )
 
 // Store resolves the geniex data directory for the CLI. Model storage itself
@@ -42,17 +43,25 @@ func (s *Store) init() {
 	} else {
 		homeDir, e := os.UserHomeDir()
 		if e != nil {
-			fmt.Fprintf(os.Stderr, "geniex: failed to resolve user home directory: %s\n", e)
-			os.Exit(1)
+			fatal("resolve user home directory", e)
 		}
 		s.home = filepath.Join(homeDir, ".cache", "geniex")
 	}
 	slog.Info("Using data directory", "path", s.home)
 
 	if e := os.MkdirAll(s.home, 0o770); e != nil {
-		fmt.Fprintf(os.Stderr, "geniex: failed to create data directory %s: %s\n", s.home, e)
-		os.Exit(1)
+		fatal(fmt.Sprintf("create data directory %s", s.home), e)
 	}
+}
+
+// fatal reports an unusable data directory and exits; Get() is a sync.Once with
+// no error channel. Prints as well as logs: the default log level is "none".
+func fatal(what string, err error) {
+	slog.Error(what, "err", err)
+	theme := render.GetTheme()
+	fmt.Fprintln(os.Stderr, theme.Error.Sprintf("Error: %s: %s", what, err))
+	fmt.Fprintln(os.Stderr, theme.Error.Sprint("Point --data-dir (or GENIEX_DATADIR) at a writable directory."))
+	os.Exit(1)
 }
 
 // DataPath returns the geniex data directory root.

--- a/cli/server/handler/model.go
+++ b/cli/server/handler/model.go
@@ -30,12 +30,8 @@ func ListModels(c *gin.Context) {
 	res := make([]openai.Model, 0, len(models))
 	for _, m := range models {
 		for _, q := range m.Precisions {
-			id := m.Name
-			if q != geniex_sdk.PrecisionNA {
-				id += ":" + q
-			}
 			res = append(res, openai.Model{
-				ID:      id,
+				ID:      geniex_sdk.JoinNamePrecision(m.Name, q),
 				OwnedBy: strings.Split(m.Name, "/")[0],
 			})
 		}
@@ -79,13 +75,9 @@ func RetrieveModel(c *gin.Context) {
 		quant = m.Precisions[i]
 	}
 
-	id := m.Name
-	if quant != geniex_sdk.PrecisionNA {
-		id += ":" + quant
-	}
 	c.JSON(http.StatusOK, ModelResponse{
 		Model: openai.Model{
-			ID:      id,
+			ID:      geniex_sdk.JoinNamePrecision(m.Name, quant),
 			OwnedBy: strings.Split(m.Name, "/")[0],
 		},
 		ModelType: m.ModelType.String(),

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -29,11 +29,7 @@ func resolveDraftModelPath(draft string) (string, error) {
 		return draft, nil
 	}
 	name, precision := geniex_sdk.SplitNamePrecision(draft)
-	key := name
-	if precision != "" {
-		key = name + ":" + precision
-	}
-	paths, err := geniex_sdk.ModelGetPaths(key)
+	paths, err := geniex_sdk.ModelGetPaths(geniex_sdk.JoinNamePrecision(name, precision))
 	if err != nil {
 		return "", fmt.Errorf("resolve draft model %q: %w", draft, err)
 	}


### PR DESCRIPTION
## Summary

Six defects around the model manager's lifecycle and its `name:precision` keys,
found by an audit of every `geniex_model_*` call site in the CLI, server and Go
binding. They share a blast radius — a model reference that silently resolves to
the wrong thing, or an error the user never sees — so they land together.

**`ModelInit` failure was invisible, then fatal much later.** The root
`PersistentPreRun` logged with `slog.Error` and carried on. The default log level
is `none`, so an unwritable or corrupt data directory produced *no output at
all*; every later call then failed as `NOT_INITIALIZED`, an error that points
nowhere near the cause. It is `PersistentPreRunE` now and returns
`initialize model manager at <path>: <err>`.

**`ModelInit` had no counterpart.** A `PersistentPostRun` calls `ModelDeinit`,
placed next to the init it mirrors. Unchecked and unguarded on purpose: the SDK's
`geniex_model_deinit` is a no-op that always returns `GENIEX_SUCCESS`, which is
also why cobra skipping `PostRun` on error costs nothing today.

**`store.init()` reported fatal errors on bare stderr.** Two duplicated
`fmt.Fprintf(os.Stderr, "geniex: ...")` + `os.Exit(1)` pairs, unthemed, with no
hint at the fix. One `fatal()` helper now logs *and* prints through the theme,
and names `--data-dir` / `GENIEX_DATADIR`.

**`name + ":" + quant` was hand-assembled in 7 places**, each with its own
`if quant != ""`. New `geniex_sdk.JoinNamePrecision` — the exact inverse of the
existing `SplitNamePrecision`, minus its URL strip — replaces all of them.

**The server hid the `N/A` precision it already accepts.** `RetrieveModel`
matches `:N/A` on input via `EqualFold`, but both handlers stripped the suffix
from the id they returned, so a model with an undetermined precision was
advertised as `org/name` — which round-trips to a *different*, SDK-picked
reference. Both now return `org/name:N/A`.

`PrecisionNA`'s doc comment was wrong about what it means and is corrected here:
the AI Hub / QAIRT layout files every entrypoint under `N/A` and swaps in the
real label once known, so a surviving `N/A` means **undetermined**, not
**unquantized**. That mistake is what produced the two handler special cases.

**`geniex_model_resolve_alias` had an FFI entry but no Go binding** — Python has
`_maybe_resolve_alias`, Go could not reach the table. Exported as `ResolveAlias`.

Not in this PR, deliberately:

- `geniex list` still hides `N/A` in its PRECISIONS column
  (`downloadedPrecisions(model, !verbose)`), so the CLI table and `/v1/models`
  now disagree for an undetermined-precision model. That is the rest of audit 21.
- `store.init()` keeps its own `os.Exit(1)`, which fires *before* `ModelInit`, so
  the data-directory error story still has two paths.

## Test plan

- [x] `bazelisk build //cli --test_env=PATH --action_env=PATH`
- [x] `bazelisk coverage //cli/... --combined_report=lcov --test_env=PATH --action_env=PATH` — 15 passed / 6 skipped
- [x] `bazelisk test //bindings/go:geniex_sdk_go_test --test_env=PATH --action_env=PATH` — new `TestResolveAlias` + `TestJoinNamePrecision`
- [x] `gofmt -l cli/ bindings/go/` — clean
- [x] `:N/A` is a real reference, not a display string: with a hand-written manifest carrying `"ModelFile": {"N/A": {...}}`, `geniex infer qualcomm/NaTest:N/A` resolves the path and reaches `geniex_llm_create` (failing only on this host's missing qairt plugin), while `:Q4_0` fails earlier with `quantization 'Q4_0' not found`
- [x] Against a live `geniex serve`, `GET /v1/models`, `GET /v1/models/qualcomm/NaTest` and `GET /v1/models/qualcomm/NaTest:N%2FA` all return `"id": "qualcomm/NaTest:N/A"`
- [x] `geniex --data-dir /proc/nope model list` prints the themed `Error: create data directory ...` plus the `--data-dir` hint, exit 1

Closes qcom-ai-hub/geniex#1518
