### PR TITLE
fix(release): sign Windows ARM64 binaries for Smart App Control

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,15 +178,107 @@ jobs:
       build_installer: true
       upload_artifact: true
 
-  # TODO: wire Authenticode signing for the Windows installer (AzureSignTool
-  # / ESRP / .pfx secret). Gate publish-github-release + publish-winget on it.
+  # Authenticode-sign every Windows ARM64 PE file (installer + SDK DLLs) so
+  # Windows Smart App Control / SmartScreen stop blocking GenieX (issue #1398).
+  # Signing is a hard release gate: without a signing cert the job fails, so an
+  # unsigned Windows build can never ship again.
   sign-windows:
     name: sign-windows
     needs: [build-cli]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    runs-on: windows-latest
+    timeout-minutes: 20
     steps:
-      - run: 'echo "TODO: sign cli-setup-windows-arm64."'
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          submodules: false
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: sdk-windows-arm64
+          path: sdk-windows-arm64
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: cli-setup-windows-arm64
+          path: .
+
+      - name: Locate signtool
+        id: signtool
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $kit = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Directory -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending | Select-Object -First 1
+          if (-not $kit) { throw "Windows SDK (signtool) not found" }
+          $signtool = Get-ChildItem $kit.FullName -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $signtool) { throw "signtool.exe not found under Windows Kits" }
+          Write-Host "signtool: $signtool"
+          Add-Content -Path $env:GITHUB_OUTPUT -Value "path=$signtool"
+
+      - name: Ensure signing certificate is configured
+        shell: powershell
+        env:
+          WINDOWS_CODESIGN_PFX: ${{ secrets.WINDOWS_CODESIGN_PFX }}
+        run: |
+          if (-not $env:WINDOWS_CODESIGN_PFX) {
+            Write-Error "WINDOWS_CODESIGN_PFX secret is not configured. Windows binaries must be Authenticode-signed or Windows Smart App Control / SmartScreen blocks them (qualcomm/GenieX#1398). Set the secret (base64 of the code-signing .pfx) and re-run the release."
+            exit 1
+          }
+
+      - name: Sign Windows binaries (Authenticode)
+        shell: powershell
+        env:
+          WINDOWS_CODESIGN_PFX: ${{ secrets.WINDOWS_CODESIGN_PFX }}
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
+          WINDOWS_CODESIGN_TIMESTAMP_URL: ${{ secrets.WINDOWS_CODESIGN_TIMESTAMP_URL }}
+          SIGNTOOL_PATH: ${{ steps.signtool.outputs.path }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $signtool = $env:SIGNTOOL_PATH
+          $tsa = if ($env:WINDOWS_CODESIGN_TIMESTAMP_URL) { $env:WINDOWS_CODESIGN_TIMESTAMP_URL } else { "http://timestamp.digicert.com" }
+
+          $pfx = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:WINDOWS_CODESIGN_PFX))
+
+          $targets = @()
+          $targets += Get-ChildItem -LiteralPath "sdk-windows-arm64" -Recurse -File | Where-Object { $_.Extension -in @(".exe", ".dll") }
+          $targets += Get-Item -LiteralPath "geniex-cli-setup.exe"
+
+          $signed = 0
+          foreach ($t in $targets) {
+            Write-Host "signing $($t.FullName)"
+            & $signtool sign /fd SHA256 /td SHA256 /tr $tsa /f $pfx /p $env:WINDOWS_CODESIGN_PASSWORD $t.FullName
+            if ($LASTEXITCODE -ne 0) { throw "signtool failed on $($t.FullName)" }
+            $signed++
+          }
+          Write-Host "Signed $signed PE file(s)."
+
+      - name: Verify Authenticode signatures
+        shell: powershell
+        run: |
+          $failed = 0
+          & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signatures.ps1 -Path sdk-windows-arm64
+          if ($LASTEXITCODE -ne 0) { $failed = 1 }
+          & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signatures.ps1 -Path geniex-cli-setup.exe
+          if ($LASTEXITCODE -ne 0) { $failed = 1 }
+          if ($failed -ne 0) { throw "One or more Windows binaries are unsigned or have an invalid Authenticode signature." }
+          Write-Host "All Windows binaries are Authenticode-signed."
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sdk-windows-arm64
+          path: sdk-windows-arm64/
+          retention-days: 1
+          overwrite: true
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: cli-setup-windows-arm64
+          path: geniex-cli-setup.exe
+          retention-days: 1
+          overwrite: true
 
   # Assemble every release asset into one release-assets artifact so
   # publish-github-release and publish-s3 can run in parallel.

