### PR TITLE
ci(bench): add SmolVLM-2B and SmolVLM2-2.2B to the QDC bench matrix

### DIFF
--- a/sdk/benchmark/qdc/bench-models.json
+++ b/sdk/benchmark/qdc/bench-models.json
@@ -203,6 +203,28 @@
     "image": true
   },
   {
+    "name": "SmolVLM-2B",
+    "plugin": "llama_cpp",
+    "devices": ["cpu", "npu"],
+    "model_id": "ggml-org/SmolVLM-Instruct-GGUF:Q8_0",
+    "hub": "hf",
+    "url": "https://huggingface.co/ggml-org/SmolVLM-Instruct-GGUF/resolve/main/SmolVLM-Instruct-Q8_0.gguf",
+    "mmproj_url": "https://huggingface.co/ggml-org/SmolVLM-Instruct-GGUF/resolve/main/mmproj-SmolVLM-Instruct-f16.gguf",
+    "vlm": true,
+    "image": true
+  },
+  {
+    "name": "SmolVLM2-2.2B",
+    "plugin": "llama_cpp",
+    "devices": ["cpu", "npu"],
+    "model_id": "ggml-org/SmolVLM2-2.2B-Instruct-GGUF:Q8_0",
+    "hub": "hf",
+    "url": "https://huggingface.co/ggml-org/SmolVLM2-2.2B-Instruct-GGUF/resolve/main/SmolVLM2-2.2B-Instruct-Q8_0.gguf",
+    "mmproj_url": "https://huggingface.co/ggml-org/SmolVLM2-2.2B-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-2.2B-Instruct-f16.gguf",
+    "vlm": true,
+    "image": true
+  },
+  {
     "name": "Qwen3-4B-qairt",
     "plugin": "qairt",
     "devices": ["npu"],


### PR DESCRIPTION
## Summary

Adds both SmolVLM rows to `bench-models.json` so geniex-bench covers the models
in the SmolVLM onboarding investigation (qcom-ai-hub/geniex#1514) — `cpu` + `npu`
cells over ctx 512/1024/4096.

`ggml-org` publishes no Q4_0 for either repo (Q4_K_M / Q8_0 / f16 only), so both
rows pin `:Q8_0`; Q8_0 is one of the repacked HTP types, so the npu cells still
land on Hexagon.

Issue: https://github.com/qcom-ai-hub/geniex/issues/1514

## Test plan
- [x] `model_rows()` emits both rows for SM8750, e.g. `SmolVLM-2B|llama_cpp|cpu,npu|ggml-org/SmolVLM-Instruct-GGUF:Q8_0|1|1|||`
- [x] all four HF URLs (model + mmproj, both repos) return HTTP 206 on a ranged GET
- [x] bench dispatched from this branch (run 33165633181) — 5 devices x 2 models; running