### PR TITLE
feat(sdk): add preflight disk-space check to model pull

### DIFF
--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -513,6 +513,7 @@ func pullModel(ctx context.Context, name, quant string) error {
 		}
 		if bar == nil {
 			bar = render.NewProgressBar(total, downloaded, "downloading")
+			fmt.Println(render.GetTheme().Info.Sprint("   Press Ctrl+C to cancel — progress is saved, not discarded."))
 		}
 		bar.Set(downloaded)
 		return ctx.Err() == nil
@@ -523,7 +524,9 @@ func pullModel(ctx context.Context, name, quant string) error {
 			bar.Clear()
 		}
 		if ctx.Err() != nil {
+			key := geniex_sdk.JoinNamePrecision(name, quant)
 			fmt.Println(render.GetTheme().Warning.Sprint("✗  Download cancelled"))
+			fmt.Println(render.GetTheme().Info.Sprintf("   Run 'geniex pull %s' to resume, or 'geniex remove %s' to free the disk space instead.", key, key))
 			return nil
 		}
 		return err

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -60,6 +60,7 @@ typedef enum {
     GENIEX_ERROR_COMMON_MANIFEST_PARSE      = -100014, /**< Failed to parse a manifest / index document */
     GENIEX_ERROR_COMMON_CHIPSET_UNAVAILABLE = -100015, /**< Requested chipset not available for this model */
     GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED = -100016, /**< Parameter not supported by this plugin */
+    GENIEX_ERROR_COMMON_INSUFFICIENT_DISK_SPACE = -100017, /**< Not enough free disk space for the download */
 
     GENIEX_ERROR_COMMON_MODEL_LOAD    = -100201, /**< Model loading failed */
     GENIEX_ERROR_COMMON_MODEL_INVALID = -100203, /**< Invalid model format */

--- a/sdk/model-manager/crates/core/src/error.rs
+++ b/sdk/model-manager/crates/core/src/error.rs
@@ -93,6 +93,17 @@ pub enum Error {
     #[error("download cancelled")]
     Cancelled,
 
+    /// Not enough free disk space to fetch the still-pending files.
+    /// `required` is the sum of their full sizes (a conservative
+    /// overestimate for a partially-resumed file); `available` is
+    /// `fs2::available_space` on the destination directory.
+    #[error(
+        "not enough free disk space: this download needs {:.2} GiB but only {:.2} GiB is available",
+        *required as f64 / (1024.0 * 1024.0 * 1024.0),
+        *available as f64 / (1024.0 * 1024.0 * 1024.0)
+    )]
+    InsufficientDiskSpace { required: u64, available: u64 },
+
     #[error("invalid model name: '{0}' (must be 'org/repo' with no path traversal)")]
     InvalidModelName(String),
 

--- a/sdk/model-manager/crates/core/src/pull.rs
+++ b/sdk/model-manager/crates/core/src/pull.rs
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use crate::config::StoreConfig;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::executor::{Executor, ProgressCallback};
 use crate::manifest_builder::ManifestHint;
 use crate::mapping::canonicalize_model_name;
@@ -168,6 +168,9 @@ pub async fn pull_with_source(
             }
 
             let pending = resume::filter_pending(&plan.files, &dest_dir);
+            let required: u64 = pending.iter().map(|f| f.size).sum();
+            let available = fs2::available_space(&dest_dir)?;
+            check_disk_space(required, available)?;
             if !pending.is_empty() {
                 let executor = Executor::new(transport.clone(), 4);
                 executor.run(&pending, &dest_dir, on_progress).await?;
@@ -278,6 +281,16 @@ fn remove_inflight_dir(inflight_dir: &Path) {
     }
 }
 