--- a/.github/workflows/signature-verify-test.yml
+++ b/.github/workflows/signature-verify-test.yml
@@ -1,0 +1,41 @@
+name: Windows Signature Verifier Test
+
+# Runs the self-test for scripts/verify-windows-signatures.ps1 on Windows so
+# the Authenticode gate used by the release pipeline (release.yml → sign-windows)
+# is exercised in CI, not just at release time. Covers qualcomm/GenieX#1398.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/verify-windows-signatures.ps1"
+      - "scripts/test-verify-windows-signatures.ps1"
+      - ".github/workflows/release.yml"
+      - ".github/workflows/signature-verify-test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: signature-verify-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify-windows-signatures self-test
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: Run verifier self-test
+        shell: powershell
+        run: |
+          & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/test-verify-windows-signatures.ps1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Windows signature verifier self-test failed."
+            exit $LASTEXITCODE
+          }

--- a/docs/cn/resources/troubleshooting.mdx
+++ b/docs/cn/resources/troubleshooting.mdx
@@ -13,7 +13,16 @@ import Feedback from "/snippets/page-feedback.mdx";
   </Accordion>
 
   <Accordion title="Windows SmartScreen 拦截 CLI 安装包">
-    `.exe` 尚未代码签名。在 SmartScreen 对话框中点击 **More info → Run anyway**。
+    发布版本已完成 Authenticode 代码签名，SmartScreen 会信任。若使用的是旧版未签名安装包，在 SmartScreen 对话框中点击 **More info → Run anyway**。
+  </Accordion>
+
+  <Accordion title="Windows Smart App Control 拦截 GenieX DLL">
+    Smart App Control 只运行已签名且信誉良好的二进制——未签名构建会被拦截，CLI 可能无法完整启动。发布版本已完成 Authenticode 签名并获得信任。
+
+    若你使用的是旧版或自行编译的未签名构建：
+    1. 从 [CLI 安装](/cn/run/cli/install) 页面重新下载最新发布版。
+    2. 若仍被拦截，可临时关闭 Smart App Control：**Windows 安全中心 → 应用和浏览器控制 → Smart App Control 设置 → 关闭**（之后记得重新开启）。
+    3. 在受管设备上，请 IT 管理员允许该发布者。
   </Accordion>
 </AccordionGroup>
 

--- a/docs/cn/run/cli/install.mdx
+++ b/docs/cn/run/cli/install.mdx
@@ -20,7 +20,7 @@ CLI 提供 Windows ARM64 原生可执行文件，以及面向跃龙 QCS9075 等 
       最新 Windows ARM64 GenieX CLI。点击下载好的 `.exe` 并按提示完成安装。
     </Card>
 
