### PR TITLE
feat(cli): stream text and tool calls as they complete

### DIFF
--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -34,6 +34,7 @@ go_cgo_test(
     name = "handler_test",
     srcs = [
         "chat_response_test.go",
+        "chat_stream_test.go",
         "chat_test.go",
         "completion_test.go",
     ],

--- a/cli/server/handler/BUILD.bazel
+++ b/cli/server/handler/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
 go_cgo_test(
     name = "handler_test",
     srcs = [
+        "chat_response_test.go",
         "chat_test.go",
         "completion_test.go",
     ],

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -289,13 +289,13 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 
 		wait := func() error { wg.Wait(); return genErr }
 		includeUsage := param.StreamOptions.IncludeUsage.Value
+		class := tokenClass(plainClass)
+		if reasoningSeparated(param.ReasoningFormat) {
+			class = reasoningClass()
+		}
 		if parseTool {
-			streamToolCall(c, dataCh, wait, includeUsage, &profile)
+			streamToolCall(c, dataCh, wait, includeUsage, &profile, class)
 		} else {
-			class := tokenClass(plainClass)
-			if reasoningSeparated(param.ReasoningFormat) {
-				class = reasoningClass()
-			}
 			streamPlainText(c, dataCh, wait, includeUsage, &profile, render(class))
 		}
 
@@ -306,7 +306,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		// blocking
 		var content, reasoning strings.Builder
 		class := tokenClass(plainClass)
-		if !parseTool && reasoningSeparated(param.ReasoningFormat) {
+		if reasoningSeparated(param.ReasoningFormat) {
 			class = reasoningClass()
 		}
 		profile, _, err := gen(prompt, sink(class, &content, &reasoning))

--- a/cli/server/handler/chat_response.go
+++ b/cli/server/handler/chat_response.go
@@ -57,9 +57,10 @@ func writePromptTooLong(c *gin.Context, profile geniex_sdk.ProfileData) {
 // Adds reasoning_content, which openai-go's ChatCompletionMessage lacks; used
 // only when thinking is separated so the inline default stays byte-identical.
 type blockingMessage struct {
-	Role             string `json:"role"`
-	Content          string `json:"content"`
-	ReasoningContent string `json:"reasoning_content,omitempty"`
+	Role             string                                      `json:"role"`
+	Content          string                                      `json:"content"`
+	ReasoningContent string                                      `json:"reasoning_content,omitempty"`
+	ToolCalls        []openai.ChatCompletionMessageToolCallUnion `json:"tool_calls,omitempty"`
 }
 
 type blockingChoice struct {
@@ -75,35 +76,33 @@ type blockingResponse struct {
 }
 
 func writeBlockingResponse(c *gin.Context, content, reasoning string, profile geniex_sdk.ProfileData, parseTool bool) {
+	finishReason := mapFinishReason(profile.StopReason)
+	var toolCalls []openai.ChatCompletionMessageToolCallUnion
 	if parseTool {
-		toolCall, err := utils.ParseToolCalls(content)
-		if err == nil {
-			choice := openai.ChatCompletionChoice{
-				FinishReason: "tool_calls",
-				Message: openai.ChatCompletionMessage{
-					Role: constant.Assistant(openai.MessageRoleAssistant),
-					ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
-						ID:       fmt.Sprintf("call_%d", rand.Uint32()),
-						Type:     "function",
-						Function: toolCall,
-					}},
-				},
-			}
-			c.JSON(http.StatusOK, openai.ChatCompletion{
-				Choices: []openai.ChatCompletionChoice{choice},
-				Usage:   profile2Usage(profile),
-			})
-			return
+		// Parse keeps the text around a call: that is content, not part of it.
+		text, calls := utils.NewToolCallScanner().Parse(content)
+		content = text
+		if len(calls) > 0 {
+			finishReason = "tool_calls"
+		} else {
+			slog.Debug("No tool call in the response")
 		}
-		slog.Warn("Tool call parse error, fallback to text", "error", err)
+		for _, call := range calls {
+			toolCalls = append(toolCalls, openai.ChatCompletionMessageToolCallUnion{
+				ID:       fmt.Sprintf("call_%d", rand.Uint32()),
+				Type:     "function",
+				Function: call,
+			})
+		}
 	}
 
 	if reasoning == "" {
 		choice := openai.ChatCompletionChoice{
-			FinishReason: mapFinishReason(profile.StopReason),
+			FinishReason: finishReason,
 			Message: openai.ChatCompletionMessage{
-				Role:    constant.Assistant(openai.MessageRoleAssistant),
-				Content: content,
+				Role:      constant.Assistant(openai.MessageRoleAssistant),
+				Content:   content,
+				ToolCalls: toolCalls,
 			},
 		}
 		c.JSON(http.StatusOK, openai.ChatCompletion{
@@ -120,8 +119,9 @@ func writeBlockingResponse(c *gin.Context, content, reasoning string, profile ge
 				Role:             string(openai.MessageRoleAssistant),
 				Content:          content,
 				ReasoningContent: reasoning,
+				ToolCalls:        toolCalls,
 			},
-			FinishReason: mapFinishReason(profile.StopReason),
+			FinishReason: finishReason,
 		}},
 		Usage: profile2Usage(profile),
 	})

--- a/cli/server/handler/chat_response_test.go
+++ b/cli/server/handler/chat_response_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+// Covers both bodies writeBlockingResponse can produce: openai's own struct, and the
+// local one that carries reasoning_content.
+type blockingBody struct {
+	Choices []struct {
+		FinishReason string `json:"finish_reason"`
+		Message      struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			ToolCalls        []struct {
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+// A tool call must not cost the text around it, nor the reasoning: both used to be
+// dropped whenever one was found.
+func TestWriteBlockingResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const call = `{"name":"get_weather","arguments":{"city":"Beijing"}}`
+	weather := [2]string{"get_weather", `{"city":"Beijing"}`}
+
+	tests := []struct {
+		name          string
+		content       string
+		reasoning     string
+		parseTool     bool
+		wantContent   string
+		wantReasoning string
+		wantFinish    string
+		wantCalls     [][2]string
+	}{
+		{
+			name: "text only", content: "hello",
+			wantContent: "hello", wantFinish: "stop",
+		},
+		{
+			name: "tools on but nothing to match", content: "hello", parseTool: true,
+			wantContent: "hello", wantFinish: "stop",
+		},
+		{
+			name: "a call keeps the prose around it", content: "sure " + call + " done", parseTool: true,
+			wantContent: "sure  done", wantFinish: "tool_calls", wantCalls: [][2]string{weather},
+		},
+		{
+			name: "parallel calls", content: call + call, parseTool: true,
+			wantFinish: "tool_calls", wantCalls: [][2]string{weather, weather},
+		},
+		{
+			name: "gemma4 syntax", content: `x <|tool_call>call:f{a:1}<tool_call|>`, parseTool: true,
+			wantContent: "x ", wantFinish: "tool_calls", wantCalls: [][2]string{{"f", `{"a":1}`}},
+		},
+		{
+			name: "reasoning with a call", content: "sure " + call, reasoning: "let me check",
+			parseTool: true, wantContent: "sure ", wantReasoning: "let me check",
+			wantFinish: "tool_calls", wantCalls: [][2]string{weather},
+		},
+		{
+			name: "reasoning without a call", content: "hello", reasoning: "let me check",
+			parseTool: true, wantContent: "hello", wantReasoning: "let me check", wantFinish: "stop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			profile := geniex_sdk.ProfileData{StopReason: "eos"}
+			writeBlockingResponse(c, tt.content, tt.reasoning, profile, tt.parseTool)
+
+			var got blockingBody
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("body %s: %v", w.Body.Bytes(), err)
+			}
+			if len(got.Choices) != 1 {
+				t.Fatalf("choices = %d, want 1", len(got.Choices))
+			}
+			choice := got.Choices[0]
+			if choice.FinishReason != tt.wantFinish {
+				t.Errorf("finish_reason = %q, want %q", choice.FinishReason, tt.wantFinish)
+			}
+			if choice.Message.Content != tt.wantContent {
+				t.Errorf("content = %q, want %q", choice.Message.Content, tt.wantContent)
+			}
+			if choice.Message.ReasoningContent != tt.wantReasoning {
+				t.Errorf("reasoning_content = %q, want %q", choice.Message.ReasoningContent, tt.wantReasoning)
+			}
+			if len(choice.Message.ToolCalls) != len(tt.wantCalls) {
+				t.Fatalf("tool_calls = %+v, want %v", choice.Message.ToolCalls, tt.wantCalls)
+			}
+			for i, want := range tt.wantCalls {
+				fn := choice.Message.ToolCalls[i].Function
+				if fn.Name != want[0] || fn.Arguments != want[1] {
+					t.Errorf("tool_calls[%d] = (%q, %q), want (%q, %q)",
+						i, fn.Name, fn.Arguments, want[0], want[1])
+				}
+			}
+		})
+	}
+}

--- a/cli/server/handler/chat_stream.go
+++ b/cli/server/handler/chat_stream.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log/slog"
 	"math/rand/v2"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openai/openai-go/v3"
@@ -71,14 +70,15 @@ func usageChunk(u openai.CompletionUsage) streamChunk {
 	return streamChunk{Object: streamChunkObject, Choices: []streamChoice{}, Usage: &u}
 }
 
-func toolCallChunk(call openai.ChatCompletionMessageFunctionToolCallFunction) streamChunk {
+func toolCallChunk(index int, call openai.ChatCompletionMessageFunctionToolCallFunction) streamChunk {
 	return streamChunk{
 		Object: streamChunkObject,
 		Choices: []streamChoice{{
 			Delta: streamDelta{
 				ToolCalls: []openai.ChatCompletionChunkChoiceDeltaToolCall{{
-					ID:   fmt.Sprintf("call_%d", rand.Uint32()),
-					Type: "function",
+					Index: int64(index),
+					ID:    fmt.Sprintf("call_%d", rand.Uint32()),
+					Type:  "function",
 					Function: openai.ChatCompletionChunkChoiceDeltaToolCallFunction{
 						Name:      call.Name,
 						Arguments: call.Arguments,
@@ -115,14 +115,22 @@ func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, in
 	})
 }
 
-// Buffers the whole stream, then emits one tool-call chunk (or a content chunk
-// on parse failure).
+// Streams the text that cannot be part of a tool call as it arrives, and each
+// tool call as soon as it is complete.
 func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData) {
-	buffer := strings.Builder{}
+	scanner := utils.NewToolCallScanner()
+	sent := 0 // the delta index, which has to keep rising across chunks
 	c.Stream(func(w io.Writer) bool {
 		r, ok := <-dataCh
 		if ok {
-			buffer.WriteString(r)
+			text, calls := scanner.Push(r)
+			if text != "" {
+				c.SSEvent("", contentChunk(text))
+			}
+			for _, call := range calls {
+				c.SSEvent("", toolCallChunk(sent, call))
+				sent++
+			}
 			return true
 		}
 		// A context window exhausted mid-stream is a normal truncated completion:
@@ -133,14 +141,19 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			c.SSEvent("", map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 			return false
 		}
-		finishReason := "tool_calls"
-		toolCall, err := utils.ParseToolCalls(buffer.String())
-		if err != nil {
-			slog.Warn("Tool call parse error, fallback to text", "error", err)
-			finishReason = mapFinishReason(profile.StopReason)
-			c.SSEvent("", contentChunk(buffer.String()))
-		} else {
-			c.SSEvent("", toolCallChunk(toolCall))
+		// The held tail may still hold calls the model stopped short of closing.
+		tail, calls := scanner.Tail()
+		if tail != "" {
+			slog.Warn("Tool call not matched, streaming the held text instead")
+			c.SSEvent("", contentChunk(tail))
+		}
+		for _, call := range calls {
+			c.SSEvent("", toolCallChunk(sent, call))
+			sent++
+		}
+		finishReason := mapFinishReason(profile.StopReason)
+		if sent > 0 {
+			finishReason = "tool_calls"
 		}
 		c.SSEvent("", finishChunk(finishReason))
 		if includeUsage {

--- a/cli/server/handler/chat_stream.go
+++ b/cli/server/handler/chat_stream.go
@@ -40,15 +40,6 @@ type streamChunk struct {
 
 const streamChunkObject = "chat.completion.chunk"
 
-func contentChunk(content string) streamChunk {
-	return streamChunk{
-		Object: streamChunkObject,
-		Choices: []streamChoice{{
-			Delta: streamDelta{Role: string(openai.MessageRoleAssistant), Content: content},
-		}},
-	}
-}
-
 func tokenChunk(text string, reasoning bool) streamChunk {
 	delta := streamDelta{Role: string(openai.MessageRoleAssistant)}
 	if reasoning {
@@ -134,7 +125,7 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 			}
 			text, calls := scanner.Push(token)
 			if text != "" {
-				c.SSEvent("", contentChunk(text))
+				c.SSEvent("", tokenChunk(text, false))
 			}
 			for _, call := range calls {
 				c.SSEvent("", toolCallChunk(sent, call))
@@ -154,7 +145,7 @@ func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, inc
 		tail, calls := scanner.Tail()
 		if tail != "" {
 			slog.Warn("Tool call not matched, streaming the held text instead")
-			c.SSEvent("", contentChunk(tail))
+			c.SSEvent("", tokenChunk(tail, false))
 		}
 		for _, call := range calls {
 			c.SSEvent("", toolCallChunk(sent, call))

--- a/cli/server/handler/chat_stream.go
+++ b/cli/server/handler/chat_stream.go
@@ -117,13 +117,22 @@ func streamPlainText(c *gin.Context, dataCh <-chan string, wait func() error, in
 
 // Streams the text that cannot be part of a tool call as it arrives, and each
 // tool call as soon as it is complete.
-func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData) {
+func streamToolCall(c *gin.Context, dataCh <-chan string, wait func() error, includeUsage bool, profile *geniex_sdk.ProfileData, class tokenClass) {
 	scanner := utils.NewToolCallScanner()
 	sent := 0 // the delta index, which has to keep rising across chunks
 	c.Stream(func(w io.Writer) bool {
 		r, ok := <-dataCh
 		if ok {
-			text, calls := scanner.Push(r)
+			token, isReasoning, emit := class(r)
+			if !emit {
+				return true
+			}
+			// A tool call never lives in the thinking block, which goes out as it is.
+			if isReasoning {
+				c.SSEvent("", tokenChunk(token, true))
+				return true
+			}
+			text, calls := scanner.Push(token)
 			if text != "" {
 				c.SSEvent("", contentChunk(text))
 			}

--- a/cli/server/handler/chat_stream_test.go
+++ b/cli/server/handler/chat_stream_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package handler
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+// The deltas of one SSE stream, in order, with [DONE] dropped.
+func sseDeltas(t *testing.T, body string) []streamChoice {
+	t.Helper()
+	var out []streamChoice
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := strings.CutPrefix(line, "data:")
+		if !ok || strings.TrimSpace(data) == "[DONE]" {
+			continue
+		}
+		var chunk streamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			t.Fatalf("chunk %s: %v", data, err)
+		}
+		out = append(out, chunk.Choices...)
+	}
+	return out
+}
+
+// gin.Context.Stream waits on CloseNotify, which the plain recorder lacks.
+type streamRecorder struct {
+	*httptest.ResponseRecorder
+	gone chan bool
+}
+
+func (r *streamRecorder) CloseNotify() <-chan bool { return r.gone }
+
+func runStreamToolCall(t *testing.T, class tokenClass, tokens ...string) []streamChoice {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := &streamRecorder{httptest.NewRecorder(), make(chan bool)}
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/v1/chat/completions", nil)
+
+	dataCh := make(chan string, len(tokens))
+	for _, tok := range tokens {
+		dataCh <- tok
+	}
+	close(dataCh)
+	profile := geniex_sdk.ProfileData{StopReason: "eos"}
+	streamToolCall(c, dataCh, func() error { return nil }, false, &profile, class)
+	return sseDeltas(t, w.Body.String())
+}
+
+// Thinking must not reach the scanner, and must not leak into content: with tools
+// present it used to stream inline, and a call then dropped it along with the prose.
+func TestStreamToolCallSeparatesReasoning(t *testing.T) {
+	got := runStreamToolCall(t, reasoningClass(),
+		"<think>", "the city ", "is Beijing", "</think>", "sure ",
+		`{"name":"f","arg`, `uments":{"city":"Beijing"}}`, " done")
+
+	var content, reasoning strings.Builder
+	var calls []openai_call
+	for _, ch := range got {
+		content.WriteString(ch.Delta.Content)
+		reasoning.WriteString(ch.Delta.ReasoningContent)
+		for _, tc := range ch.Delta.ToolCalls {
+			calls = append(calls, openai_call{int(tc.Index), tc.Function.Name, tc.Function.Arguments})
+		}
+	}
+	if reasoning.String() != "the city is Beijing" {
+		t.Errorf("reasoning = %q", reasoning.String())
+	}
+	if content.String() != "sure  done" {
+		t.Errorf("content = %q", content.String())
+	}
+	if len(calls) != 1 || calls[0] != (openai_call{0, "f", `{"city":"Beijing"}`}) {
+		t.Errorf("calls = %+v", calls)
+	}
+	if reason := got[len(got)-1].FinishReason; reason == nil || *reason != "tool_calls" {
+		t.Errorf("finish_reason = %v, want tool_calls", reason)
+	}
+}
+
+type openai_call struct {
+	index     int
+	name      string
+	arguments string
+}
+
+// Parallel calls need a rising index, and plain text needs no tool_calls finish.
+func TestStreamToolCallIndexes(t *testing.T) {
+	got := runStreamToolCall(t, plainClass,
+		`{"name":"a","arguments":{}}`, `{"name":"b","arguments":{}}`)
+	var indexes []int64
+	for _, ch := range got {
+		for _, tc := range ch.Delta.ToolCalls {
+			indexes = append(indexes, tc.Index)
+		}
+	}
+	if len(indexes) != 2 || indexes[0] != 0 || indexes[1] != 1 {
+		t.Errorf("indexes = %v, want [0 1]", indexes)
+	}
+
+	got = runStreamToolCall(t, plainClass, "no ", "call ", "here")
+	last := got[len(got)-1]
+	if last.FinishReason == nil || *last.FinishReason != "stop" {
+		t.Errorf("finish_reason = %v, want stop", last.FinishReason)
+	}
+}

--- a/cli/server/handler/chat_stream_test.go
+++ b/cli/server/handler/chat_stream_test.go
@@ -57,6 +57,13 @@ func runStreamToolCall(t *testing.T, class tokenClass, tokens ...string) []strea
 	return sseDeltas(t, w.Body.String())
 }
 
+// One tool_calls delta, flattened for comparison.
+type toolCallDelta struct {
+	index     int
+	name      string
+	arguments string
+}
+
 // Thinking must not reach the scanner, and must not leak into content: with tools
 // present it used to stream inline, and a call then dropped it along with the prose.
 func TestStreamToolCallSeparatesReasoning(t *testing.T) {
@@ -65,12 +72,12 @@ func TestStreamToolCallSeparatesReasoning(t *testing.T) {
 		`{"name":"f","arg`, `uments":{"city":"Beijing"}}`, " done")
 
 	var content, reasoning strings.Builder
-	var calls []openai_call
+	var calls []toolCallDelta
 	for _, ch := range got {
 		content.WriteString(ch.Delta.Content)
 		reasoning.WriteString(ch.Delta.ReasoningContent)
 		for _, tc := range ch.Delta.ToolCalls {
-			calls = append(calls, openai_call{int(tc.Index), tc.Function.Name, tc.Function.Arguments})
+			calls = append(calls, toolCallDelta{int(tc.Index), tc.Function.Name, tc.Function.Arguments})
 		}
 	}
 	if reasoning.String() != "the city is Beijing" {
@@ -79,18 +86,12 @@ func TestStreamToolCallSeparatesReasoning(t *testing.T) {
 	if content.String() != "sure  done" {
 		t.Errorf("content = %q", content.String())
 	}
-	if len(calls) != 1 || calls[0] != (openai_call{0, "f", `{"city":"Beijing"}`}) {
+	if len(calls) != 1 || calls[0] != (toolCallDelta{0, "f", `{"city":"Beijing"}`}) {
 		t.Errorf("calls = %+v", calls)
 	}
 	if reason := got[len(got)-1].FinishReason; reason == nil || *reason != "tool_calls" {
 		t.Errorf("finish_reason = %v, want tool_calls", reason)
 	}
-}
-
-type openai_call struct {
-	index     int
-	name      string
-	arguments string
 }
 
 // Parallel calls need a rising index, and plain text needs no tool_calls finish.

--- a/cli/server/utils/BUILD.bazel
+++ b/cli/server/utils/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
         "common.go",
         "toolcall.go",
         "toolcall_gemma4.go",
+        "toolcall_json.go",
+        "toolcall_qwen3.go",
     ],
     importpath = "github.com/qualcomm/GenieX/cli/server/utils",
     visibility = ["//visibility:public"],
@@ -22,6 +24,7 @@ go_test(
     srcs = [
         "common_test.go",
         "toolcall_gemma4_test.go",
+        "toolcall_json_test.go",
         "toolcall_test.go",
     ],
     embed = [":utils"],

--- a/cli/server/utils/toolcall.go
+++ b/cli/server/utils/toolcall.go
@@ -4,113 +4,178 @@
 package utils
 
 import (
-	"errors"
 	"log/slog"
 	"strings"
 
-	"github.com/bytedance/sonic"
-	"github.com/bytedance/sonic/ast"
 	"github.com/openai/openai-go/v3"
 )
 
-// balancedObjectEnd returns the index just past the '}' matching the '{' at
-// start, skipping braces inside string literals. -1 if never closed.
-func balancedObjectEnd(s string, start int) int {
-	depth := 0
-	inStr, escaped := false, false
-	for i := start; i < len(s); i++ {
-		c := s[i]
-		if inStr {
-			switch {
-			case escaped:
-				escaped = false
-			case c == '\\':
-				escaped = true
-			case c == '"':
-				inStr = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inStr = true
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return i + 1
-			}
-		}
-	}
-	return -1
+type toolCallFn = openai.ChatCompletionMessageFunctionToolCallFunction
+
+// toolCallFormat is one tool-call syntax. feed is stateful: one value per stream.
+type toolCallFormat interface {
+	// parse searches s for every call of this syntax, so one region works too.
+	parse(s string) []toolCallFn
+	// feed consumes what it has not seen of all and reports where this syntax
+	// sits, ignoring anything before from:
+	//
+	//	(-1, -1)  nothing here; every byte of all is safe to emit
+	//	(n, -1)   a call may begin at n but has not finished
+	//	(n, m)    all[n:m] is a finished candidate; parse decides
+	//
+	// all only grows and from never decreases, so offsets stay absolute. A region
+	// is reported again until from moves past it, so an earlier one can win first.
+	feed(all string, from int) (int, int)
 }
 
-// extractJSONObjects returns every balanced {...} substring in s, skipping
-// stray or unterminated '{' so later objects are still found.
-func extractJSONObjects(s string) []string {
-	var objs []string
-	for i := 0; i < len(s); i++ {
-		if s[i] != '{' {
-			continue
+// markerScan finds one literal in a growing string, one pass, no backtracking.
+type markerScan struct {
+	marker string
+	pos    int // bytes of all consumed
+	start  int // where the candidate began; == pos when none is forming
+	done   int // where the marker ended; 0 until it matches, never 0 after
+}
+
+func (m *markerScan) reset(from int) { m.pos, m.start, m.done = from, from, 0 }
+
+func (m *markerScan) feed(all string) {
+	for m.done == 0 && m.pos < len(all) {
+		if m.start == m.pos {
+			i := strings.IndexByte(all[m.pos:], m.marker[0])
+			if i < 0 {
+				m.start, m.pos = len(all), len(all)
+				return
+			}
+			m.start, m.pos = m.pos+i, m.pos+i
 		}
-		end := balancedObjectEnd(s, i)
+		m.pos++
+		// Sliding start up to pos gives up: all[pos-1:pos] was the last try.
+		for m.start < m.pos && !strings.HasPrefix(m.marker, all[m.start:m.pos]) {
+			m.start++
+		}
+		if m.pos-m.start == len(m.marker) {
+			m.done = m.pos
+		}
+	}
+}
+
+// markerFormat covers a syntax wrapped in two literals. Without a closing one, a
+// format implements feed itself, as JSONToolCall does.
+//
+// BUG: the scan is not string-aware, so an end literal quoted inside the call's
+// own arguments cuts the region short and the call goes out as text instead. What
+// quotes a string differs per format, so a fix needs a hook the formats fill in.
+type markerFormat struct {
+	begin markerScan
+	end   markerScan
+}
+
+func newMarkerFormat(begin, end string) markerFormat {
+	return markerFormat{begin: markerScan{marker: begin}, end: markerScan{marker: end}}
+}
+
+func (m *markerFormat) feed(all string, from int) (int, int) {
+	if from > m.begin.start { // the region was consumed or bypassed: start over
+		m.begin.reset(from)
+		m.end.reset(from)
+	}
+	m.begin.feed(all)
+	if m.begin.done == 0 {
+		if m.begin.start < len(all) {
+			return m.begin.start, -1 // only a prefix of begin so far
+		}
+		return -1, -1
+	}
+	if m.end.pos < m.begin.done {
+		m.end.reset(m.begin.done)
+	}
+	m.end.feed(all)
+	at := m.begin.done - len(m.begin.marker)
+	if m.end.done == 0 {
+		return at, -1
+	}
+	return at, m.end.done
+}
+
+// ToolCallScanner splits a token stream into text and tool calls, holding back
+// only what could still be part of a call.
+type ToolCallScanner struct {
+	buf     strings.Builder // String() shares its bytes: keeping it all is free
+	emitted int
+	formats []toolCallFormat
+}
+
+// NewToolCallScanner registers the formats most specific first, since bare JSON
+// matches inside anything.
+func NewToolCallScanner() *ToolCallScanner {
+	return &ToolCallScanner{formats: []toolCallFormat{
+		newGemma4ToolCall(),
+		newQwen3ToolCall(),
+		&JSONToolCall{},
+	}}
+}
+
+// Push appends a chunk and returns the text safe to emit plus the calls that finished.
+func (s *ToolCallScanner) Push(token string) (string, []toolCallFn) {
+	s.buf.WriteString(token)
+
+	// Each pass consumes at most one region, and a chunk can hold several.
+	text, calls := "", []toolCallFn(nil)
+	for {
+		// The earliest format wins: what a later one found may sit inside its region.
+		all, from := s.buf.String(), s.emitted
+		hold, end, owner := len(all), -1, -1
+		for i, f := range s.formats {
+			n, m := f.feed(all, from)
+			if n < 0 || n >= hold {
+				continue
+			}
+			hold, end, owner = n, m, i
+		}
+
+		// Nothing finished: emit up to the hold point, buffer the rest.
 		if end < 0 {
+			s.emitted = hold
+			if text == "" { // the hot path: nothing to prepend, so skip the concat
+				return all[from:hold], calls
+			}
+			return text + all[from:hold], calls
+		}
+
+		s.emitted = end
+		got := s.formats[owner].parse(all[hold:end])
+		if len(got) == 0 {
+			text += all[from:end] // the region was prose all along
 			continue
 		}
-		objs = append(objs, s[i:end])
-		i = end - 1
+		slog.Debug("Parsed tool calls", "tool_calls", got)
+		text += all[from:hold]
+		calls = append(calls, got...)
 	}
-	return objs
 }
 
-// parseToolCallObject decodes one JSON object into a tool call, succeeding only
-// when "name" is a string and "arguments" is an object or string.
-func parseToolCallObject(obj string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
-	toolCall := openai.ChatCompletionMessageFunctionToolCallFunction{}
-
-	name, err := sonic.GetFromString(obj, "name")
-	if err != nil {
-		return toolCall, err
-	}
-	if name.TypeSafe() != ast.V_STRING {
-		return toolCall, errors.New("name is not a string")
-	}
-	toolCall.Name, err = name.String()
-	if err != nil {
-		return toolCall, err
-	}
-
-	arguments, err := sonic.GetFromString(obj, "arguments")
-	if err != nil {
-		return toolCall, err
-	}
-	switch arguments.TypeSafe() {
-	case ast.V_OBJECT:
-		toolCall.Arguments, _ = arguments.Raw()
-	case ast.V_STRING:
-		toolCall.Arguments, _ = arguments.String()
-	default:
-		return toolCall, errors.New("unknown arguments type")
-	}
-
-	return toolCall, nil
+// Parse splits a whole response on a fresh scanner, keeping and dropping what the
+// streaming path does.
+func (s *ToolCallScanner) Parse(all string) (string, []toolCallFn) {
+	text, calls := s.Push(all)
+	tail, got := s.Tail()
+	return text + tail, append(calls, got...)
 }
 
-// ParseToolCalls returns the first tool call in resp. Gemma 4's non-JSON
-// `<|tool_call>call:...` syntax is detected by its marker; every other model
-// wraps a `{"name":..., "arguments":...}` JSON object we scan for directly.
-func ParseToolCalls(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
-	if strings.Contains(resp, gemma4ToolCallOpen) {
-		return parseToolCallsGemma4(resp)
-	}
-
-	for _, obj := range extractJSONObjects(resp) {
-		if toolCall, err := parseToolCallObject(obj); err == nil {
-			slog.Debug("Parsed tool call", "tool_call", toolCall)
-			return toolCall, nil
+// Tail ends the stream. What is buffered is text, unless the model stopped short of
+// closing a call: last chance to find one, so try every format, not just the holder.
+func (s *ToolCallScanner) Tail() (string, []toolCallFn) {
+	tail := s.buf.String()[s.emitted:]
+	s.emitted += len(tail) // terminal: a second call has nothing left to report
+	for _, f := range s.formats {
+		calls := f.parse(tail)
+		if len(calls) == 0 {
+			continue
 		}
+		// parse reports no offsets, so text before or between the calls goes too.
+		slog.Warn("Tool call recovered from unclosed output, dropping the text held with it",
+			"held_bytes", len(tail), "tool_calls", len(calls))
+		return "", calls
 	}
-
-	return openai.ChatCompletionMessageFunctionToolCallFunction{}, errors.New("tool call not match")
+	return tail, nil
 }

--- a/cli/server/utils/toolcall.go
+++ b/cli/server/utils/toolcall.go
@@ -60,7 +60,7 @@ func (m *markerScan) feed(all string) {
 }
 
 // markerFormat covers a syntax wrapped in two literals. Without a closing one, a
-// format implements feed itself, as JSONToolCall does.
+// format implements feed itself, as jsonToolCall does.
 //
 // BUG: the scan is not string-aware, so an end literal quoted inside the call's
 // own arguments cuts the region short and the call goes out as text instead. What
@@ -111,7 +111,7 @@ func NewToolCallScanner() *ToolCallScanner {
 	return &ToolCallScanner{formats: []toolCallFormat{
 		newGemma4ToolCall(),
 		newQwen3ToolCall(),
-		&JSONToolCall{},
+		&jsonToolCall{},
 	}}
 }
 

--- a/cli/server/utils/toolcall_gemma4.go
+++ b/cli/server/utils/toolcall_gemma4.go
@@ -20,15 +20,15 @@ const (
 	gemma4String = `<|"|>`
 )
 
-type Gemma4ToolCall struct {
+type gemma4ToolCall struct {
 	markerFormat
 }
 
-func newGemma4ToolCall() *Gemma4ToolCall {
-	return &Gemma4ToolCall{newMarkerFormat(gemma4Open, gemma4Close)}
+func newGemma4ToolCall() *gemma4ToolCall {
+	return &gemma4ToolCall{newMarkerFormat(gemma4Open, gemma4Close)}
 }
 
-func (t *Gemma4ToolCall) parse(s string) []toolCallFn { return parseGemma4ToolCalls(s) }
+func (t *gemma4ToolCall) parse(s string) []toolCallFn { return parseGemma4ToolCalls(s) }
 
 // parseGemma4ToolCalls returns every call in s. The end marker is not required: a
 // call whose dict closed is complete, so Tail can still recover a truncated one.

--- a/cli/server/utils/toolcall_gemma4.go
+++ b/cli/server/utils/toolcall_gemma4.go
@@ -4,52 +4,143 @@
 package utils
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/bytedance/sonic"
-	"github.com/openai/openai-go/v3"
 )
 
-// Gemma 4 emits tool calls as `<|tool_call>call:NAME{key:value,...}<tool_call|>`
-// instead of JSON. The body is a custom dict where strings are wrapped in
-// `<|"|>...<|"|>`, keys are bare up to ':', and scalars (number/bool/null) are
-// verbatim. Grammar mirrors llama.cpp's common_chat_params_init_gemma4.
+// Gemma 4 wraps each call in `<|tool_call>call:NAME{key:value,...}<tool_call|>`.
+// The body is a custom dict, not JSON: strings are wrapped in `<|"|>...<|"|>`, keys
+// are bare up to ':', and scalars are verbatim. Parallel calls are separate
+// wrappers, so a region still holds exactly one. Grammar: llama.cpp's
+// common_chat_params_init_gemma4.
 const (
-	gemma4ToolCallOpen = "<|tool_call>call:"
-	gemma4StringMarker = `<|"|>`
+	gemma4Open   = "<|tool_call>call:"
+	gemma4Close  = "<tool_call|>"
+	gemma4String = `<|"|>`
 )
 
-var errGemma4 = errors.New("gemma4 tool call not match")
+type Gemma4ToolCall struct {
+	markerFormat
+}
 
-// parseToolCallsGemma4 extracts the first `<|tool_call>call:NAME{...}` in resp
-// and returns it with the dict body transcoded to JSON arguments.
-func parseToolCallsGemma4(resp string) (openai.ChatCompletionMessageFunctionToolCallFunction, error) {
-	tc := openai.ChatCompletionMessageFunctionToolCallFunction{}
+func newGemma4ToolCall() *Gemma4ToolCall {
+	return &Gemma4ToolCall{newMarkerFormat(gemma4Open, gemma4Close)}
+}
 
-	start := strings.Index(resp, gemma4ToolCallOpen)
-	if start < 0 {
-		return tc, errGemma4
+func (t *Gemma4ToolCall) parse(s string) []toolCallFn { return parseGemma4ToolCalls(s) }
+
+// parseGemma4ToolCalls returns every call in s. The end marker is not required: a
+// call whose dict closed is complete, so Tail can still recover a truncated one.
+func parseGemma4ToolCalls(s string) []toolCallFn {
+	var calls []toolCallFn
+	for {
+		i := strings.Index(s, gemma4Open)
+		if i < 0 {
+			return calls
+		}
+		s = s[i+len(gemma4Open):] // a malformed call resumes at the next marker
+		brace := strings.IndexByte(s, '{')
+		if brace < 0 {
+			return calls
+		}
+		name := strings.TrimSpace(s[:brace])
+		args, next := parseGemma4Seq(s, brace, '{', '}', parseGemma4Member)
+		if name == "" || next < 0 {
+			continue
+		}
+		calls = append(calls, toolCallFn{Name: name, Arguments: args})
+		s = s[next:]
 	}
-	i := start + len(gemma4ToolCallOpen)
+}
 
-	brace := strings.IndexByte(resp[i:], '{')
-	if brace < 0 {
-		return tc, errGemma4
-	}
-	name := strings.TrimSpace(resp[i : i+brace])
-	if name == "" {
-		return tc, errGemma4
-	}
+// parseGemma4Value reads one value at s[i] as JSON plus the index past it, or a
+// negative index when s does not match the grammar. The parsers below all do.
+func parseGemma4Value(s string, i int) (string, int) {
+	switch {
+	case i >= len(s):
+		return "", -1
 
-	args, _, err := parseGemma4Dict(resp, i+brace)
-	if err != nil {
-		return tc, err
-	}
+	case strings.HasPrefix(s[i:], gemma4String):
+		i += len(gemma4String)
+		end := strings.Index(s[i:], gemma4String)
+		if end < 0 {
+			return "", -1
+		}
+		quoted, _ := sonic.MarshalString(s[i : i+end])
+		return quoted, i + end + len(gemma4String)
 
-	tc.Name = name
-	tc.Arguments = args
-	return tc, nil
+	case s[i] == '{':
+		return parseGemma4Seq(s, i, '{', '}', parseGemma4Member)
+	case s[i] == '[':
+		return parseGemma4Seq(s, i, '[', ']', parseGemma4Value)
+
+	default: // a number, bool or null runs to the next ',', '}' or ']'
+		start := i
+		for i < len(s) && s[i] != ',' && s[i] != '}' && s[i] != ']' {
+			i++
+		}
+		tok := strings.TrimSpace(s[start:i])
+		var v any
+		if tok == "" || sonic.UnmarshalString(tok, &v) != nil {
+			return "", -1
+		}
+		return tok, i
+	}
+}
+
+// parseGemma4Member reads one `key:value` pair as `"key":value`. The key grammar is
+// `[^:}]+`, so a member missing its value fails instead of swallowing later text.
+func parseGemma4Member(s string, i int) (string, int) {
+	colon := strings.IndexByte(s[i:], ':')
+	if colon < 0 || strings.IndexByte(s[i:i+colon], '}') >= 0 {
+		return "", -1
+	}
+	key := strings.TrimSpace(s[i : i+colon])
+	if key == "" {
+		return "", -1
+	}
+	val, next := parseGemma4Value(s, skipGemma4Space(s, i+colon+1))
+	if next < 0 {
+		return "", -1
+	}
+	quoted, _ := sonic.MarshalString(key)
+	return quoted + ":" + val, next
+}
+
+// parseGemma4Seq reads a comma-separated `open ... shut` sequence of elem. s[i] is
+// open, which the caller has checked.
+func parseGemma4Seq(s string, i int, open, shut byte,
+	elem func(string, int) (string, int)) (string, int) {
+	var b strings.Builder
+	b.WriteByte(open)
+
+	i = skipGemma4Space(s, i+1)
+	if i < len(s) && s[i] == shut {
+		b.WriteByte(shut)
+		return b.String(), i + 1
+	}
+	for {
+		enc, next := elem(s, skipGemma4Space(s, i))
+		if next < 0 {
+			return "", -1
+		}
+		b.WriteString(enc)
+		i = skipGemma4Space(s, next)
+		if i >= len(s) {
+			return "", -1
+		}
+		switch s[i] {
+		case ',':
+			i++
+			b.WriteByte(',')
+		case shut:
+			b.WriteByte(shut)
+			return b.String(), i + 1
+		default:
+			return "", -1
+		}
+	}
 }
 
 func skipGemma4Space(s string, i int) int {
@@ -57,120 +148,4 @@ func skipGemma4Space(s string, i int) int {
 		i++
 	}
 	return i
-}
-
-// parseGemma4Value parses one value at s[i] and returns its JSON encoding and
-// the index just past it.
-func parseGemma4Value(s string, i int) (string, int, error) {
-	if i >= len(s) {
-		return "", i, errGemma4
-	}
-	switch {
-	case strings.HasPrefix(s[i:], gemma4StringMarker):
-		return parseGemma4String(s, i)
-	case s[i] == '{':
-		return parseGemma4Dict(s, i)
-	case s[i] == '[':
-		return parseGemma4Array(s, i)
-	default:
-		return parseGemma4Scalar(s, i)
-	}
-}
-
-func parseGemma4String(s string, i int) (string, int, error) {
-	i += len(gemma4StringMarker)
-	end := strings.Index(s[i:], gemma4StringMarker)
-	if end < 0 {
-		return "", i, errGemma4
-	}
-	quoted, err := sonic.MarshalString(s[i : i+end])
-	if err != nil {
-		return "", i, err
-	}
-	return quoted, i + end + len(gemma4StringMarker), nil
-}
-
-func parseGemma4Dict(s string, i int) (string, int, error) {
-	return parseGemma4Seq(s, i, '{', '}', parseGemma4Member)
-}
-
-func parseGemma4Array(s string, i int) (string, int, error) {
-	return parseGemma4Seq(s, i, '[', ']', parseGemma4Value)
-}
-
-// parseGemma4Member parses one `key:value` pair and returns it as `"key":value`.
-// The key grammar is `[^:}]+`: it must be non-empty and cannot span the dict's
-// closing '}', so a member missing its value fails instead of swallowing later
-// text as the key.
-func parseGemma4Member(s string, i int) (string, int, error) {
-	colon := strings.IndexByte(s[i:], ':')
-	if colon < 0 || strings.IndexByte(s[i:i+colon], '}') >= 0 {
-		return "", i, errGemma4
-	}
-	key := strings.TrimSpace(s[i : i+colon])
-	if key == "" {
-		return "", i, errGemma4
-	}
-	val, next, err := parseGemma4Value(s, skipGemma4Space(s, i+colon+1))
-	if err != nil {
-		return "", i, err
-	}
-	quotedKey, err := sonic.MarshalString(key)
-	if err != nil {
-		return "", next, err
-	}
-	return quotedKey + ":" + val, next, nil
-}
-
-// parseGemma4Seq parses a comma-separated `open ... close` sequence, encoding
-// each element with elem. s[i] must be open (guaranteed by the caller).
-func parseGemma4Seq(s string, i int, open, close byte,
-	elem func(s string, i int) (string, int, error)) (string, int, error) {
-	i++ // past open
-
-	var b strings.Builder
-	b.WriteByte(open)
-
-	i = skipGemma4Space(s, i)
-	if i < len(s) && s[i] == close {
-		b.WriteByte(close)
-		return b.String(), i + 1, nil
-	}
-
-	for {
-		enc, next, err := elem(s, skipGemma4Space(s, i))
-		if err != nil {
-			return "", next, err
-		}
-		b.WriteString(enc)
-		i = skipGemma4Space(s, next)
-
-		if i >= len(s) {
-			return "", i, errGemma4
-		}
-		switch s[i] {
-		case ',':
-			i++
-			b.WriteByte(',')
-		case close:
-			b.WriteByte(close)
-			return b.String(), i + 1, nil
-		default:
-			return "", i, errGemma4
-		}
-	}
-}
-
-// parseGemma4Scalar reads a number/bool/null up to the next ',', '}' or ']'.
-func parseGemma4Scalar(s string, i int) (string, int, error) {
-	start := i
-	for i < len(s) && s[i] != ',' && s[i] != '}' && s[i] != ']' {
-		i++
-	}
-	tok := strings.TrimSpace(s[start:i])
-	var v any
-	if tok == "" || sonic.UnmarshalString(tok, &v) != nil {
-		return "", start, errGemma4
-	}
-	return tok, i, nil
 }

--- a/cli/server/utils/toolcall_gemma4_test.go
+++ b/cli/server/utils/toolcall_gemma4_test.go
@@ -5,148 +5,250 @@ package utils
 
 import "testing"
 
-func TestParseToolCallsGemma4(t *testing.T) {
+func TestParseGemma4ToolCalls(t *testing.T) {
 	tests := []struct {
-		name      string
-		resp      string
-		wantName  string
-		wantArgs  string
-		wantError bool
+		name string
+		resp string
+		want []toolCallFn // nil: no tool call
 	}{
 		{
-			name:     "single string argument",
-			resp:     `<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>}<tool_call|>`,
-			wantName: "get_weather",
-			wantArgs: `{"city":"Beijing"}`,
+			name: "single string argument",
+			resp: `<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>}<tool_call|>`,
+			want: []toolCallFn{{Name: "get_weather", Arguments: `{"city":"Beijing"}`}},
 		},
 		{
-			name:     "multiple arguments mixed types",
-			resp:     `<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>,days:3,metric:true}<tool_call|>`,
-			wantName: "get_weather",
-			wantArgs: `{"city":"Beijing","days":3,"metric":true}`,
+			name: "multiple arguments mixed types",
+			resp: `<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>,days:3,metric:true}<tool_call|>`,
+			want: []toolCallFn{{Name: "get_weather", Arguments: `{"city":"Beijing","days":3,"metric":true}`}},
 		},
 		{
-			name:     "empty arguments",
-			resp:     `<|tool_call>call:now{}<tool_call|>`,
-			wantName: "now",
-			wantArgs: `{}`,
+			name: "empty arguments",
+			resp: `<|tool_call>call:now{}<tool_call|>`,
+			want: []toolCallFn{{Name: "now", Arguments: `{}`}},
 		},
 		{
-			name:     "nested dict",
-			resp:     `<|tool_call>call:f{loc:{lat:1.5,lng:<|"|>x<|"|>}}<tool_call|>`,
-			wantName: "f",
-			wantArgs: `{"loc":{"lat":1.5,"lng":"x"}}`,
+			name: "nested dict",
+			resp: `<|tool_call>call:f{loc:{lat:1.5,lng:<|"|>x<|"|>}}<tool_call|>`,
+			want: []toolCallFn{{Name: "f", Arguments: `{"loc":{"lat":1.5,"lng":"x"}}`}},
 		},
 		{
-			name:     "array of strings",
-			resp:     `<|tool_call>call:pick{items:[<|"|>a<|"|>,<|"|>b<|"|>]}<tool_call|>`,
-			wantName: "pick",
-			wantArgs: `{"items":["a","b"]}`,
+			name: "array of strings",
+			resp: `<|tool_call>call:pick{items:[<|"|>a<|"|>,<|"|>b<|"|>]}<tool_call|>`,
+			want: []toolCallFn{{Name: "pick", Arguments: `{"items":["a","b"]}`}},
 		},
 		{
-			name:     "array of dicts",
-			resp:     `<|tool_call>call:batch{items:[{a:1},{b:2}]}<tool_call|>`,
-			wantName: "batch",
-			wantArgs: `{"items":[{"a":1},{"b":2}]}`,
+			name: "array of dicts",
+			resp: `<|tool_call>call:batch{items:[{a:1},{b:2}]}<tool_call|>`,
+			want: []toolCallFn{{Name: "batch", Arguments: `{"items":[{"a":1},{"b":2}]}`}},
 		},
 		{
-			name:     "null and negative number",
-			resp:     `<|tool_call>call:f{x:null,y:-4.2}<tool_call|>`,
-			wantName: "f",
-			wantArgs: `{"x":null,"y":-4.2}`,
+			name: "null and negative number",
+			resp: `<|tool_call>call:f{x:null,y:-4.2}<tool_call|>`,
+			want: []toolCallFn{{Name: "f", Arguments: `{"x":null,"y":-4.2}`}},
 		},
 		{
-			name:     "string with special chars escaped",
-			resp:     `<|tool_call>call:say{text:<|"|>a "quote" and }brace{<|"|>}<tool_call|>`,
-			wantName: "say",
-			wantArgs: `{"text":"a \"quote\" and }brace{"}`,
+			name: "string with special chars escaped",
+			resp: `<|tool_call>call:say{text:<|"|>a "quote" and }brace{<|"|>}<tool_call|>`,
+			want: []toolCallFn{{Name: "say", Arguments: `{"text":"a \"quote\" and }brace{"}`}},
 		},
 		{
-			name:     "preceded by reasoning and content",
-			resp:     "<|channel>thought\nlet me check\n<channel|>Sure! <|tool_call>call:go{x:1}<tool_call|>",
-			wantName: "go",
-			wantArgs: `{"x":1}`,
+			name: "preceded by reasoning and content",
+			resp: "<|channel>thought\nlet me check\n<channel|>Sure! <|tool_call>call:go{x:1}<tool_call|>",
+			want: []toolCallFn{{Name: "go", Arguments: `{"x":1}`}},
 		},
 		{
-			name:     "picks first of parallel tool calls",
-			resp:     `<|tool_call>call:first{a:1}<tool_call|><|tool_call>call:second{b:2}<tool_call|>`,
-			wantName: "first",
-			wantArgs: `{"a":1}`,
+			name: "whitespace around members",
+			resp: `<|tool_call>call:f{ a : 1 , b : <|"|>x<|"|> }<tool_call|>`,
+			want: []toolCallFn{{Name: "f", Arguments: `{"a":1,"b":"x"}`}},
 		},
 		{
-			name:     "whitespace around members",
-			resp:     `<|tool_call>call:f{ a : 1 , b : <|"|>x<|"|> }<tool_call|>`,
-			wantName: "f",
-			wantArgs: `{"a":1,"b":"x"}`,
+			// p.repeat in the grammar: parallel calls are separate wrappers
+			name: "parallel tool calls",
+			resp: `<|tool_call>call:first{a:1}<tool_call|><|tool_call>call:second{b:2}<tool_call|>`,
+			want: []toolCallFn{{Name: "first", Arguments: `{"a":1}`}, {Name: "second", Arguments: `{"b":2}`}},
 		},
 		{
-			name:      "no tool call marker",
-			resp:      "just some plain text",
-			wantError: true,
+			name: "three parallel calls with text between",
+			resp: `<|tool_call>call:a{}<tool_call|> then <|tool_call>call:b{}<tool_call|>ok<|tool_call>call:c{}<tool_call|>`,
+			want: []toolCallFn{{Name: "a", Arguments: `{}`}, {Name: "b", Arguments: `{}`}, {Name: "c", Arguments: `{}`}},
 		},
 		{
-			name:      "marker but no brace",
-			resp:      `<|tool_call>call:broken`,
-			wantError: true,
+			name: "a malformed call does not hide the next one",
+			resp: `<|tool_call>call:bad{k}<tool_call|><|tool_call>call:good{x:1}<tool_call|>`,
+			want: []toolCallFn{{Name: "good", Arguments: `{"x":1}`}},
 		},
 		{
-			name:      "unterminated dict",
-			resp:      `<|tool_call>call:f{x:1`,
-			wantError: true,
+			// the end marker is not part of the grammar this parser needs
+			name: "unclosed wrapper still parses",
+			resp: `<|tool_call>call:f{x:1}`,
+			want: []toolCallFn{{Name: "f", Arguments: `{"x":1}`}},
 		},
 		{
-			name:      "unterminated string value",
-			resp:      `<|tool_call>call:f{x:<|"|>abc}<tool_call|>`,
-			wantError: true,
+			name: "no tool call marker",
+			resp: "just some plain text",
 		},
 		{
-			name:      "empty function name",
-			resp:      `<|tool_call>call:{x:1}<tool_call|>`,
-			wantError: true,
+			name: "marker but no brace",
+			resp: `<|tool_call>call:broken`,
 		},
 		{
-			name:      "empty key rejected",
-			resp:      `<|tool_call>call:f{:1}<tool_call|>`,
-			wantError: true,
+			name: "unterminated dict",
+			resp: `<|tool_call>call:f{x:1`,
+		},
+		{
+			name: "unterminated string value",
+			resp: `<|tool_call>call:f{x:<|"|>abc}<tool_call|>`,
+		},
+		{
+			name: "empty function name",
+			resp: `<|tool_call>call:{x:1}<tool_call|>`,
+		},
+		{
+			name: "empty key rejected",
+			resp: `<|tool_call>call:f{:1}<tool_call|>`,
 		},
 		{
 			// key scan must stop at '}' rather than swallowing the next member's colon
-			name:      "member without value does not swallow later key",
-			resp:      `<|tool_call>call:f{k}{x:1}<tool_call|>`,
-			wantError: true,
+			name: "member without value does not swallow later key",
+			resp: `<|tool_call>call:f{k}{x:1}<tool_call|>`,
+		},
+		{
+			name: "json syntax is not a gemma4 call",
+			resp: `{"name": "f", "arguments": {}}`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseToolCallsGemma4(tt.resp)
-			if tt.wantError {
-				if err == nil {
-					t.Fatalf("expected error, got tool call %+v", got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got.Name != tt.wantName {
-				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
-			}
-			if got.Arguments != tt.wantArgs {
-				t.Errorf("arguments = %q, want %q", got.Arguments, tt.wantArgs)
+			if got := parseGemma4ToolCalls(tt.resp); !callsEqual(got, tt.want) {
+				t.Errorf("parsed %+v, want %+v", got, tt.want)
 			}
 		})
 	}
 }
 
-// ParseToolCalls must route gemma4-marked output to the gemma4 parser while
-// leaving JSON output on the generic path.
-func TestParseToolCallsDispatch(t *testing.T) {
-	got, err := ParseToolCalls(`<|tool_call>call:get_weather{city:<|"|>Beijing<|"|>}<tool_call|>`)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// Each wrapper is its own region, so parallel calls come out one per Push with the
+// text between them streamed in order.
+func TestGemma4Stream(t *testing.T) {
+	tests := []struct {
+		name      string
+		resp      string
+		wantText  string
+		wantCalls []toolCallFn
+	}{
+		{
+			name:      "one call",
+			resp:      `<|tool_call>call:f{a:1}<tool_call|>`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"a":1}`}},
+		},
+		{
+			name:      "prose around a call",
+			resp:      `Sure! <|tool_call>call:f{a:1}<tool_call|> done`,
+			wantText:  "Sure!  done",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"a":1}`}},
+		},
+		{
+			name:      "two parallel calls",
+			resp:      `<|tool_call>call:first{a:1}<tool_call|><|tool_call>call:second{b:2}<tool_call|>`,
+			wantCalls: []toolCallFn{{Name: "first", Arguments: `{"a":1}`}, {Name: "second", Arguments: `{"b":2}`}},
+		},
+		{
+			name:      "parallel calls separated by a newline",
+			resp:      "<|tool_call>call:a{}<tool_call|>\n<|tool_call>call:b{}<tool_call|>",
+			wantText:  "\n",
+			wantCalls: []toolCallFn{{Name: "a", Arguments: `{}`}, {Name: "b", Arguments: `{}`}},
+		},
+		{
+			name: "three parallel calls",
+			resp: `<|tool_call>call:a{x:<|"|>1<|"|>}<tool_call|><|tool_call>call:b{}<tool_call|><|tool_call>call:c{y:[1,2]}<tool_call|>`,
+			wantCalls: []toolCallFn{
+				{Name: "a", Arguments: `{"x":"1"}`},
+				{Name: "b", Arguments: `{}`},
+				{Name: "c", Arguments: `{"y":[1,2]}`},
+			},
+		},
+		{
+			name:      "a malformed call streams as text between two good ones",
+			resp:      `<|tool_call>call:a{}<tool_call|><|tool_call>call:bad{k}<tool_call|><|tool_call>call:c{}<tool_call|>`,
+			wantText:  `<|tool_call>call:bad{k}<tool_call|>`,
+			wantCalls: []toolCallFn{{Name: "a", Arguments: `{}`}, {Name: "c", Arguments: `{}`}},
+		},
+		{
+			// the model stopped before the end marker: Tail still finds the call
+			name:      "unclosed wrapper",
+			resp:      `<|tool_call>call:f{a:1}`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"a":1}`}},
+		},
+		{
+			name:      "braces and quotes inside a gemma4 string",
+			resp:      `<|tool_call>call:say{t:<|"|>a "q" }{ b<|"|>}<tool_call|>!`,
+			wantText:  "!",
+			wantCalls: []toolCallFn{{Name: "say", Arguments: `{"t":"a \"q\" }{ b"}`}},
+		},
+		{
+			name:     "refuted open marker",
+			resp:     "<|tool_call>calX nothing here",
+			wantText: "<|tool_call>calX nothing here",
+		},
+		{
+			name:     "ends on a partial open marker",
+			resp:     "stops at <|tool_call>",
+			wantText: "stops at <|tool_call>",
+		},
+		{
+			name:     "a stray end marker is prose",
+			resp:     "<tool_call|> stray",
+			wantText: "<tool_call|> stray",
+		},
+		{
+			// gemma4 arguments are not JSON, so no format claims them
+			name:     "wrapper holding no call is prose",
+			resp:     `<|tool_call>call:f{not a dict}<tool_call|>`,
+			wantText: `<|tool_call>call:f{not a dict}<tool_call|>`,
+		},
+		{
+			// markerFormat's BUG: the quoted end marker cuts the region short, so this
+			// parses as nothing and streams as text. Parse on the whole text finds it.
+			name:     "an end marker inside a gemma4 string loses the call",
+			resp:     `<|tool_call>call:f{t:<|"|>a<tool_call|>b<|"|>}<tool_call|>`,
+			wantText: `<|tool_call>call:f{t:<|"|>a<tool_call|>b<|"|>}<tool_call|>`,
+		},
 	}
-	if got.Name != "get_weather" || got.Arguments != `{"city":"Beijing"}` {
-		t.Errorf("gemma4 dispatch failed: %+v", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for size := 1; size <= 8; size++ {
+				text, calls := stream(tt.resp, size)
+				if text != tt.wantText {
+					t.Errorf("size %d: text = %q, want %q", size, text, tt.wantText)
+				}
+				if !callsEqual(calls, tt.wantCalls) {
+					t.Errorf("size %d: calls = %+v, want %+v", size, calls, tt.wantCalls)
+				}
+			}
+		})
+	}
+}
+
+// Streaming and the whole-text scan are separate implementations of the parallel case
+// too, so they check each other.
+func TestGemma4StreamAgreesWithParse(t *testing.T) {
+	responses := []string{
+		`<|tool_call>call:f{a:1}<tool_call|>`,
+		`<|tool_call>call:a{}<tool_call|><|tool_call>call:b{}<tool_call|>`,
+		`hi <|tool_call>call:a{}<tool_call|> mid <|tool_call>call:b{x:[1,{y:2}]}<tool_call|> tail`,
+		`<|tool_call>call:f{a:1}`,
+		"<|channel>thought\nhmm\n<channel|><|tool_call>call:go{}<tool_call|>",
+		// a gemma4 string holding JSON: the bare-JSON scan must not claim it
+		`<|tool_call>call:f{body:<|"|>{"name":"x","arguments":{}}<|"|>}<tool_call|>`,
+	}
+
+	for _, resp := range responses {
+		t.Run(resp, func(t *testing.T) {
+			_, got := stream(resp, 1)
+			if want := parseGemma4ToolCalls(resp); !callsEqual(got, want) {
+				t.Errorf("streamed %+v, parsed %+v", got, want)
+			}
+		})
 	}
 }

--- a/cli/server/utils/toolcall_json.go
+++ b/cli/server/utils/toolcall_json.go
@@ -10,18 +10,18 @@ import (
 	"github.com/bytedance/sonic/ast"
 )
 
-// JSONToolCall is a bare JSON object, with nothing marking where it ends: the
+// jsonToolCall is a bare JSON object, with nothing marking where it ends: the
 // object it opens is the whole candidate, and parse decides whether it is a call.
-type JSONToolCall struct {
+type jsonToolCall struct {
 	pos  int // bytes of all consumed
 	obj  int // where the candidate object began; == pos when none is open
 	end  int // where that object closed; 0 until it does
 	walk braceWalk
 }
 
-func (t *JSONToolCall) parse(s string) []toolCallFn { return parseJSONToolCalls(s) }
+func (t *jsonToolCall) parse(s string) []toolCallFn { return parseJSONToolCalls(s) }
 
-func (t *JSONToolCall) feed(all string, from int) (int, int) {
+func (t *jsonToolCall) feed(all string, from int) (int, int) {
 	if from > t.obj { // the region was consumed or bypassed: start over
 		t.pos, t.obj, t.end = from, from, 0
 	}

--- a/cli/server/utils/toolcall_json.go
+++ b/cli/server/utils/toolcall_json.go
@@ -1,0 +1,134 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import (
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
+)
+
+// JSONToolCall is a bare JSON object, with nothing marking where it ends: the
+// object it opens is the whole candidate, and parse decides whether it is a call.
+type JSONToolCall struct {
+	pos  int // bytes of all consumed
+	obj  int // where the candidate object began; == pos when none is open
+	end  int // where that object closed; 0 until it does
+	walk braceWalk
+}
+
+func (t *JSONToolCall) parse(s string) []toolCallFn { return parseJSONToolCalls(s) }
+
+func (t *JSONToolCall) feed(all string, from int) (int, int) {
+	if from > t.obj { // the region was consumed or bypassed: start over
+		t.pos, t.obj, t.end = from, from, 0
+	}
+	if t.end > 0 {
+		return t.obj, t.end
+	}
+	if t.obj == t.pos {
+		i := strings.IndexByte(all[t.pos:], '{')
+		if i < 0 {
+			t.obj, t.pos = len(all), len(all)
+			return -1, -1
+		}
+		t.obj, t.pos, t.walk = t.pos+i, t.pos+i, braceWalk{}
+	}
+	n := t.walk.feed(all[t.pos:])
+	if n < 0 {
+		t.pos = len(all)
+		return t.obj, -1 // still open: it may yet close into a call
+	}
+	t.pos += n
+	t.end = t.pos
+	return t.obj, t.end
+}
+
+// braceWalk tracks nesting depth across chunk boundaries, ignoring braces inside
+// string literals. feed returns the offset past the '}' closing the first object.
+type braceWalk struct {
+	depth   int
+	inStr   bool
+	escaped bool
+}
+
+func (w *braceWalk) feed(s string) int {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if w.inStr {
+			switch {
+			case w.escaped:
+				w.escaped = false
+			case c == '\\':
+				w.escaped = true
+			case c == '"':
+				w.inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			w.inStr = true
+		case '{':
+			w.depth++
+		case '}':
+			w.depth--
+			if w.depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+// parseToolCallObject decodes one object, nil unless "name" is a string and
+// "arguments" an object or a string.
+func parseToolCallObject(obj string) *toolCallFn {
+	name, err := sonic.GetFromString(obj, "name")
+	if err != nil || name.TypeSafe() != ast.V_STRING {
+		return nil
+	}
+	args, err := sonic.GetFromString(obj, "arguments")
+	if err != nil {
+		return nil
+	}
+	var raw string
+	switch args.TypeSafe() {
+	case ast.V_OBJECT:
+		raw, _ = args.Raw()
+	case ast.V_STRING:
+		raw, _ = args.String()
+	default:
+		return nil
+	}
+	call := &toolCallFn{Arguments: raw}
+	call.Name, _ = name.String()
+	return call
+}
+
+// parseJSONToolCalls returns every object in s that is a tool call. Wrappers such
+// as `<tool_call>` tags or code fences are transparent: only the objects matter.
+func parseJSONToolCalls(s string) []toolCallFn {
+	var calls []toolCallFn
+	for i := 0; i < len(s); {
+		j := strings.IndexByte(s[i:], '{')
+		if j < 0 {
+			break
+		}
+		i += j
+		// s is complete here, so an object left open holds nothing: look inside.
+		var w braceWalk
+		end := w.feed(s[i:])
+		if end < 0 {
+			i++
+			continue
+		}
+		if call := parseToolCallObject(s[i : i+end]); call != nil {
+			calls = append(calls, *call)
+		}
+		i += end
+	}
+	return calls
+}

--- a/cli/server/utils/toolcall_json_test.go
+++ b/cli/server/utils/toolcall_json_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import "testing"
+
+func TestParseJSONToolCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		resp string
+		want []toolCallFn // nil: no tool call
+	}{
+		{
+			name: "bare json object",
+			resp: `{"name": "get_weather", "arguments": {"city": "Beijing"}}`,
+			want: []toolCallFn{{Name: "get_weather", Arguments: `{"city": "Beijing"}`}},
+		},
+		{
+			name: "json with surrounding prose",
+			resp: `Sure, let me call it. {"name": "get_weather", "arguments": {"city": "Beijing"}} Done.`,
+			want: []toolCallFn{{Name: "get_weather", Arguments: `{"city": "Beijing"}`}},
+		},
+		{
+			name: "string arguments",
+			resp: `{"name": "echo", "arguments": "hello"}`,
+			want: []toolCallFn{{Name: "echo", Arguments: "hello"}},
+		},
+		{
+			name: "nested braces in arguments",
+			resp: `{"name": "f", "arguments": {"a": {"b": {"c": 1}}}}`,
+			want: []toolCallFn{{Name: "f", Arguments: `{"a": {"b": {"c": 1}}}`}},
+		},
+		{
+			name: "deeply nested arguments",
+			resp: `prose {"name": "deep", "arguments": {"l1": {"l2": {"l3": {"l4": {"l5": {"v": [1, {"x": 2}]}}}}}}} tail`,
+			want: []toolCallFn{{Name: "deep", Arguments: `{"l1": {"l2": {"l3": {"l4": {"l5": {"v": [1, {"x": 2}]}}}}}}`}},
+		},
+		{
+			name: "nested objects with braces inside strings",
+			resp: `{"name": "g", "arguments": {"outer": {"inner": {"note": "close } here { and {} there"}}}}`,
+			want: []toolCallFn{{Name: "g", Arguments: `{"outer": {"inner": {"note": "close } here { and {} there"}}}`}},
+		},
+		{
+			name: "array of nested objects as arguments",
+			resp: `{"name": "batch", "arguments": {"items": [{"a": {"b": 1}}, {"c": {"d": 2}}]}}`,
+			want: []toolCallFn{{Name: "batch", Arguments: `{"items": [{"a": {"b": 1}}, {"c": {"d": 2}}]}`}},
+		},
+		{
+			name: "braces inside string literal ignored",
+			resp: `{"name": "say", "arguments": {"text": "a } b { c"}}`,
+			want: []toolCallFn{{Name: "say", Arguments: `{"text": "a } b { c"}`}},
+		},
+		{
+			name: "escaped quote inside string",
+			resp: `{"name": "say", "arguments": {"text": "quote \" and } brace"}}`,
+			want: []toolCallFn{{Name: "say", Arguments: `{"text": "quote \" and } brace"}`}},
+		},
+		{
+			name: "skips leading object without name",
+			resp: `{"thinking": "hmm"} then {"name": "go", "arguments": {}}`,
+			want: []toolCallFn{{Name: "go", Arguments: `{}`}},
+		},
+		{
+			name: "skips object with name but no arguments",
+			resp: `{"name": "no_args"} {"name": "real", "arguments": {"x": 1}}`,
+			want: []toolCallFn{{Name: "real", Arguments: `{"x": 1}`}},
+		},
+		{
+			name: "adjacent tool calls",
+			resp: `{"name": "first", "arguments": {"a": 1}}{"name": "second", "arguments": {"b": 2}}`,
+			want: []toolCallFn{{Name: "first", Arguments: `{"a": 1}`}, {Name: "second", Arguments: `{"b": 2}`}},
+		},
+		{
+			name: "skips candidate with array arguments",
+			resp: `{"name": "bad", "arguments": [1, 2, 3]} {"name": "good", "arguments": {"ok": 1}}`,
+			want: []toolCallFn{{Name: "good", Arguments: `{"ok": 1}`}},
+		},
+		{
+			name: "skips candidate with numeric arguments",
+			resp: `{"name": "bad", "arguments": 42} {"name": "good", "arguments": "text"}`,
+			want: []toolCallFn{{Name: "good", Arguments: "text"}},
+		},
+		{
+			name: "skips candidate with non-string name",
+			resp: `{"name": 7, "arguments": {}} {"name": "good", "arguments": {}}`,
+			want: []toolCallFn{{Name: "good", Arguments: `{}`}},
+		},
+		{
+			name: "all candidates invalid falls through to error",
+			resp: `{"name": "a", "arguments": [1]} {"name": 2, "arguments": {}} {"name": "c"}`,
+		},
+		{
+			name: "tool calls separated by prose",
+			resp: `Call one: {"name": "first", "arguments": {}}. Then: {"name": "second", "arguments": {}}`,
+			want: []toolCallFn{{Name: "first", Arguments: `{}`}, {Name: "second", Arguments: `{}`}},
+		},
+		{
+			name: "leading unterminated brace does not swallow later call",
+			resp: `reasoning { partial and never closed ... {"name": "go", "arguments": {"ok": true}}`,
+			want: []toolCallFn{{Name: "go", Arguments: `{"ok": true}`}},
+		},
+		{
+			name: "stray closing braces before real call",
+			resp: `garbage } } more } {"name": "go", "arguments": {}}`,
+			want: []toolCallFn{{Name: "go", Arguments: `{}`}},
+		},
+		{
+			name: "name with escaped chars",
+			resp: `{"name": "ns\\tool", "arguments": {"path": "C:\\tmp"}}`,
+			want: []toolCallFn{{Name: `ns\tool`, Arguments: `{"path": "C:\\tmp"}`}},
+		},
+		{
+			name: "empty object skipped then real call",
+			resp: `{} {"name": "go", "arguments": {}}`,
+			want: []toolCallFn{{Name: "go", Arguments: `{}`}},
+		},
+		{
+			// a wrapper is transparent: only the object inside it matters
+			name: "json inside code fence",
+			resp: "here you go:\n```json\n{\"name\": \"fenced\", \"arguments\": {\"q\": \"x\"}}\n```",
+			want: []toolCallFn{{Name: "fenced", Arguments: `{"q": "x"}`}},
+		},
+		{
+			name: "no json object",
+			resp: "just some plain text without any call",
+		},
+		{
+			name: "unterminated object",
+			resp: `{"name": "go", "arguments":`,
+		},
+		{
+			name: "only non-tool-call objects",
+			resp: `{"foo": 1} {"bar": 2} {"name": 42}`,
+		},
+		{
+			name: "empty string",
+			resp: "",
+		},
+		{
+			name: "braces only inside a string literal",
+			resp: `the model said "{ not json }" and stopped`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseJSONToolCalls(tt.resp); !callsEqual(got, tt.want) {
+				t.Errorf("parsed %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A bare object is held while it is open and reported as a region once it closes;
+// whether that region is a call is parse's business, not feed's.
+func TestJSONToolCallFeed(t *testing.T) {
+	tests := []struct {
+		name            string
+		s               string
+		wantAt, wantEnd int
+	}{
+		{"prose", "no braces here", -1, -1},
+		{"open object", `prose {"na`, 6, -1},
+		{"tool call", `hi {"name": "f", "arguments": {}}`, 3, 33},
+		{"a non-call object is still a region", `{"foo": 1} ok`, 0, 10},
+		{"stops at the first close", "a { b } c { d", 2, 7},
+		{"first of two calls", `{"name":"a","arguments":{}}{"name":"b","arguments":{}}`, 0, 27},
+		{"braces inside a string", `{"name":"f","arguments":{"s":"}}"}}`, 0, 35},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at, end := (&JSONToolCall{}).feed(tt.s, 0)
+			if at != tt.wantAt || end != tt.wantEnd {
+				t.Errorf("feed(%q) = (%d, %d), want (%d, %d)", tt.s, at, end, tt.wantAt, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/cli/server/utils/toolcall_json_test.go
+++ b/cli/server/utils/toolcall_json_test.go
@@ -171,7 +171,7 @@ func TestJSONToolCallFeed(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			at, end := (&JSONToolCall{}).feed(tt.s, 0)
+			at, end := (&jsonToolCall{}).feed(tt.s, 0)
 			if at != tt.wantAt || end != tt.wantEnd {
 				t.Errorf("feed(%q) = (%d, %d), want (%d, %d)", tt.s, at, end, tt.wantAt, tt.wantEnd)
 			}

--- a/cli/server/utils/toolcall_qwen3.go
+++ b/cli/server/utils/toolcall_qwen3.go
@@ -3,14 +3,14 @@
 
 package utils
 
-// Qwen3ToolCall is the `<tool_call>{json}</tool_call>` wrapper of Qwen3 and
+// qwen3ToolCall is the `<tool_call>{json}</tool_call>` wrapper of Qwen3 and
 // Hermes-style templates. Its body is plain JSON, so it shares that parser.
-type Qwen3ToolCall struct {
+type qwen3ToolCall struct {
 	markerFormat
 }
 
-func newQwen3ToolCall() *Qwen3ToolCall {
-	return &Qwen3ToolCall{newMarkerFormat("<tool_call>", "</tool_call>")}
+func newQwen3ToolCall() *qwen3ToolCall {
+	return &qwen3ToolCall{newMarkerFormat("<tool_call>", "</tool_call>")}
 }
 
-func (t *Qwen3ToolCall) parse(s string) []toolCallFn { return parseJSONToolCalls(s) }
+func (t *qwen3ToolCall) parse(s string) []toolCallFn { return parseJSONToolCalls(s) }

--- a/cli/server/utils/toolcall_qwen3.go
+++ b/cli/server/utils/toolcall_qwen3.go
@@ -1,0 +1,16 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+// Qwen3ToolCall is the `<tool_call>{json}</tool_call>` wrapper of Qwen3 and
+// Hermes-style templates. Its body is plain JSON, so it shares that parser.
+type Qwen3ToolCall struct {
+	markerFormat
+}
+
+func newQwen3ToolCall() *Qwen3ToolCall {
+	return &Qwen3ToolCall{newMarkerFormat("<tool_call>", "</tool_call>")}
+}
+
+func (t *Qwen3ToolCall) parse(s string) []toolCallFn { return parseJSONToolCalls(s) }

--- a/cli/server/utils/toolcall_test.go
+++ b/cli/server/utils/toolcall_test.go
@@ -3,198 +3,435 @@
 
 package utils
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-func TestParseToolCalls(t *testing.T) {
+func callsEqual(got, want []toolCallFn) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i].Name != want[i].Name || got[i].Arguments != want[i].Arguments {
+			return false
+		}
+	}
+	return true
+}
+
+// stream feeds resp in chunks of size and returns everything emitted as content
+// plus every call reported, in order.
+func stream(resp string, size int) (string, []toolCallFn) {
+	s := NewToolCallScanner()
+	text := ""
+	var calls []toolCallFn
+	for i := 0; i < len(resp); i += size {
+		out, got := s.Push(resp[i:min(i+size, len(resp))])
+		text += out
+		calls = append(calls, got...)
+	}
+	tail, got := s.Tail()
+	return text + tail, append(calls, got...)
+}
+
+// Every byte is either streamed as content or consumed by a tool call, and the
+// split must not depend on where the token boundaries fall.
+func TestScannerStream(t *testing.T) {
 	tests := []struct {
 		name      string
 		resp      string
-		wantName  string
-		wantArgs  string
-		wantError bool
+		wantText  string
+		wantCalls []toolCallFn
 	}{
 		{
-			name:     "bare json object",
-			resp:     `{"name": "get_weather", "arguments": {"city": "Beijing"}}`,
-			wantName: "get_weather",
-			wantArgs: `{"city": "Beijing"}`,
+			name:     "prose only",
+			resp:     "Sure, here is the answer.",
+			wantText: "Sure, here is the answer.",
 		},
 		{
-			name:     "json with surrounding prose",
-			resp:     `Sure, let me call it. {"name": "get_weather", "arguments": {"city": "Beijing"}} Done.`,
-			wantName: "get_weather",
-			wantArgs: `{"city": "Beijing"}`,
+			name:      "bare call after prose",
+			resp:      `sure {"name": "f", "arguments": {}}`,
+			wantText:  "sure ",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}},
 		},
 		{
-			name:     "string arguments",
-			resp:     `{"name": "echo", "arguments": "hello"}`,
-			wantName: "echo",
-			wantArgs: "hello",
+			// the point of an end marker: the stream resumes after the call
+			name:      "prose after a call",
+			resp:      `{"name": "f", "arguments": {}} and then some prose`,
+			wantText:  " and then some prose",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}},
 		},
 		{
-			name:     "nested braces in arguments",
-			resp:     `{"name": "f", "arguments": {"a": {"b": {"c": 1}}}}`,
-			wantName: "f",
-			wantArgs: `{"a": {"b": {"c": 1}}}`,
+			name:      "two calls with prose between",
+			resp:      `a {"name":"f","arguments":{}} b {"name":"g","arguments":{"x":1}} c`,
+			wantText:  "a  b  c",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}, {Name: "g", Arguments: `{"x":1}`}},
 		},
 		{
-			name:     "deeply nested arguments",
-			resp:     `prose {"name": "deep", "arguments": {"l1": {"l2": {"l3": {"l4": {"l5": {"v": [1, {"x": 2}]}}}}}}} tail`,
-			wantName: "deep",
-			wantArgs: `{"l1": {"l2": {"l3": {"l4": {"l5": {"v": [1, {"x": 2}]}}}}}}`,
+			name:      "qwen3 wrapper",
+			resp:      "<tool_call>{\"name\": \"f\", \"arguments\": {}}</tool_call>",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}},
 		},
 		{
-			name:     "nested objects with braces inside strings",
-			resp:     `{"name": "g", "arguments": {"outer": {"inner": {"note": "close } here { and {} there"}}}}`,
-			wantName: "g",
-			wantArgs: `{"outer": {"inner": {"note": "close } here { and {} there"}}}`,
+			name:      "qwen3 wrapper then prose",
+			resp:      "<tool_call>\n{\"name\": \"f\", \"arguments\": {}}\n</tool_call> bye",
+			wantText:  " bye",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}},
 		},
 		{
-			name:     "array of nested objects as arguments",
-			resp:     `{"name": "batch", "arguments": {"items": [{"a": {"b": 1}}, {"c": {"d": 2}}]}}`,
-			wantName: "batch",
-			wantArgs: `{"items": [{"a": {"b": 1}}, {"c": {"d": 2}}]}`,
+			name:      "two qwen3 wrappers",
+			resp:      `<tool_call>{"name":"f","arguments":{}}</tool_call><tool_call>{"name":"g","arguments":{}}</tool_call>`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}, {Name: "g", Arguments: `{}`}},
 		},
 		{
-			name:     "braces inside string literal ignored",
-			resp:     `{"name": "say", "arguments": {"text": "a } b { c"}}`,
-			wantName: "say",
-			wantArgs: `{"text": "a } b { c"}`,
+			// the model stopped before the closing tag: Tail still finds the call
+			name:      "unclosed wrapper",
+			resp:      `<tool_call>{"name": "f", "arguments": {}}`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}},
 		},
 		{
-			name:     "escaped quote inside string",
-			resp:     `{"name": "say", "arguments": {"text": "quote \" and } brace"}}`,
-			wantName: "say",
-			wantArgs: `{"text": "quote \" and } brace"}`,
+			// The brace holds the buffer for JSON, but the call in it is gemma4's.
+			name:      "a gemma4 call held by a stray brace",
+			resp:      `code { <|tool_call>call:f{a:1}<tool_call|>`,
+			wantText:  "code ",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"a":1}`}},
 		},
 		{
-			name:     "skips leading object without name",
-			resp:     `{"thinking": "hmm"} then {"name": "go", "arguments": {}}`,
-			wantName: "go",
-			wantArgs: `{}`,
+			name:      "a gemma4 call held by a qwen3 marker",
+			resp:      `<tool_call>oops <|tool_call>call:f{a:1}<tool_call|>`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"a":1}`}},
 		},
 		{
-			name:     "skips object with name but no arguments",
-			resp:     `{"name": "no_args"} {"name": "real", "arguments": {"x": 1}}`,
-			wantName: "real",
-			wantArgs: `{"x": 1}`,
+			// one region, two calls: both come out on the Push that closed it
+			name:      "two calls in one wrapper",
+			resp:      `<tool_call>{"name":"a","arguments":{}}{"name":"b","arguments":{}}</tool_call>`,
+			wantCalls: []toolCallFn{{Name: "a", Arguments: `{}`}, {Name: "b", Arguments: `{}`}},
 		},
 		{
-			name:     "picks first of multiple tool calls",
-			resp:     `{"name": "first", "arguments": {"a": 1}}{"name": "second", "arguments": {"b": 2}}`,
-			wantName: "first",
-			wantArgs: `{"a": 1}`,
+			// what a Mistral-style array syntax looks like inside one region
+			name:      "a json array of calls in one wrapper",
+			resp:      `<tool_call>[{"name":"a","arguments":{}},{"name":"b","arguments":{"x":1}}]</tool_call>`,
+			wantCalls: []toolCallFn{{Name: "a", Arguments: `{}`}, {Name: "b", Arguments: `{"x":1}`}},
 		},
 		{
-			name:     "skips candidate with array arguments",
-			resp:     `{"name": "bad", "arguments": [1, 2, 3]} {"name": "good", "arguments": {"ok": 1}}`,
-			wantName: "good",
-			wantArgs: `{"ok": 1}`,
+			name:     "wrapper holding no call is prose",
+			resp:     "<tool_call>not a call at all</tool_call> ok",
+			wantText: "<tool_call>not a call at all</tool_call> ok",
 		},
 		{
-			name:     "skips candidate with numeric arguments",
-			resp:     `{"name": "bad", "arguments": 42} {"name": "good", "arguments": "text"}`,
-			wantName: "good",
-			wantArgs: "text",
+			name:     "refuted marker prefix",
+			resp:     "<tool_callaaa and more",
+			wantText: "<tool_callaaa and more",
 		},
 		{
-			name:     "skips candidate with non-string name",
-			resp:     `{"name": 7, "arguments": {}} {"name": "good", "arguments": {}}`,
-			wantName: "good",
-			wantArgs: `{}`,
+			name:     "non-call object is released",
+			resp:     `{"foo": 1} hi`,
+			wantText: `{"foo": 1} hi`,
 		},
 		{
-			name:      "all candidates invalid falls through to error",
-			resp:      `{"name": "a", "arguments": [1]} {"name": 2, "arguments": {}} {"name": "c"}`,
-			wantError: true,
+			name:     "unclosed brace held to the end",
+			resp:     "here is code {\n\tf(a, b)",
+			wantText: "here is code {\n\tf(a, b)",
 		},
 		{
-			name:     "multiple tool calls separated by prose",
-			resp:     `Call one: {"name": "first", "arguments": {}}. Then: {"name": "second", "arguments": {}}`,
-			wantName: "first",
-			wantArgs: `{}`,
+			name:      "braces and escapes inside strings",
+			resp:      `{"name":"f","arguments":{"s":"}{ \" }"}} tail`,
+			wantText:  " tail",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"s":"}{ \" }"}`}},
 		},
 		{
-			name:     "leading unterminated brace does not swallow later call",
-			resp:     `reasoning { partial and never closed ... {"name": "go", "arguments": {"ok": true}}`,
-			wantName: "go",
-			wantArgs: `{"ok": true}`,
+			name:      "arguments given as a string",
+			resp:      `{"name":"echo","arguments":"hi"} bye`,
+			wantText:  " bye",
+			wantCalls: []toolCallFn{{Name: "echo", Arguments: "hi"}},
 		},
 		{
-			name:     "stray closing braces before real call",
-			resp:     `garbage } } more } {"name": "go", "arguments": {}}`,
-			wantName: "go",
-			wantArgs: `{}`,
+			name:      "two wrappers with text between",
+			resp:      `<tool_call>{"name":"f","arguments":{}}</tool_call>tail<tool_call>{"name":"g","arguments":{}}</tool_call>`,
+			wantText:  "tail",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}, {Name: "g", Arguments: `{}`}},
 		},
 		{
-			name:     "name with escaped chars",
-			resp:     `{"name": "ns\\tool", "arguments": {"path": "C:\\tmp"}}`,
-			wantName: `ns\tool`,
-			wantArgs: `{"path": "C:\\tmp"}`,
+			name:     "stray closing marker",
+			resp:     "</tool_call> stray close",
+			wantText: "</tool_call> stray close",
 		},
 		{
-			name:     "empty object skipped then real call",
-			resp:     `{} {"name": "go", "arguments": {}}`,
-			wantName: "go",
-			wantArgs: `{}`,
+			name:     "empty wrapper",
+			resp:     "<tool_call></tool_call> ok",
+			wantText: "<tool_call></tool_call> ok",
 		},
 		{
-			// tag/fence wrappers are transparent: the inner object is extracted
-			name:     "json inside tool_call tag",
-			resp:     "<tool_call>\n{\"name\": \"tagged\", \"arguments\": {\"k\": 1}}\n</tool_call>",
-			wantName: "tagged",
-			wantArgs: `{"k": 1}`,
+			name:      "a marker inside the call's own arguments",
+			resp:      `{"name":"f","arguments":{"s":"<tool_call>"}}`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"s":"<tool_call>"}`}},
 		},
 		{
-			name:     "json inside code fence",
-			resp:     "here you go:\n```json\n{\"name\": \"fenced\", \"arguments\": {\"q\": \"x\"}}\n```",
-			wantName: "fenced",
-			wantArgs: `{"q": "x"}`,
+			name:     "a marker quoted in prose is held, then released",
+			resp:     `talk about "<tool_call>" in prose`,
+			wantText: `talk about "<tool_call>" in prose`,
 		},
 		{
-			name:      "no json object",
-			resp:      "just some plain text without any call",
-			wantError: true,
+			// markerFormat's BUG: the quoted end tag cuts the region short, so this
+			// parses as nothing and streams as text. Parse on the whole text finds it.
+			name:     "a closing marker inside the arguments loses the call",
+			resp:     `<tool_call>{"name":"f","arguments":{"s":"</tool_call>"}}</tool_call>`,
+			wantText: `<tool_call>{"name":"f","arguments":{"s":"</tool_call>"}}</tool_call>`,
 		},
 		{
-			name:      "unterminated object",
-			resp:      `{"name": "go", "arguments":`,
-			wantError: true,
+			name:      "a quoted brace before the call",
+			resp:      `note: "{" then {"name":"f","arguments":{}}`,
+			wantText:  `note: "`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{}`}},
 		},
 		{
-			name:      "only non-tool-call objects",
-			resp:      `{"foo": 1} {"bar": 2} {"name": 42}`,
-			wantError: true,
+			name:      "braces inside the arguments string",
+			resp:      `{"name":"f","arguments":{"s":"}}{{"}}`,
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"s":"}}{{"}`}},
 		},
 		{
-			name:      "empty string",
-			resp:      "",
-			wantError: true,
+			name:      "an escaped backslash ends the string",
+			resp:      `{"name":"f","arguments":{"p":"C:\\"}} x`,
+			wantText:  " x",
+			wantCalls: []toolCallFn{{Name: "f", Arguments: `{"p":"C:\\"}`}},
 		},
 		{
-			name:      "braces only inside a string literal",
-			resp:      `the model said "{ not json }" and stopped`,
-			wantError: true,
+			name:     "a marker that never opens",
+			resp:     "a <b <c <too <tool_ nothing opens here",
+			wantText: "a <b <c <too <tool_ nothing opens here",
+		},
+		{
+			name:     "ends on a bare marker prefix",
+			resp:     "stops mid marker <tool_c",
+			wantText: "stops mid marker <tool_c",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseToolCalls(tt.resp)
-			if tt.wantError {
-				if err == nil {
-					t.Fatalf("expected error, got tool call %+v", got)
+			// 8 bytes is well above any real token; TestParseMatchesStream covers the
+			// other end, a whole response in one chunk.
+			for size := 1; size <= 8; size++ {
+				text, calls := stream(tt.resp, size)
+				if text != tt.wantText {
+					t.Errorf("size %d: text = %q, want %q", size, text, tt.wantText)
 				}
-				return
+				if !callsEqual(calls, tt.wantCalls) {
+					t.Errorf("size %d: calls = %+v, want %+v", size, calls, tt.wantCalls)
+				}
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+		})
+	}
+}
+
+// The streaming path and the whole-text scan are separate implementations, so they
+// check each other.
+func TestStreamAgreesWithJSONParse(t *testing.T) {
+	responses := []string{
+		"just prose",
+		`{"name":"f","arguments":{"a":1}}`,
+		`prose {"name":"f","arguments":{}} more`,
+		`{"name":"a","arguments":{}} x {"name":"b","arguments":{}}`,
+		"<tool_call>{\"name\":\"f\",\"arguments\":{}}</tool_call>",
+		`<tool_call>{"name":"f","arguments":{}}`,
+		`{"foo":1} noise {"name":"f","arguments":{}}`,
+		"a } b { c unbalanced",
+	}
+
+	for _, resp := range responses {
+		t.Run(resp, func(t *testing.T) {
+			_, got := stream(resp, 1)
+			if want := parseJSONToolCalls(resp); !callsEqual(got, want) {
+				t.Errorf("streamed %+v, parsed %+v", got, want)
 			}
-			if got.Name != tt.wantName {
-				t.Errorf("name = %q, want %q", got.Name, tt.wantName)
+		})
+	}
+}
+
+// Parse is the non-streaming twin of Push, so it must keep and drop the same bytes.
+func TestParseMatchesStream(t *testing.T) {
+	responses := []string{
+		"just prose",
+		`sure {"name":"f","arguments":{}} and then prose`,
+		`{"name":"a","arguments":{}} x {"name":"b","arguments":{}} y`,
+		`<tool_call>{"name":"f","arguments":{}}</tool_call>tail`,
+		`{"foo":1} then {"name":"f","arguments":{}}`,
+		`hi <|tool_call>call:a{}<tool_call|>mid<|tool_call>call:b{x:1}<tool_call|>bye`,
+		`<tool_call>{"name":"f","arguments":{}}`,
+		"here is code {\n\tf(a, b)",
+	}
+
+	for _, resp := range responses {
+		t.Run(resp, func(t *testing.T) {
+			wantText, wantCalls := stream(resp, 1)
+			text, calls := NewToolCallScanner().Parse(resp)
+			if text != wantText {
+				t.Errorf("text = %q, want %q", text, wantText)
 			}
-			if got.Arguments != tt.wantArgs {
-				t.Errorf("arguments = %q, want %q", got.Arguments, tt.wantArgs)
+			if !callsEqual(calls, wantCalls) {
+				t.Errorf("calls = %+v, want %+v", calls, wantCalls)
+			}
+		})
+	}
+}
+
+// Tail ends the stream, so what it drained is consumed: calling it again is empty.
+func TestTailIsTerminal(t *testing.T) {
+	for _, resp := range []string{
+		"here is code {\n\tf(a, b)",
+		`<tool_call>{"name":"f","arguments":{}}`,
+	} {
+		s := NewToolCallScanner()
+		s.Push(resp)
+		s.Tail()
+		if text, calls := s.Tail(); text != "" || len(calls) > 0 {
+			t.Errorf("resp %q: second Tail = (%q, %+v), want empty", resp, text, calls)
+		}
+	}
+}
+
+// A format reporting an offset behind from panics Push on a negative-length slice.
+// Only the interface pins that, so run the formats the way Push runs them.
+func TestFeedOffsetsStayAhead(t *testing.T) {
+	// Near-miss adjacency is what breaks a scan: try every triple of these.
+	pieces := []string{"<|tool_call>call:", "<tool_call>", "</tool_call>", "<tool_call|>",
+		"{", "}", `"`, `<|"|>`, "a:1", " "}
+	var corpus []string
+	for _, a := range pieces {
+		for _, b := range pieces {
+			for _, c := range pieces {
+				corpus = append(corpus, a+b+c)
+			}
+		}
+	}
+	corpus = append(corpus,
+		`{"name":"f","arguments":{}} and {"name":"g","arguments":{}}`,
+		`<tool_call>{"name":"f","arguments":{"s":"</tool_call>"}}</tool_call>`,
+		`<|tool_call>call:a{}<tool_call|>mid<|tool_call>call:b{x:<|"|>}{<|"|>}<tool_call|>`,
+		`{"a":"<tool_call>"} more`,
+		"prose { unclosed <tool_call> forever")
+
+	for _, resp := range corpus {
+		for size := 1; size <= 3; size++ {
+			formats := NewToolCallScanner().formats
+			from := 0
+			for j := min(size, len(resp)); ; j = min(j+size, len(resp)) {
+				for { // Push steps until nothing closes, so from can move several times
+					hold, end := j, -1
+					for i, f := range formats {
+						at, e := f.feed(resp[:j], from)
+						if at >= 0 && at < from {
+							t.Fatalf("format %d: feed(%q, %d) = (%d, %d), start behind from",
+								i, resp[:j], from, at, e)
+						}
+						if e >= 0 && e < at {
+							t.Fatalf("format %d: feed(%q, %d) = (%d, %d), end behind start",
+								i, resp[:j], from, at, e)
+						}
+						if at >= 0 && at < hold {
+							hold, end = at, e
+						}
+					}
+					from = hold // what a step emits up to
+					if end < 0 {
+						break
+					}
+					from = end // or consumes through
+				}
+				if j == len(resp) {
+					break
+				}
+			}
+		}
+	}
+}
+
+// The first whole marker, else the earliest tail still a prefix of one.
+func TestMarkerScan(t *testing.T) {
+	tests := []struct {
+		name        string
+		marker      string
+		s           string
+		start, done int
+	}{
+		{"empty", "<ab>", "", 0, 0},
+		{"no candidate", "<ab>", "plain prose", 11, 0},
+		{"whole marker", "<ab>", "hi <ab> there", 3, 7},
+		{"partial at end", "<ab>", "hi <a", 3, 0},
+		{"partial refuted", "<ab>", "hi <xy", 6, 0},
+		{"restart inside a candidate", "<ab>", "<<ab>", 1, 5},
+		{"overlapping restart", "aab", "aaab", 1, 4},
+		{"first of two", "<ab>", "<ab> x <ab>", 0, 4},
+		{"stops at the first match", "<ab>", "<ab>zzz", 0, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for size := 1; size <= max(len(tt.s), 1); size++ {
+				m := &markerScan{marker: tt.marker}
+				for i := 0; i < len(tt.s); i += size {
+					m.feed(tt.s[:min(i+size, len(tt.s))])
+				}
+				if m.start != tt.start || m.done != tt.done {
+					t.Errorf("size %d: (start, done) = (%d, %d), want (%d, %d)",
+						size, m.start, m.done, tt.start, tt.done)
+				}
+			}
+		})
+	}
+}
+
+// A region is reported only once both markers are in, and repeated until from
+// moves past it.
+func TestMarkerFormatFeed(t *testing.T) {
+	tests := []struct {
+		name            string
+		s               string
+		wantAt, wantEnd int
+	}{
+		{"prose", "nothing here", -1, -1},
+		{"partial open", "prose <tool_c", 6, -1},
+		{"open only", "prose <tool_call>{}", 6, -1},
+		{"both markers", "hi <tool_call>x</tool_call>!", 3, 27},
+		{"refuted prefix", "prose <tool_callx", -1, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newMarkerFormat("<tool_call>", "</tool_call>")
+			at, end := m.feed(tt.s, 0)
+			if at != tt.wantAt || end != tt.wantEnd {
+				t.Errorf("feed(%q) = (%d, %d), want (%d, %d)", tt.s, at, end, tt.wantAt, tt.wantEnd)
+			}
+		})
+	}
+}
+
+// Each format added puts another marker scan on the prose case, which is the one
+// that has to stay fast. 4 bytes per Push stands in for a model token.
+func BenchmarkToolCallScanner(b *testing.B) {
+	prose := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 100)
+	call := `{"name": "write_file", "arguments": {"path": "a.go", "body": "` +
+		strings.Repeat("x", 4096) + `"}}`
+	// A stray brace in prose holds everything after it: the worst case.
+	held := "here is the code {\n" + strings.Repeat("\tdoSomething(a, b)\n", 1500)
+
+	for _, bb := range []struct{ name, resp string }{
+		{"prose", prose},
+		{"call", prose[:200] + call},
+		{"two_calls", prose[:200] + call + " and then " + call},
+		{"wrapped", prose[:200] + "<tool_call>" + call + "</tool_call>" + prose[:200]},
+		{"held", held},
+	} {
+		b.Run(bb.name, func(b *testing.B) {
+			b.SetBytes(int64(len(bb.resp)))
+			for b.Loop() {
+				s := NewToolCallScanner()
+				for i := 0; i < len(bb.resp); i += 4 {
+					s.Push(bb.resp[i:min(i+4, len(bb.resp))])
+				}
+				s.Tail()
 			}
 		})
 	}

--- a/docs/cn/run/cli/local-server.mdx
+++ b/docs/cn/run/cli/local-server.mdx
@@ -185,7 +185,7 @@ usage: CompletionUsage(completion_tokens=58, prompt_tokens=19, total_tokens=77, 
 思考模型默认会把思维链原样保留在 `message.content`（`<think>…</think>`），与最终回复混在一起。传入 `reasoning_format="deepseek"` 可让服务器把思维链拆到 OpenAI 标准的 `message.reasoning_content` 字段，`content` 只保留干净的回复。
 
 <Note>
-`reasoning_format` 与 `enable_think` 是两件事：`enable_think=False` 让模型**不产生**思维链；`reasoning_format="deepseek"` 让模型照常思考，但把思维链**移出** `content`。取值 `none`（默认）保持原样内联，`deepseek` / `deepseek-legacy` / `auto` 均触发分离。工具调用请求会忽略该参数（工具解析需要原始带标签的文本）。
+`reasoning_format` 与 `enable_think` 是两件事：`enable_think=False` 让模型**不产生**思维链；`reasoning_format="deepseek"` 让模型照常思考，但把思维链**移出** `content`。取值 `none`（默认）保持原样内联，`deepseek` / `deepseek-legacy` / `auto` 均触发分离。工具调用请求同样生效（含流式）：思维链会先分离出来，再对回复扫描工具调用。
 </Note>
 
 ```python python

--- a/docs/en/run/cli/local-server.mdx
+++ b/docs/en/run/cli/local-server.mdx
@@ -228,7 +228,7 @@ usage: CompletionUsage(completion_tokens=58, prompt_tokens=19, total_tokens=77, 
 By default a thinking model leaves its chain-of-thought inline in `message.content` (`<think>…</think>`), mixed in with the final reply. Pass `reasoning_format="deepseek"` to make the server move the chain-of-thought into the OpenAI-standard `message.reasoning_content` field, leaving `content` clean.
 
 <Note>
-`reasoning_format` is not the same as `enable_think`: `enable_think=False` makes the model **not produce** a chain-of-thought at all, while `reasoning_format="deepseek"` lets it think as usual but **moves** the thinking out of `content`. Values are `none` (default, kept inline) and `deepseek` / `deepseek-legacy` / `auto` (all separate). Tool-call requests ignore this parameter (tool parsing needs the raw tagged text).
+`reasoning_format` is not the same as `enable_think`: `enable_think=False` makes the model **not produce** a chain-of-thought at all, while `reasoning_format="deepseek"` lets it think as usual but **moves** the thinking out of `content`. Values are `none` (default, kept inline) and `deepseek` / `deepseek-legacy` / `auto` (all separate). It applies to tool-call requests too, streaming included: the thinking block is separated before the reply is scanned for a tool call.
 </Note>
 
 ```python python


### PR DESCRIPTION
## Problem

Closes qcom-ai-hub/geniex#1524 — a request carrying `tools` buffered the whole generation, so the client saw nothing until it finished. Closes qcom-ai-hub/geniex#1527 — only the first tool call of a turn survived, and a matched call also dropped the prose around it.

## Approach

One incremental `ToolCallScanner` replaces the two implementations each format used to need (a stateless `Boundary` rescan plus a stateful `Watch`/`Feed` pair that had to agree). A format is now just `parse` + `feed`, and adding one is a constructor plus a parser.

- `feed(all, from)` reports `(-1,-1)` / `(n,-1)` / `(n,m)` in absolute offsets; the earliest format wins, so what a later one finds inside another's region cannot hijack it.
- `Push` returns the text safe to emit plus every call that finished, stepping until nothing closes so one chunk can carry several calls.
- `Tail` recovers a call the model stopped short of closing, and tries every format because the region holding the tail may contain another's syntax.
- `tool_calls` is a slice on both the streaming and blocking paths, with a delta `index` that rises across chunks.
- A matched call no longer costs the text around it: `content` and `tool_calls` are returned together.
- `reasoning_format` now applies to tool-call requests too, streaming included — it used to be ignored, which left the thinking block in `content`. Defaults are unchanged (`none` keeps it inline).

## Verification

`bazel test //cli/cmd/... //cli/internal/... //cli/server/...` passes, and both formats were driven end to end against real models on Linux/Vulkan.

<details>
<summary>Real-model results — <code>--compute hybrid</code>, <code>gemma-4-E2B-it-Q4_0</code> and <code>Qwen3-4B-Q4_0</code></summary>

| scenario | result |
|---|---|
| gemma4 blocking + tools | `finish_reason=tool_calls`, `get_weather({"city":"Beijing"})` |
| gemma4 streaming, parallel calls | index `0` / `1` at +388ms / +452ms — 64ms apart, not batched at `Tail` |
| content kept beside `tool_calls` | Qwen3 inline mode returns both the `<think>…` text and the call (previously the text was dropped) |
| `reasoning_format=deepseek` + tools, blocking | `content='\n\n'`, `reasoning_content` holds the chain of thought, call intact |
| same, streaming | 72 `reasoning_content` deltas from +199ms, no `<think>` in any content delta, call at +712ms |
| plain prose while `tools` is set | 7 content deltas 14-18ms apart, `finish_reason=stop` |

</details>

<details>
<summary>Test coverage</summary>

- `TestScannerStream` — 30 responses × chunk sizes 1-8: every byte is either emitted as text or consumed by a call, whatever the token boundaries.
- `TestParseMatchesStream` / `TestStreamAgreesWithJSONParse` / `TestGemma4StreamAgreesWithParse` — the streaming path and the whole-text parsers check each other.
- `TestFeedOffsetsStayAhead` — 1005 near-miss marker triples driven the way `Push` drives them, so no format can report an offset behind `from`.
- `TestStreamToolCallSeparatesReasoning` / `TestStreamToolCallIndexes` — SSE frames of the handler itself, which had no coverage before.
- `BenchmarkToolCallScanner` — prose stays the fast path at ~240 MB/s; every mutation of the new logic was checked to break at least one test.

</details>

<details>
<summary>Known limitations, each pinned by a test</summary>

- `markerFormat` is not string-aware, so an end marker quoted inside a call's own arguments cuts the region short and the call streams as text. Flagged `BUG:` in the code; a fix needs a per-format string hook.
- `Tail` takes the first format that finds a call, so a truncated turn mixing two syntaxes can lose the other one.
- gemma4's `parse` searches for `{` without a bound, so prose that literally spells `<|tool_call>call:` can fabricate a call — pre-existing, and now less costly since text before the hold point still streams.
- `thinkfsm` matches whole tokens, so a closing think marker that arrives split or fused leaves the call inside `reasoning_content`.

</details>
