### PR TITLE
docs: document geniex model commands and RB3 Gen 2 VLM limit

### DIFF
--- a/docs/cn/resources/troubleshooting.mdx
+++ b/docs/cn/resources/troubleshooting.mdx
@@ -115,6 +115,24 @@ import Feedback from "/snippets/page-feedback.mdx";
 
     若 CPU-only 版本仍然失败，请带上以上输出到 [GitHub Issues](https://github.com/qualcomm/GenieX/issues) 或 Slack 反馈。
   </Accordion>
+
+  <Accordion title="Gemma 4 E2B 在 RB3 Gen 2（QCS6490）上被 OOM 杀掉">
+    该模型按 VLM 加载需要约 4.94 GB——3.04 GB 的 `Q4_0` 权重加上 1.9 GB 的 F32 mmproj 投影器——而这块板子可用内存约 4.7 GB，因此内核会在加载投影器时杀掉进程：
+
+    ```text
+    Out of memory: Killed process 19714 (geniex) total-vm:7849464kB, anon-rss:0kB, file-rss:771016kB
+    ```
+
+    把模型记录为 `llm`，只跑其**文本路径**——这会跳过投影器，内存即可容纳。此模式下无法使用图像与音频输入。
+
+    ```bash bash
+    geniex pull google/gemma-4-E2B-it-qat-q4_0-gguf
+    geniex model set-type google/gemma-4-E2B-it-qat-q4_0-gguf llm
+    geniex infer google/gemma-4-E2B-it-qat-q4_0-gguf
+    ```
+
+    参见 [`geniex model set-type`](/cn/run/cli/reference#geniex-model-set-type)。
+  </Accordion>
 </AccordionGroup>
 
 ## **Android**

--- a/docs/cn/run/cli/reference.mdx
+++ b/docs/cn/run/cli/reference.mdx
@@ -94,6 +94,35 @@ geniex infer ai-hub-models/Qwen2.5-VL-7B-Instruct-GGUF
 Describe this picture </full/path/to/image.png>
 ```
 
+## **`geniex model`**
+
+查看与重新配置已缓存的模型。
+
+### **`geniex model set-type`**
+
+覆盖缓存模型清单中记录的模型类型。省略类型参数时会进入交互式选择。
+
+```bash
+geniex model set-type <model-name> [llm|vlm]
+```
+
+类型决定 `geniex infer` 走哪条路径：`vlm` 会连同权重一起加载 mmproj 投影器并接受图像 / 音频输入，`llm` 只加载语言权重。把多模态 GGUF 强制设为 `llm`，就是在权重 + 投影器装不进内存的板子上只跑其文本路径的方法。
+
+```bash
+geniex model set-type google/gemma-4-E2B-it-qat-q4_0-gguf llm
+```
+
+<Note>`geniex pull --model-type llm <model>` 在下载时就写入同一字段，因此新拉取的模型无需再执行 `set-type`。</Note>
+
+### **`geniex model list`**
+
+列出带 `qairt`（NPU）构建的 Qualcomm AI Hub 模型。默认只列出与检测到的芯片兼容的模型，加 `--all` 可列出全部。
+
+```bash
+geniex model list
+geniex model list --all
+```
+
 ## **`geniex serve`**
 
 启动兼容 OpenAI 协议的本地服务器。API 详见[本地服务器](/cn/run/cli/local-server)。

--- a/docs/en/resources/troubleshooting.mdx
+++ b/docs/en/resources/troubleshooting.mdx
@@ -129,6 +129,24 @@ import Feedback from "/snippets/page-feedback.mdx";
 
     If the CPU-only build still fails, report it in [GitHub Issues](https://github.com/qualcomm/GenieX/issues) or Slack with the output above.
   </Accordion>
+
+  <Accordion title="Gemma 4 E2B is OOM-killed on RB3 Gen 2 (QCS6490)">
+    As a VLM the model needs ~4.94 GB — 3.04 GB of `Q4_0` weights plus a 1.9 GB F32 mmproj projector — against the ~4.7 GB this board has available, so the kernel kills the process while the projector loads:
+
+    ```text
+    Out of memory: Killed process 19714 (geniex) total-vm:7849464kB, anon-rss:0kB, file-rss:771016kB
+    ```
+
+    Record the model as an `llm` to run its **text path** only — that skips the projector and fits. Image and audio input are unavailable in this mode.
+
+    ```bash bash
+    geniex pull google/gemma-4-E2B-it-qat-q4_0-gguf
+    geniex model set-type google/gemma-4-E2B-it-qat-q4_0-gguf llm
+    geniex infer google/gemma-4-E2B-it-qat-q4_0-gguf
+    ```
+
+    See [`geniex model set-type`](/en/run/cli/reference#geniex-model-set-type).
+  </Accordion>
 </AccordionGroup>
 
 ## **Android**

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -114,6 +114,35 @@ This is a scenic, panoramic photograph that features a traditional Japanese temp
 
 In an interactive session with an audio-capable model, `/mic` records a clip instead of loading one from disk — `Ctrl-C` stops the recording and transcribes it. This needs **SoX** on your `PATH` (`sudo apt install sox`, or `winget install --id=ChrisBagwell.SoX -e` on Windows); without it GenieX warns `SoX is not installed` at startup. See the [audio input tutorial](/en/tutorials/audio-input) for the full walkthrough.
 
+## **`geniex model`**
+
+Inspect and reconfigure cached models.
+
+### **`geniex model set-type`**
+
+Override the model type recorded in a cached model's manifest. Omit the type to pick it interactively.
+
+```bash
+geniex model set-type <model-name> [llm|vlm]
+```
+
+The type decides which path `geniex infer` takes: `vlm` loads the mmproj projector alongside the weights and accepts image / audio input, while `llm` loads the language weights only. Forcing a multimodal GGUF to `llm` is how you run its text path on a board where weights + projector don't fit in memory.
+
+```bash
+geniex model set-type google/gemma-4-E2B-it-qat-q4_0-gguf llm
+```
+
+<Note>`geniex pull --model-type llm <model>` writes the same field at download time, so a fresh pull needs no `set-type` afterwards.</Note>
+
+### **`geniex model list`**
+
+List Qualcomm AI Hub Models that have a `qairt` (NPU) build. Only models compatible with the detected chipset are listed unless you pass `--all`.
+
+```bash
+geniex model list
+geniex model list --all
+```
+
 ## **`geniex serve`**
 
 Start the OpenAI-compatible local server. See [Local server](/en/run/cli/local-server) for the API.


### PR DESCRIPTION
## Summary

Two documentation gaps found while closing out the RB3 Gen 2 (QCS6490) enablement work.

**`geniex model` was entirely undocumented.** Neither `docs/` nor `notes/` mentioned the command tree, so `geniex model set-type` — the only way to run a multimodal GGUF's text path — was reachable only by reading `cli/cmd/geniex/model.go`. Added a `geniex model` section to the CLI reference covering `set-type` (including what the type actually changes: `vlm` loads the mmproj projector alongside the weights, `llm` loads the language weights only) and `list`, plus a note that `geniex pull --model-type llm` writes the same manifest field at download time.

**Nothing told an RB3 Gen 2 user why Gemma 4 E2B dies.** A troubleshooting entry under Linux now gives the memory arithmetic (~4.94 GB needed as a VLM — 3.04 GB `Q4_0` weights + 1.9 GB F32 mmproj — against the ~4.7 GB available), the OOM-killer line users will actually see, and the three-command `set-type llm` workaround, linking to the reference section above.

`en` and `cn` both updated.

## Test plan

- [x] `set-type` / `model list` usage, argument shape, `--all`, and the interactive path verified against `setTypeCmd` / `listHubCmd` in `cli/cmd/geniex/model.go`
- [x] The "`llm` skips the projector" claim verified against `cli/cmd/geniex/infer.go` — `effectiveType == ModelTypeLLM` dispatches to `inferLLM`, whose `LlmCreateInput` carries no `MmprojPath` (only `inferVLM` passes `paths.MmprojPath`)
- [x] Memory figures and the OOM line come from the on-device RB3 Gen 2 run in qcom-ai-hub/geniex#1497
- [x] Code fences balanced in all four files; the reference → troubleshooting cross-link was intentionally dropped, leaving one direction only
- [ ] Not previewed with `mint dev` (no Node toolchain on this host). The `#geniex-model-set-type` anchor was checked against Mintlify's heading-slug rules and the existing `#increasing-the-context-length` link, not rendered

Refs qcom-ai-hub/geniex#1497