-    安装包尚未代码签名——Windows SmartScreen 会发出告警。点击 **More info → Run anyway**。
+    发布版本已完成 Authenticode 代码签名，Windows SmartScreen 与 Smart App Control 均会信任。若使用的是旧版未签名安装包，SmartScreen 会告警——点击 **More info → Run anyway**。若 Smart App Control 仍拦截某个 DLL，参见[故障排查 → Windows Smart App Control 拦截](/cn/resources/troubleshooting#windows-smart-app-control-拦截-geniex-dll)。
 
     ### **加入 PATH**
 

--- a/docs/en/resources/troubleshooting.mdx
+++ b/docs/en/resources/troubleshooting.mdx
@@ -13,7 +13,16 @@ import Feedback from "/snippets/page-feedback.mdx";
   </Accordion>
 
   <Accordion title="Windows SmartScreen blocks the CLI installer">
-    The `.exe` is not yet code-signed. Click **More info → Run anyway** in the SmartScreen dialog.
+    Release builds are Authenticode-signed, so SmartScreen trusts them. On an older unsigned build, click **More info → Run anyway** in the SmartScreen dialog.
+  </Accordion>
+
+  <Accordion title="Windows Smart App Control blocks a GenieX DLL">
+    Smart App Control only runs signed, reputable binaries — unsigned builds are blocked, so the CLI may not start fully. Release builds are Authenticode-signed and trusted.
+
+    If you're on an older or self-built unsigned build:
+    1. Re-download the latest release from the [CLI install](/en/run/cli/install) page.
+    2. If it's still blocked, temporarily turn off Smart App Control: **Windows Security → App & browser control → Smart App Control settings → Off** (re-enable it afterwards), or run `geniex` from a PowerShell session that isn't subject to the block.
+    3. On managed devices, have your IT admin allow the publisher.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/en/run/cli/install.mdx
+++ b/docs/en/run/cli/install.mdx
@@ -20,7 +20,7 @@ The CLI ships as a native Windows ARM64 executable, and as a Linux ARM64 Docker 
       Latest GenieX CLI for Windows ARM64. Click the downloaded `.exe` and follow the prompts.
     </Card>
 
-    The installer is not yet code-signed — Windows SmartScreen will warn you. Click **More info → Run anyway**.
+    Release builds are Authenticode-signed, so Windows SmartScreen and Smart App Control trust them. On an older unsigned build, Windows SmartScreen warns — click **More info → Run anyway**. If Smart App Control still blocks a DLL, see [Troubleshooting → Windows Smart App Control](/en/resources/troubleshooting#windows-smart-app-control-blocks-a-geniex-dll).
 
     ### **Add to PATH**
 

--- a/notes/release.md
+++ b/notes/release.md
@@ -193,7 +193,9 @@ The cross-repo checkout reuses `secrets.GH_PAT` (already scoped for cross-repo a
 
 ## Windows installer signing gate
 
-The Windows installer is published before it is Authenticode-signed, so `geniex update` gates on `windows-signed.txt` to avoid pushing an unsigned build. On Windows, once a newer version is found, the updater GETs this file (see [`cli/cmd/geniex/update.go`](../cli/cmd/geniex/update.go), `isWindowsSigned`): contents `true` → proceed with the download; anything else or missing → treat as up-to-date and skip.
+The Windows ARM64 build is Authenticode-signed in the release pipeline: the `sign-windows` job downloads `sdk-windows-arm64` + `cli-setup-windows-arm64`, signs every `.exe`/`.dll` PE with `signtool` (RFC3161 timestamping), verifies each signature with [`scripts/verify-windows-signatures.ps1`](../scripts/verify-windows-signatures.ps1), and re-uploads the signed artifacts. The job is a hard gate — if `WINDOWS_CODESIGN_PFX` / `WINDOWS_CODESIGN_PASSWORD` secrets are not configured, the release fails rather than shipping binaries that Windows Smart App Control / SmartScreen blocks (qualcomm/GenieX#1398). Secrets: `WINDOWS_CODESIGN_PFX` (base64 of the `.pfx`), `WINDOWS_CODESIGN_PASSWORD`, optional `WINDOWS_CODESIGN_TIMESTAMP_URL` (default `http://timestamp.digicert.com`).
+
+`geniex update` still gates on `windows-signed.txt` to avoid pushing an unsigned build. On Windows, once a newer version is found, the updater GETs this file (see [`cli/cmd/geniex/update.go`](../cli/cmd/geniex/update.go), `isWindowsSigned`): contents `true` → proceed with the download; anything else or missing → treat as up-to-date and skip.
 
 Release-side: upload `windows-signed.txt` with `true` after the latest stable installer is signed; set it back to a non-`true` value before publishing the next, not-yet-signed installer.
 
@@ -208,7 +210,7 @@ Release-side: upload `windows-signed.txt` with `true` after the latest stable in
   - test `llama_cpp` npu on qualcomm pc
 - create a offical release tag on same commit
 - signed windows installer
-  - send unsigned installer to wido team
+  - the `sign-windows` job signs the installer + SDK DLLs with the cert from `WINDOWS_CODESIGN_PFX`; verify the run's "Verify Authenticode signatures" step passed
   - replace installer on s3
   - update sha256
   - update `windows-signed.txt` to true, see [§ Windows installer signing gate](#windows-installer-signing-gate)

--- a/scripts/test-verify-windows-signatures.ps1
+++ b/scripts/test-verify-windows-signatures.ps1
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+<#
+.SYNOPSIS
+    Self-test for scripts/verify-windows-signatures.ps1.
+
+.DESCRIPTION
+    Creates real signed and unsigned Windows PE fixtures and asserts the
+    verifier accepts a fully signed tree and rejects one containing an
+    unsigned binary. Exits non-zero on any failed assertion. Windows only.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File scripts/test-verify-windows-signatures.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+
+$verify = Join-Path $PSScriptRoot "verify-windows-signatures.ps1"
+if (-not (Test-Path -LiteralPath $verify)) {
+    throw "verifier not found: $verify"
+}
+
+$work = Join-Path $env:TEMP "geniex-verify-test"
+if (Test-Path -LiteralPath $work) {
+    Remove-Item -LiteralPath $work -Recurse -Force
+}
+New-Item -ItemType Directory -Path $work | Out-Null
+
+$signedDir = Join-Path $work "signed"
+$unsignedDir = Join-Path $work "unsigned"
+$mixedDir = Join-Path $work "mixed"
+foreach ($d in @($signedDir, $unsignedDir, $mixedDir)) {
+    New-Item -ItemType Directory -Path $d | Out-Null
+}
+
+# Signed fixture: a Microsoft-signed system DLL.
+$signedDll = (Get-ChildItem "$env:WINDIR\System32\*.dll" |
+    Where-Object { (Get-AuthenticodeSignature -LiteralPath $_.FullName).Status -eq "Valid" } |
+    Select-Object -First 1 -ExpandProperty FullName)
+if (-not $signedDll) {
+    throw "No Microsoft-signed DLL found under $env:WINDIR\System32 to use as a signed fixture."
+}
+Copy-Item -LiteralPath $signedDll -Destination (Join-Path $signedDir "signed.dll")
+Copy-Item -LiteralPath $signedDll -Destination (Join-Path $mixedDir "signed.dll")
+
+# Unsigned fixture: a freshly compiled managed DLL has no Authenticode signature.
+$unsignedCs = @"
+public static class GenieXUnsignedFixture {
+    public static int Value() { return 42; }
+}
+"@
+$unsignedDll = Join-Path $unsignedDir "unsigned.dll"
+Add-Type -TypeDefinition $unsignedCs -OutputAssembly $unsignedDll -OutputType Library
+Copy-Item -LiteralPath $unsignedDll -Destination (Join-Path $mixedDir "unsigned.dll")
+
+function Invoke-Verify([string]$Target, [int]$ExpectedExit) {
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $verify -Path $Target -Quiet
+    $code = $LASTEXITCODE
+    if ($code -ne $ExpectedExit) {
+        throw "verifier exit $code for '$Target', expected $ExpectedExit"
+    }
+    Write-Host "PASS: '$Target' exited $code (expected $ExpectedExit)"
+}
+
+try {
+    Invoke-Verify -Target $signedDir -ExpectedExit 0
+    Invoke-Verify -Target $unsignedDir -ExpectedExit 1
+    Invoke-Verify -Target $mixedDir -ExpectedExit 1
+
+    # Single-file form must behave the same as its containing directory.
+    Invoke-Verify -Target (Join-Path $signedDir "signed.dll") -ExpectedExit 0
+    Invoke-Verify -Target (Join-Path $unsignedDir "unsigned.dll") -ExpectedExit 1
+
+    Write-Host ""
+    Write-Host "All assertions passed."
+    exit 0
+}
+finally {
+    Remove-Item -LiteralPath $work -Recurse -Force
+}

--- a/scripts/verify-windows-signatures.ps1
+++ b/scripts/verify-windows-signatures.ps1
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+<#
+.SYNOPSIS
+    Verifies the Authenticode signature status of Windows PE files.
+
+.DESCRIPTION
+    Recursively scans a path for Windows PE files (.exe / .dll) and reports
+    each file's Authenticode signature status. Exits non-zero if any file
+    does not carry the required status, so it can gate a release: Windows
+    Smart App Control and SmartScreen block unsigned / invalid binaries
+    (see qualcomm/GenieX issue #1398).
+
+.PARAMETER Path
+    Directory or single file to scan.
+
+.PARAMETER Extension
+    File extensions treated as PE files. Default: .exe, .dll.
+
+.PARAMETER RequiredStatus
+    Signature status every scanned file must have. Default: Valid.
+
+.PARAMETER Quiet
+    Only print a one-line summary, not per-file lines.
+
+.EXAMPLE
+    powershell -NoProfile -ExecutionPolicy Bypass -File scripts/verify-windows-signatures.ps1 -Path sdk-windows-arm64
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [string[]]$Extension = @('.exe', '.dll'),
+    [ValidateSet('Valid', 'HashMismatch', 'NotSigned', 'UnknownError', 'NotTrusted', 'Incomplete')]
+    [string]$RequiredStatus = 'Valid',
+    [switch]$Quiet
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-IsPeFile {
+    param([System.IO.FileInfo]$File)
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($File.FullName)
+        # DOS stub
+        if ($bytes.Length -lt 64 -or $bytes[0] -ne 0x4D -or $bytes[1] -ne 0x5A) {
+            return $false
+        }
+        # PE header offset at 0x3C; 'PE\0\0'
+        $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+        return ($peOffset -ge 0 -and ($peOffset + 4) -le $bytes.Length -and
+                $bytes[$peOffset] -eq 0x50 -and $bytes[$peOffset + 1] -eq 0x45 -and
+                $bytes[$peOffset + 2] -eq 0 -and $bytes[$peOffset + 3] -eq 0)
+    }
+    catch {
+        return $false
+    }
+}
+
+if (Test-Path -LiteralPath $Path -PathType Leaf) {
+    $items = @(Get-Item -LiteralPath $Path)
+}
+else {
+    $items = @(Get-ChildItem -LiteralPath $Path -Recurse -File | Where-Object { $_.Extension -in $Extension })
+}
+
+$peFiles = @($items | Where-Object { Test-IsPeFile -File $_ })
+if ($peFiles.Count -eq 0) {
+    Write-Host "verify-windows-signatures: no PE files found under '$Path'"
+    exit 0
+}
+
+$failed = @()
+foreach ($file in $peFiles) {
+    $sig = Get-AuthenticodeSignature -LiteralPath $file.FullName
+    $ok = ($sig.Status.ToString() -eq $RequiredStatus)
+    if (-not $Quiet) {
+        $mark = if ($ok) { 'OK  ' } else { 'FAIL' }
+        Write-Host ("{0} {1,-14} {2}" -f $mark, $sig.Status, $file.FullName)
+    }
+    if (-not $ok) {
+        $failed += $file.FullName
+    }
+}
+
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Host "verify-windows-signatures: FAILED - $($failed.Count) file(s) do not have a '$RequiredStatus' Authenticode signature:"
+    foreach ($f in $failed) {
+        Write-Host "  $f"
+    }
+    exit 1
+}
+
+Write-Host "verify-windows-signatures: OK - all $($peFiles.Count) PE file(s) have a '$RequiredStatus' Authenticode signature."
+exit 0


### PR DESCRIPTION
## Summary

Windows Smart App Control / SmartScreen blocks GenieX because release Windows ARM64 binaries were shipped unsigned (Closes #1398).

This PR wires Authenticode signing into the release pipeline so every shipped Windows binary is signed and verified:
- **sign-windows job** signs all .exe/.dll in sdk-windows-arm64 + the installer with signtool (RFC3161 timestamp) using WINDOWS_CODESIGN_PFX / WINDOWS_CODESIGN_PASSWORD secrets, and is a **hard release gate** - no cert, no release.
- **scripts/verify-windows-signatures.ps1** asserts every PE file has a *Valid* Authenticode signature (post-sign gate).
- **scripts/test-verify-windows-signatures.ps1** self-test (signed + unsigned fixtures) runs in CI via signature-verify-test.yml.
- Docs (en/cn) + 
otes/release.md updated.

## Test plan

- [x] scripts/verify-windows-signatures.ps1 - signed dir exit 0; unsigned dir exit 1; mixed dir exit 1; single-file forms match
- [x] scripts/test-verify-windows-signatures.ps1 - **All assertions passed** (5/5) on Windows
- [x] YAML validates for elease.yml + signature-verify-test.yml
- [x] PowerShell scripts parse cleanly
- [ ] CI (signature-verify-test + pr-check)

Closes #1398