+fn check_disk_space(required: u64, available: u64) -> Result<()> {
+    if required > available {
+        return Err(Error::InsufficientDiskSpace {
+            required,
+            available,
+        });
+    }
+    Ok(())
+}
+
 fn drop_marker(dest_dir: &Path, file_name: &str) {
     if file_name.is_empty() {
         return;
@@ -317,5 +330,27 @@ mod tests {
         // Do not create it — function must return without warning or panic.
         remove_inflight_dir(&inflight);
         assert!(!inflight.exists());
+    }
+
+    #[test]
+    fn check_disk_space_ok_when_enough_room() {
+        assert!(check_disk_space(100, 200).is_ok());
+    }
+
+    #[test]
+    fn check_disk_space_ok_at_exact_boundary() {
+        assert!(check_disk_space(100, 100).is_ok());
+    }
+
+    #[test]
+    fn check_disk_space_errs_when_not_enough_room() {
+        let err = check_disk_space(200, 100).unwrap_err();
+        assert!(matches!(
+            err,
+            Error::InsufficientDiskSpace {
+                required: 200,
+                available: 100
+            }
+        ));
     }
 }

--- a/sdk/model-manager/crates/ffi/src/types.rs
+++ b/sdk/model-manager/crates/ffi/src/types.rs
@@ -52,6 +52,7 @@ pub const GENIEX_ERROR_COMMON_RATE_LIMITED: i32 = -100011;
 pub const GENIEX_ERROR_COMMON_HUB_SERVER: i32 = -100012;
 pub const GENIEX_ERROR_COMMON_MANIFEST_PARSE: i32 = -100014;
 pub const GENIEX_ERROR_COMMON_CHIPSET_UNAVAILABLE: i32 = -100015;
+pub const GENIEX_ERROR_COMMON_INSUFFICIENT_DISK_SPACE: i32 = -100017;
 pub const GENIEX_ERROR_COMMON_MODEL_INVALID: i32 = -100203;
 
 /// C-compatible per-file progress entry. Must mirror `geniex_FileProgress`
@@ -91,6 +92,7 @@ pub fn err_to_code(e: &Error) -> i32 {
         // failure, same category as a malformed remote index.
         Error::ManifestParse { .. } | Error::Json(_) => GENIEX_ERROR_COMMON_MANIFEST_PARSE,
         Error::ChipsetUnavailable { .. } => GENIEX_ERROR_COMMON_CHIPSET_UNAVAILABLE,
+        Error::InsufficientDiskSpace { .. } => GENIEX_ERROR_COMMON_INSUFFICIENT_DISK_SPACE,
         Error::Cancelled => GENIEX_ERROR_COMMON_CANCELLED,
         // Inference failed because the source has no files we recognize as a
         // model — surface it as an invalid-model error, not a generic unknown.

--- a/sdk/src/error.cpp
+++ b/sdk/src/error.cpp
@@ -57,6 +57,8 @@ const char* geniex_get_error_message(const geniex_ErrorCode error_code) {
             return "Requested chipset not available for this model";
         case GENIEX_ERROR_COMMON_PARAM_NOT_SUPPORTED:
             return "Parameter not supported by this plugin";
+        case GENIEX_ERROR_COMMON_INSUFFICIENT_DISK_SPACE:
+            return "Insufficient disk space for download";
         case GENIEX_ERROR_COMMON_MODEL_LOAD:
             return "Model loading failed";
         case GENIEX_ERROR_COMMON_MODEL_INVALID:


### PR DESCRIPTION
## Summary
- Add a preflight free-disk-space check to model downloads (`geniex pull`, and the implicit pull `infer` triggers for an uncached model), implemented once in the model-manager core so every binding (CLI, Python, Android) gets it — rejects with a clear "needs X GiB, Y GiB available" message before any bytes move. The check is unconditional (no bypass flag).
- Make Ctrl+C-to-cancel discoverable (hint on the progress line) and clarify that cancelling preserves the partial download for resume, rather than silently discarding it. On cancel, point at `geniex remove` as the explicit way to free the space if that's what the user wants — auto-deleting on cancel would break the existing `.progress`-bitmap resume mechanism.

## Test plan
- [x] `geniex pull ggml-org/tiny-llamas --model-hub hf` — real HF download completes end-to-end; the new "Press Ctrl+C to cancel — progress is saved, not discarded." hint shows on the progress line.
- [x] `geniex pull local/hugemodel --model-hub localfs --local-path <dir with a 900GB sparse file>` — refuses immediately: `needs 838.19 GiB but only 531.88 GiB is available`, exit 1, no bytes written.
- [x] Ctrl+C mid-download → partial `.progress` marker preserved → re-running `pull` resumes instead of restarting — pending, needs a live cancel during an in-progress transfer (not exercised in this pass).