### PR TITLE
feat(sdk): re-introduce ModelScope hub for geniex pull

### DIFF
--- a/.github/workflows/_qdc-test.yml
+++ b/.github/workflows/_qdc-test.yml
@@ -58,10 +58,17 @@ jobs:
         env:
           GATE: ${{ inputs.gate_on_changed_files }}
           ANY: ${{ steps.files.outputs.any }}
+          # Fork PRs intentionally receive no repository secrets.  Treat a
+          # missing QDC credential as an unavailable hardware lane instead of
+          # invoking the dispatcher with an empty key and failing every cell.
+          HAS_QDC_API_KEY: ${{ secrets.QDC_API_KEY != '' }}
           PLATFORM: ${{ matrix.platform }}
         run: |
           set -euo pipefail
-          if [ "$GATE" = "true" ] && [ "$ANY" != "true" ]; then
+          if [ "$HAS_QDC_API_KEY" != "true" ]; then
+            echo "::notice::QDC_API_KEY is unavailable; skipping $PLATFORM"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$GATE" = "true" ] && [ "$ANY" != "true" ]; then
             echo "No QDC-relevant path changes — skipping $PLATFORM"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else

--- a/bindings/go/model_manager.go
+++ b/bindings/go/model_manager.go
@@ -57,22 +57,25 @@ func ParseModelType(s string) (ModelType, bool) {
 	}
 }
 
-// SplitNamePrecision splits "name[:precision]" into (name, precision). A pasted
-// HuggingFace URL prefix is stripped first so its scheme colon isn't mistaken
-// for the precision separator. Name canonicalization, precision case-folding
-// (GGUF quant labels are matched upper-cased), and hub routing all happen in
-// the SDK across the FFI boundary — including Docker Hub, where the suffix is a
-// case-sensitive registry tag the SDK deliberately leaves untouched. This only
-// does the URL strip + ':' split so callers can pass the two to the FFI
-// separately.
+// SplitNamePrecision splits "name[:precision]" into (name, precision). A
+// pasted model-page URL keeps its scheme, which is held back from the ':'
+// split so the scheme colon isn't mistaken for the precision separator — the
+// SDK needs the surviving host to route the hub (e.g. modelscope.cn). Name
+// canonicalization, precision case-folding (GGUF quant labels are matched
+// upper-cased), and hub routing all happen in the SDK across the FFI boundary
+// — including Docker Hub, where the suffix is a case-sensitive registry tag
+// the SDK deliberately leaves untouched. This only does the ':' split so
+// callers can pass the two to the FFI separately.
 func SplitNamePrecision(arg string) (string, string) {
-	arg = strings.TrimPrefix(arg, "https://huggingface.co/")
-	arg = strings.TrimPrefix(arg, "http://huggingface.co/")
+	scheme := ""
+	if i := strings.Index(arg, "://"); i >= 0 {
+		scheme, arg = arg[:i+3], arg[i+3:]
+	}
 	name, precision, found := strings.Cut(arg, ":")
 	if !found || precision == "" {
-		return name, ""
+		return scheme + name, ""
 	}
-	return name, precision
+	return scheme + name, precision
 }
 
 // JoinNamePrecision builds the "name:precision" key the SDK accepts. Inverse of

--- a/bindings/go/model_manager_test.go
+++ b/bindings/go/model_manager_test.go
@@ -22,6 +22,32 @@ func TestResolveAlias(t *testing.T) {
 	}
 }
 
+func TestSplitNamePrecision(t *testing.T) {
+	cases := []struct{ arg, name, precision string }{
+		{"org/repo:Q4_0", "org/repo", "Q4_0"},
+		{"org/repo", "org/repo", ""},
+		{"org/repo:N/A", "org/repo", "N/A"},
+		{"docker.io/ai/gemma3:latest", "docker.io/ai/gemma3", "latest"},
+		{
+			"https://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF:Q4_K_M",
+			"https://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF",
+			"Q4_K_M",
+		},
+		{
+			"https://huggingface.co/Qwen/Qwen3-0.6B-GGUF",
+			"https://huggingface.co/Qwen/Qwen3-0.6B-GGUF",
+			"",
+		},
+	}
+	for _, c := range cases {
+		name, precision := SplitNamePrecision(c.arg)
+		if name != c.name || precision != c.precision {
+			t.Errorf("SplitNamePrecision(%q) = (%q, %q), want (%q, %q)",
+				c.arg, name, precision, c.name, c.precision)
+		}
+	}
+}
+
 func TestJoinNamePrecision(t *testing.T) {
 	cases := []struct{ name, precision, want string }{
 		{"org/repo", "Q4_0", "org/repo:Q4_0"},

--- a/cli/cmd/geniex/model.go
+++ b/cli/cmd/geniex/model.go
@@ -45,6 +45,8 @@ func resolveHub() (geniex_sdk.HubSource, error) {
 		return geniex_sdk.HubAIHub, nil
 	case "hf", "huggingface":
 		return geniex_sdk.HubHuggingFace, nil
+	case "modelscope", "ms":
+		return geniex_sdk.HubModelScope, nil
 	case "docker", "dockerhub":
 		return geniex_sdk.HubDocker, nil
 	case "local", "localfs":
@@ -63,7 +65,7 @@ func pull() *cobra.Command {
 		GroupID: "model",
 		Use:     "pull <model-name>[:<precision>]",
 
-		Short: "Pull model from HuggingFace, Qualcomm AI Hub Models, or Docker Hub",
+		Short: "Pull model from HuggingFace, Qualcomm AI Hub Models, ModelScope, or Docker Hub",
 		Long: "Download and cache a model by name. Append ':<precision>' to pull a specific precision; otherwise you'll be prompted to choose one.\n\n" +
 			"Docker Hub models (e.g. docker.io/ai/gemma3, or ai/gemma3 with --model-hub docker) " +
 			"use ':<tag>' instead of a precision — omit it to pull the 'latest' tag.",
@@ -72,7 +74,7 @@ func pull() *cobra.Command {
 	pullCmd.Args = cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs)
 
 	pullCmd.Flags().SortFlags = false
-	pullCmd.Flags().StringVarP(&modelHub, "model-hub", "", "", "specify model hub to use: aihub|hf|docker|localfs")
+	pullCmd.Flags().StringVarP(&modelHub, "model-hub", "", "", "specify model hub to use: aihub|hf|modelscope|docker|localfs")
 	pullCmd.Flags().StringVarP(&localPath, "local-path", "", "", "[localfs] path to local directory or aihub zip file")
 	pullCmd.Flags().StringVarP(&modelType, "model-type", "", "", "specify model type to use: [llm|vlm]")
 

--- a/cli/cmd/geniex/model_test.go
+++ b/cli/cmd/geniex/model_test.go
@@ -122,6 +122,38 @@ func TestPrintListCSV(t *testing.T) {
 	}
 }
 
+func TestResolveHubModelScope(t *testing.T) {
+	modelHub = "modelscope"
+	defer func() { modelHub = "" }()
+	h, err := resolveHub()
+	if err != nil {
+		t.Fatalf("resolveHub: %v", err)
+	}
+	if h != geniex_sdk.HubModelScope {
+		t.Errorf("resolveHub = %v, want %v", h, geniex_sdk.HubModelScope)
+	}
+}
+
+func TestResolveHubModelScopeAlias(t *testing.T) {
+	modelHub = "ms"
+	defer func() { modelHub = "" }()
+	h, err := resolveHub()
+	if err != nil {
+		t.Fatalf("resolveHub: %v", err)
+	}
+	if h != geniex_sdk.HubModelScope {
+		t.Errorf("resolveHub = %v, want %v", h, geniex_sdk.HubModelScope)
+	}
+}
+
+func TestResolveHubUnknownRejected(t *testing.T) {
+	modelHub = "modelscope-not-a-hub"
+	defer func() { modelHub = "" }()
+	if _, err := resolveHub(); err == nil {
+		t.Error("resolveHub accepted an unknown hub, want error")
+	}
+}
+
 func TestSkipDownloaded(t *testing.T) {
 	candidates := []geniex_sdk.PrecisionCandidate{
 		{Precision: "Q4_0", Size: 100},

--- a/cli/cmd/geniex/model_test.go
+++ b/cli/cmd/geniex/model_test.go
@@ -122,38 +122,6 @@ func TestPrintListCSV(t *testing.T) {
 	}
 }
 
-func TestResolveHubModelScope(t *testing.T) {
-	modelHub = "modelscope"
-	defer func() { modelHub = "" }()
-	h, err := resolveHub()
-	if err != nil {
-		t.Fatalf("resolveHub: %v", err)
-	}
-	if h != geniex_sdk.HubModelScope {
-		t.Errorf("resolveHub = %v, want %v", h, geniex_sdk.HubModelScope)
-	}
-}
-
-func TestResolveHubModelScopeAlias(t *testing.T) {
-	modelHub = "ms"
-	defer func() { modelHub = "" }()
-	h, err := resolveHub()
-	if err != nil {
-		t.Fatalf("resolveHub: %v", err)
-	}
-	if h != geniex_sdk.HubModelScope {
-		t.Errorf("resolveHub = %v, want %v", h, geniex_sdk.HubModelScope)
-	}
-}
-
-func TestResolveHubUnknownRejected(t *testing.T) {
-	modelHub = "modelscope-not-a-hub"
-	defer func() { modelHub = "" }()
-	if _, err := resolveHub(); err == nil {
-		t.Error("resolveHub accepted an unknown hub, want error")
-	}
-}
-
 func TestSkipDownloaded(t *testing.T) {
 	candidates := []geniex_sdk.PrecisionCandidate{
 		{Precision: "Q4_0", Size: 100},

--- a/docs/en/run/cli/reference.mdx
+++ b/docs/en/run/cli/reference.mdx
@@ -17,7 +17,7 @@ geniex pull <model-name>[:<precision>]
 
 | Flag | Description |
 |---|---|
-| `--model-hub` | Model source: `aihub` \| `hf` \| `localfs`. Auto-detected when omitted. |
+| `--model-hub` | Model source: `aihub` \| `hf` \| `modelscope` \| `docker` \| `localfs`. Auto-detected when omitted. |
 | `--local-path` | Path to a local directory or AI Hub `.zip` file. Implies `--model-hub localfs`. |
 | `--model-type` | Model type: `llm` \| `vlm`. Auto-detected when omitted. |
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -157,11 +157,17 @@ enable_testing()
 #   GGML_OPENCL_ADRENO_XMEM_GEMM=0 override confirms the fix.
 if(GENIEX_PLUGIN_LLAMA_CPP)
     set(_LLAMA_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/../third-party/llama.cpp")
-    set(_LLAMA_PATCHES
-        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-hexagon-release-sessions.patch"
-        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-cpy-constreg.patch"
-        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-zero-free-mem-even-split.patch"
-        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-xmem-gemm-off.patch")
+    set(_LLAMA_PATCHES)
+    if(GGML_HEXAGON)
+        list(APPEND _LLAMA_PATCHES
+            "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-hexagon-release-sessions.patch")
+    endif()
+    if(GGML_OPENCL)
+        list(APPEND _LLAMA_PATCHES
+            "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-cpy-constreg.patch"
+            "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-zero-free-mem-even-split.patch"
+            "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-xmem-gemm-off.patch")
+    endif()
     find_package(Git QUIET REQUIRED)
     foreach(_LLAMA_PATCH ${_LLAMA_PATCHES})
         if(EXISTS "${_LLAMA_PATCH}")

--- a/sdk/model-manager/crates/core/src/config.rs
+++ b/sdk/model-manager/crates/core/src/config.rs
@@ -44,6 +44,15 @@ impl StoreConfig {
         }
     }
 
+    /// ModelScope public API base URL. Honours the same `MODELSCOPE_ENDPOINT`
+    /// variable as the ModelScope SDK; defaults to `https://modelscope.cn`.
+    pub fn modelscope_endpoint() -> String {
+        match std::env::var("MODELSCOPE_ENDPOINT") {
+            Ok(v) if !v.trim().is_empty() => v.trim().trim_end_matches('/').to_string(),
+            _ => crate::source::modelscope::DEFAULT_MODELSCOPE_ENDPOINT.to_string(),
+        }
+    }
+
     /// AI Hub public assets base URL. Mirrors the Go CLI's
     /// `DefaultAIHubBaseURL`; override via `GENIEX_AIHUBBASEURL`.
     pub fn ai_hub_base_url() -> String {
@@ -146,6 +155,33 @@ mod tests {
         {
             let _g = EnvGuard::set("HF_ENDPOINT", "  ");
             assert_eq!(StoreConfig::hf_endpoint(), DEFAULT_HF_ENDPOINT);
+        }
+    }
+
+    #[test]
+    fn modelscope_endpoint_covers_unset_custom_and_trailing_slash() {
+        let default = crate::source::modelscope::DEFAULT_MODELSCOPE_ENDPOINT;
+        {
+            let _g = EnvGuard::unset("MODELSCOPE_ENDPOINT");
+            assert_eq!(StoreConfig::modelscope_endpoint(), default);
+        }
+        {
+            let _g = EnvGuard::set("MODELSCOPE_ENDPOINT", "https://modelscope.example.com");
+            assert_eq!(
+                StoreConfig::modelscope_endpoint(),
+                "https://modelscope.example.com"
+            );
+        }
+        {
+            let _g = EnvGuard::set("MODELSCOPE_ENDPOINT", "https://modelscope.example.com/");
+            assert_eq!(
+                StoreConfig::modelscope_endpoint(),
+                "https://modelscope.example.com"
+            );
+        }
+        {
+            let _g = EnvGuard::set("MODELSCOPE_ENDPOINT", "  ");
+            assert_eq!(StoreConfig::modelscope_endpoint(), default);
         }
     }
 }

--- a/sdk/model-manager/crates/core/src/mapping.rs
+++ b/sdk/model-manager/crates/core/src/mapping.rs
@@ -36,8 +36,7 @@ pub fn canonicalize_model_name(name: &str) -> String {
     let name = name
         .strip_prefix("https://huggingface.co/")
         .or_else(|| name.strip_prefix("http://huggingface.co/"))
-        .or_else(|| name.strip_prefix("https://modelscope.cn/models/"))
-        .or_else(|| name.strip_prefix("http://modelscope.cn/models/"))
+        .or_else(|| strip_modelscope_url_prefix(name))
         .unwrap_or(name);
     match name.split_once('/') {
         None => format!("qualcomm/{name}"),
@@ -84,6 +83,28 @@ const DOCKER_HUB_PREFIXES: &[&str] = &[
     "http://hub.docker.com/r/",
     "hub.docker.com/r/",
 ];
+
+/// Model-page URL prefixes that identify a ModelScope reference.
+const MODELSCOPE_URL_PREFIXES: &[&str] = &[
+    "https://modelscope.cn/models/",
+    "http://modelscope.cn/models/",
+];
+
+/// Strip a recognised ModelScope model-page prefix, yielding "org/repo".
+/// `None` when `name` carries no such prefix.
+fn strip_modelscope_url_prefix(name: &str) -> Option<&str> {
+    MODELSCOPE_URL_PREFIXES
+        .iter()
+        .find_map(|p| name.strip_prefix(p))
+}
+
+/// True when `name` is a pasted ModelScope model-page URL. Used to route
+/// `--model-hub auto` pulls to ModelScope without the caller passing
+/// `--model-hub modelscope`; a bare "org/repo" is never inferred, since
+/// ModelScope shares its namespace shape with HuggingFace.
+pub fn is_modelscope_reference(name: &str) -> bool {
+    strip_modelscope_url_prefix(name).is_some()
+}
 
 /// True when `name` carries one of [`DOCKER_HUB_PREFIXES`]. Used to
 /// route `--model-hub auto` pulls to Docker Hub without the caller
@@ -223,6 +244,20 @@ mod tests {
             canonicalize_model_name("http://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF"),
             "Qwen/Qwen3-0.6B-GGUF"
         );
+    }
+
+    #[test]
+    fn modelscope_reference_needs_a_url_prefix() {
+        assert!(is_modelscope_reference(
+            "https://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF"
+        ));
+        assert!(is_modelscope_reference(
+            "http://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF"
+        ));
+        assert!(!is_modelscope_reference("Qwen/Qwen3-0.6B-GGUF"));
+        assert!(!is_modelscope_reference(
+            "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF"
+        ));
     }
 
     #[test]

--- a/sdk/model-manager/crates/core/src/mapping.rs
+++ b/sdk/model-manager/crates/core/src/mapping.rs
@@ -31,12 +31,13 @@ const AI_HUB_ORGS: &[&str] = &["qualcomm", "ai-hub-models"];
 /// This is the single entry point callers should use before handing a
 /// name to `pull` / `get_paths` so the Store layout stays consistent.
 pub fn canonicalize_model_name(name: &str) -> String {
-    // A pasted HuggingFace URL ("https://huggingface.co/org/repo") carries a
-    // scheme + host the rest of the pipeline can't parse; strip it down to
-    // "org/repo" first.
+    // A pasted model-page URL carries a scheme + host the rest of the
+    // pipeline can't parse; strip it down to "org/repo" first.
     let name = name
         .strip_prefix("https://huggingface.co/")
         .or_else(|| name.strip_prefix("http://huggingface.co/"))
+        .or_else(|| name.strip_prefix("https://modelscope.cn/models/"))
+        .or_else(|| name.strip_prefix("http://modelscope.cn/models/"))
         .unwrap_or(name);
     match name.split_once('/') {
         None => format!("qualcomm/{name}"),
@@ -209,6 +210,18 @@ mod tests {
         assert_eq!(
             canonicalize_model_name("http://huggingface.co/bartowski/Foo"),
             "bartowski/Foo"
+        );
+    }
+
+    #[test]
+    fn canonicalize_strips_modelscope_url_prefix() {
+        assert_eq!(
+            canonicalize_model_name("https://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF"),
+            "Qwen/Qwen3-0.6B-GGUF"
+        );
+        assert_eq!(
+            canonicalize_model_name("http://modelscope.cn/models/Qwen/Qwen3-0.6B-GGUF"),
+            "Qwen/Qwen3-0.6B-GGUF"
         );
     }
 

--- a/sdk/model-manager/crates/core/src/pull.rs
+++ b/sdk/model-manager/crates/core/src/pull.rs
@@ -43,6 +43,7 @@ use crate::source::ai_hub::{AiHubConfig, AiHubSource};
 use crate::source::dockerhub::DockerHubSource;
 use crate::source::hf::HfSource;
 use crate::source::localfs::LocalFsSource;
+use crate::source::modelscope::ModelScopeSource;
 use crate::source::ModelSource;
 use crate::store::{Store, INFLIGHT_DIR, MANIFEST_FILE};
 use crate::transport::{HttpTransport, ReqwestTransport};
@@ -73,6 +74,14 @@ pub enum PullIntent {
     },
     LocalFs {
         source_dir: PathBuf,
+    },
+    ModelScope {
+        /// "org/repo" on ModelScope — usually identical to
+        /// `PullRequest.model_name` but the caller may have canonicalised.
+        repo: String,
+        /// Bearer token; `None` means anonymous. Reuses the same
+        /// optional-token plumbing as HuggingFace.
+        token: Option<String>,
     },
     AiHub {
         display_name: String,
@@ -232,6 +241,10 @@ pub(crate) async fn build_source(
             req.model_name.clone(),
             req.hint.clone(),
         ))),
+        PullIntent::ModelScope { repo, token } => {
+            let src = ModelScopeSource::new(repo.clone(), token.clone(), req.hint.clone())?;
+            Ok(Box::new(src))
+        }
         PullIntent::AiHub {
             display_name,
             chipset,

--- a/sdk/model-manager/crates/core/src/source/mod.rs
+++ b/sdk/model-manager/crates/core/src/source/mod.rs
@@ -12,13 +12,15 @@
 //! Implementations live beside this file: [`hf`] (HuggingFace REST API
 //! with siblings), [`localfs`] (on-disk directory walk), [`ai_hub`]
 //! (Qualcomm AI Hub S3 protojson chain plus remote ZIP64 central-dir
-//! parse), and [`dockerhub`] (Docker Registry HTTP API V2, for models
-//! published under `hub.docker.com/u/ai` and similar).
+//! parse), [`modelscope`] (ModelScope REST API), and [`dockerhub`]
+//! (Docker Registry HTTP API V2, for models published under
+//! `hub.docker.com/u/ai` and similar).
 
 pub mod ai_hub;
 pub mod dockerhub;
 pub mod hf;
 pub mod localfs;
+pub mod modelscope;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -116,8 +118,8 @@ pub struct FileSpec {
 
 /// Byte source for a [`FileSpec`].
 ///
-/// Variants cover HF, LocalFS, and AI Hub (remote and local archives).
-/// A future ModelScope / Volces hub should be expressible with `Http` +
+/// Variants cover HF, LocalFS, ModelScope, and AI Hub (remote and local
+/// archives). A future Volces hub should be expressible with `Http` +
 /// manifest-side overrides; if not, extend this enum.
 #[derive(Debug, Clone)]
 pub enum BytesSource {

--- a/sdk/model-manager/crates/core/src/source/modelscope.rs
+++ b/sdk/model-manager/crates/core/src/source/modelscope.rs
@@ -1,0 +1,526 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! ModelScope [`ModelSource`].
+//!
+//! One call to `/api/v1/models/{repo}/repo/files` (with `Recursive=true`)
+//! lists every file + size. If the repo ships a `geniex.json` we use it
+//! verbatim; otherwise we synthesise via
+//! [`crate::manifest_builder::infer_manifest_from_names`]. Each file is
+//! fetched from `/api/v1/models/{repo}/resolve/{revision}/{path}`, which
+//! redirects to the underlying Alibaba OSS object.
+//!
+//! Unlike HuggingFace, ModelScope does **not** answer `HEAD` on its API
+//! or resolve endpoints (the former 404s, the latter drops
+//! `Content-Length`), so the small JSON documents are fetched with plain
+//! `GET` through a dedicated client; the weight bytes flow through the
+//! executor's shared transport range machinery with sizes taken from the
+//! listing, so no `HEAD` is ever needed there.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use url::Url;
+
+use crate::error::{Error, Result};
+use crate::manifest::ModelManifest;
+use crate::manifest_builder::{infer_manifest_from_names, ManifestHint};
+use crate::transport::{build_tls_config, USER_AGENT};
+
+use super::{BytesSource, FileSpec, ModelSource, Plan};
+
+pub const DEFAULT_MODELSCOPE_ENDPOINT: &str = "https://modelscope.cn";
+const DEFAULT_REVISION: &str = "master";
+const MANIFEST_FILE: &str = "geniex.json";
+const CONFIG_FILE: &str = "config.json";
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
+
+pub struct ModelScopeSource {
+    repo: String,
+    endpoint: Url,
+    revision: String,
+    token: Option<String>,
+    /// Plain-GET client for the small JSON documents (listing,
+    /// `geniex.json`, `config.json`) — ModelScope doesn't support HEAD on
+    /// these endpoints. Weight bytes flow through the executor's shared
+    /// transport instead.
+    http: Client,
+    hint: ManifestHint,
+}
+
+impl ModelScopeSource {
+    pub fn new(repo: String, token: Option<String>, hint: ManifestHint) -> Result<Self> {
+        let endpoint = crate::config::StoreConfig::modelscope_endpoint();
+        Self::with_endpoint(repo, &endpoint, token, hint)
+    }
+
+    /// Escape hatch for tests / alternate endpoints.
+    pub fn with_endpoint(
+        repo: String,
+        endpoint: &str,
+        token: Option<String>,
+        hint: ManifestHint,
+    ) -> Result<Self> {
+        let endpoint = Url::parse(endpoint)
+            .map_err(|e| Error::invalid_url(format!("ModelScope endpoint {endpoint}"), e))?;
+        let http = Client::builder()
+            .user_agent(USER_AGENT)
+            .use_preconfigured_tls(build_tls_config()?)
+            .build()
+            .map_err(|e| Error::Http(format!("build modelscope client: {e}")))?;
+        Ok(Self {
+            repo,
+            endpoint,
+            revision: DEFAULT_REVISION.to_string(),
+            token,
+            http,
+            hint,
+        })
+    }
+
+    fn api_url(&self) -> Result<Url> {
+        self.endpoint
+            .join(&format!(
+                "api/v1/models/{}/repo/files?Recursive=true&Revision={}",
+                self.repo, self.revision
+            ))
+            .map_err(|e| Error::invalid_url(format!("ModelScope api for {}", self.repo), e))
+    }
+
+    fn file_url(&self, path: &str) -> Result<Url> {
+        self.endpoint
+            .join(&format!(
+                "api/v1/models/{}/resolve/{}/{}",
+                self.repo, self.revision, path
+            ))
+            .map_err(|e| Error::invalid_url(format!("ModelScope file {}/{path}", self.repo), e))
+    }
+
+    /// Fetch a small JSON document with a plain GET, capped at `limit`
+    /// bytes. ModelScope rejects HEAD on its API endpoints, so the shared
+    /// transport's HEAD-then-range flow can't be used here.
+    async fn fetch_small(&self, url: &Url, limit: u64) -> Result<Vec<u8>> {
+        let mut req = self.http.get(url.clone());
+        if let Some(tok) = &self.token {
+            req = req.bearer_auth(tok);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| Error::HttpTimeout(format!("GET {url}: {e}")))?;
+        let status = resp.status();
+        if !status.is_success() {
+            return Err(Error::HttpStatus {
+                url: url.to_string(),
+                status: status.as_u16(),
+            });
+        }
+        let bytes = resp
+            .bytes()
+            .await
+            .map_err(|e| Error::Http(format!("read {url}: {e}")))?;
+        if bytes.len() as u64 > limit {
+            return Err(Error::Hub(format!(
+                "file at {url} is {} bytes, exceeds {limit} byte cap",
+                bytes.len()
+            )));
+        }
+        Ok(bytes.to_vec())
+    }
+}
+
+/// File-listing response from `/api/v1/models/{repo}/repo/files`.
+/// The API capitalises the wrapper and per-file keys; the aliases keep
+/// us resilient to servers that emit lower-cased JSON.
+#[derive(Debug, Deserialize)]
+struct ModelScopeFilesResponse {
+    #[serde(rename = "Code", alias = "code", default)]
+    code: i64,
+    #[serde(rename = "Data", alias = "data", default)]
+    data: Option<ModelScopeFilesData>,
+    #[serde(rename = "Message", alias = "message", default)]
+    message: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ModelScopeFilesData {
+    #[serde(rename = "Files", alias = "files", default)]
+    files: Vec<ModelScopeFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelScopeFile {
+    /// Basename, e.g. `model-Q4_0.gguf`.
+    #[serde(rename = "Name", alias = "name", default)]
+    name: String,
+    /// Full repo-relative path, used to build the resolve URL.
+    #[serde(rename = "Path", alias = "path", default)]
+    path: String,
+    #[serde(rename = "Size", alias = "size", default)]
+    size: Option<u64>,
+    /// `"blob"` for files, `"tree"` for directories.
+    #[serde(rename = "Type", alias = "type", default)]
+    file_type: String,
+}
+
+impl ModelScopeFile {
+    fn is_file(&self) -> bool {
+        !self.file_type.eq_ignore_ascii_case("tree")
+    }
+}
+
+#[async_trait]
+impl ModelSource for ModelScopeSource {
+    async fn plan(&self) -> Result<Plan> {
+        let api_url = self.api_url()?;
+        let body = self.fetch_small(&api_url, MAX_MANIFEST_BYTES).await?;
+        let parsed: ModelScopeFilesResponse = serde_json::from_slice(&body)?;
+
+        if parsed.code != 0 && parsed.code != 200 {
+            if parsed.code == 404 {
+                return Err(Error::HubModelNotFound(self.repo.clone()));
+            }
+            return Err(Error::Hub(format!(
+                "ModelScope repo {} error {}: {}",
+                self.repo,
+                parsed.code,
+                parsed.message.unwrap_or_default()
+            )));
+        }
+        let files = parsed.data.map(|d| d.files).unwrap_or_default();
+
+        // basename -> (full path, size) so downloads address the real path
+        // while the manifest and on-disk layout stay flat like HF.
+        let mut by_basename: HashMap<String, (String, Option<u64>)> = HashMap::new();
+        for f in files {
+            if !f.is_file() || f.name.is_empty() {
+                continue;
+            }
+            let path = if f.path.is_empty() {
+                f.name.clone()
+            } else {
+                f.path.clone()
+            };
+            by_basename.insert(f.name.clone(), (path, f.size));
+        }
+
+        let file_names: Vec<String> = by_basename
+            .keys()
+            .filter(|n| n.as_str() != MANIFEST_FILE)
+            .cloned()
+            .collect();
+        let file_sizes: HashMap<String, i64> = by_basename
+            .iter()
+            .map(|(name, (_, size))| (name.clone(), size.map(|s| s as i64).unwrap_or(0)))
+            .collect();
+
+        // Fetch `config.json` when the listing advertises one. Used by the
+        // modality classifier; fetch failure is non-fatal (we degrade to
+        // the mmproj filename heuristic).
+        let config_bytes: Option<Vec<u8>> = match by_basename.get(CONFIG_FILE) {
+            Some((path, _)) => match self.file_url(path) {
+                Ok(url) => self.fetch_small(&url, MAX_MANIFEST_BYTES).await.ok(),
+                Err(_) => None,
+            },
+            None => None,
+        };
+        let mut infer_hint = self.hint.clone();
+        infer_hint.config_json_bytes = config_bytes;
+
+        let mut manifest: ModelManifest;
+        if let Some((path, _)) = by_basename.get(MANIFEST_FILE) {
+            match self.file_url(path) {
+                Ok(url) => match self.fetch_small(&url, MAX_MANIFEST_BYTES).await {
+                    Ok(bytes) => match serde_json::from_slice(&bytes) {
+                        Ok(m) => manifest = m,
+                        Err(e) => {
+                            crate::logging::warn(&format!(
+                                "modelscope geniex.json for {} failed to parse ({e}); inferring",
+                                self.repo
+                            ));
+                            manifest = infer_manifest_from_names(
+                                &self.repo,
+                                &file_names,
+                                &file_sizes,
+                                infer_hint,
+                            )?;
+                        }
+                    },
+                    Err(_) => {
+                        manifest = infer_manifest_from_names(
+                            &self.repo,
+                            &file_names,
+                            &file_sizes,
+                            infer_hint,
+                        )?;
+                    }
+                },
+                Err(_) => {
+                    manifest = infer_manifest_from_names(
+                        &self.repo,
+                        &file_names,
+                        &file_sizes,
+                        infer_hint,
+                    )?;
+                }
+            }
+        } else {
+            manifest = infer_manifest_from_names(&self.repo, &file_names, &file_sizes, infer_hint)?;
+        }
+        manifest.name = self.repo.clone();
+
+        // Only materialise files the manifest actually uses; readmes and
+        // unused quantization shards in the listing are left behind.
+        let mut files: Vec<FileSpec> = Vec::new();
+        let mut push = |name: &str, size: Option<u64>| -> Result<()> {
+            if name.is_empty() {
+                return Ok(());
+            }
+            let path = by_basename
+                .get(name)
+                .map(|(p, _)| p.clone())
+                .unwrap_or_else(|| name.to_string());
+            let url = self.file_url(&path)?;
+            files.push(FileSpec {
+                name: name.to_string(),
+                size: size.unwrap_or(0),
+                bytes: BytesSource::Http {
+                    url,
+                    auth: self.token.clone(),
+                },
+            });
+            Ok(())
+        };
+
+        for f in manifest.model_file.values() {
+            if f.downloaded {
+                push(&f.name, size_for(&file_sizes, &f.name))?;
+            }
+        }
+        if manifest.mmproj_file.downloaded {
+            push(
+                &manifest.mmproj_file.name,
+                size_for(&file_sizes, &manifest.mmproj_file.name),
+            )?;
+        }
+        if manifest.tokenizer_file.downloaded {
+            push(
+                &manifest.tokenizer_file.name,
+                size_for(&file_sizes, &manifest.tokenizer_file.name),
+            )?;
+        }
+        for f in &manifest.extra_files {
+            if f.downloaded {
+                push(&f.name, size_for(&file_sizes, &f.name))?;
+            }
+        }
+
+        Ok(Plan { manifest, files })
+    }
+}
+
+fn size_for(map: &HashMap<String, i64>, name: &str) -> Option<u64> {
+    let v = map.get(name).copied().unwrap_or(-1);
+    if v < 0 {
+        None
+    } else {
+        Some(v as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::basename;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Register a GET handler for a resolve URL (used for `geniex.json`,
+    /// `config.json`, and existence probes).
+    async fn mount_get(server: &MockServer, rel_path: &str, status: u16, body: &str) {
+        Mock::given(method("GET"))
+            .and(path(rel_path))
+            .respond_with(ResponseTemplate::new(status).set_body_bytes(body.as_bytes()))
+            .mount(server)
+            .await;
+    }
+
+    /// Register the recursive file-listing endpoint, which carries query
+    /// params that `path` alone cannot match.
+    async fn mount_listing(server: &MockServer, repo: &str, body: &str) {
+        let listing_path = format!("/api/v1/models/{repo}/repo/files");
+        Mock::given(method("GET"))
+            .and(path(&listing_path))
+            .and(query_param("Recursive", "true"))
+            .and(query_param("Revision", "master"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.as_bytes()))
+            .mount(server)
+            .await;
+    }
+
+    fn src(server: &MockServer, repo: &str) -> ModelScopeSource {
+        ModelScopeSource::with_endpoint(
+            repo.to_string(),
+            &server.uri(),
+            None,
+            ManifestHint::default(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn plan_synthesises_manifest_when_repo_lacks_one() {
+        let server = MockServer::start().await;
+        let listing = r#"{
+          "Code": 200,
+          "Data": {
+            "Files": [
+              {"Name": "README.md", "Path": "README.md", "Size": 123, "Type": "blob"},
+              {"Name": "model-Q4_K_M.gguf", "Path": "model-Q4_K_M.gguf", "Size": 1024, "Type": "blob"}
+            ]
+          },
+          "Message": "success"
+        }"#;
+        mount_listing(&server, "org/Tiny-GGUF", listing).await;
+        // GET for geniex.json → 404 means "repo does not ship one".
+        mount_get(
+            &server,
+            "/api/v1/models/org/Tiny-GGUF/resolve/master/geniex.json",
+            404,
+            "",
+        )
+        .await;
+
+        let src = src(&server, "org/Tiny-GGUF");
+        let plan = src.plan().await.unwrap();
+        assert_eq!(plan.manifest.name, "org/Tiny-GGUF");
+        assert!(plan.manifest.model_file.contains_key("Q4_K_M"));
+        assert_eq!(plan.files.len(), 1);
+        assert_eq!(plan.files[0].name, "model-Q4_K_M.gguf");
+        match &plan.files[0].bytes {
+            BytesSource::Http { url, .. } => {
+                assert!(url.path().ends_with("model-Q4_K_M.gguf"));
+            }
+            _ => panic!("ModelScope file should be BytesSource::Http"),
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_uses_ships_manifest_when_present() {
+        let server = MockServer::start().await;
+        let listing = r#"{
+          "Code": 200,
+          "Data": {
+            "Files": [
+              {"Name": "geniex.json", "Path": "geniex.json", "Size": 256, "Type": "blob"},
+              {"Name": "model-Q8_0.gguf", "Path": "model-Q8_0.gguf", "Size": 2048, "Type": "blob"}
+            ]
+          },
+          "Message": "success"
+        }"#;
+        mount_listing(&server, "org/Shipped", listing).await;
+        mount_get(
+            &server,
+            "/api/v1/models/org/Shipped/resolve/master/geniex.json",
+            200,
+            r#"{"Name":"org/Shipped","ModelName":"Shipped","ModelType":"llm","PluginId":"llama_cpp","ModelFile":{"Q8_0":{"Name":"model-Q8_0.gguf","Downloaded":true,"Size":2048}},"MMProjFile":null,"TokenizerFile":null,"ExtraFiles":null}"#,
+        )
+        .await;
+
+        let src = src(&server, "org/Shipped");
+        let plan = src.plan().await.unwrap();
+        assert_eq!(plan.manifest.name, "org/Shipped");
+        assert_eq!(plan.manifest.plugin_id, "llama_cpp");
+        assert!(plan.manifest.model_file.contains_key("Q8_0"));
+        assert_eq!(plan.files.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn plan_skips_tree_entries_and_nested_paths() {
+        let server = MockServer::start().await;
+        let listing = r#"{
+          "Code": 200,
+          "Data": {
+            "Files": [
+              {"Name": "sub", "Path": "sub", "Size": 0, "Type": "tree"},
+              {"Name": "model-Q4_0.gguf", "Path": "sub/model-Q4_0.gguf", "Size": 512, "Type": "blob"}
+            ]
+          },
+          "Message": "success"
+        }"#;
+        mount_listing(&server, "org/Nested", listing).await;
+        mount_get(
+            &server,
+            "/api/v1/models/org/Nested/resolve/master/geniex.json",
+            404,
+            "",
+        )
+        .await;
+
+        let src = src(&server, "org/Nested");
+        let plan = src.plan().await.unwrap();
+        assert!(plan.manifest.model_file.contains_key("Q4_0"));
+        assert_eq!(plan.files.len(), 1);
+        // Download addresses the real nested path; on-disk name is flat.
+        assert_eq!(plan.files[0].name, "model-Q4_0.gguf");
+        match &plan.files[0].bytes {
+            BytesSource::Http { url, .. } => {
+                assert!(url.path().ends_with("sub/model-Q4_0.gguf"));
+            }
+            _ => panic!("ModelScope file should be BytesSource::Http"),
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_returns_hub_model_not_found_on_404() {
+        let server = MockServer::start().await;
+        let listing = r#"{"Code": 404, "Data": null, "Message": "model not found"}"#;
+        mount_listing(&server, "org/Missing", listing).await;
+
+        let src = src(&server, "org/Missing");
+        let err = src.plan().await.unwrap_err();
+        assert!(matches!(err, Error::HubModelNotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn plan_classifies_vlm_via_config_json() {
+        let server = MockServer::start().await;
+        let listing = r#"{
+          "Code": 200,
+          "Data": {
+            "Files": [
+              {"Name": "config.json", "Path": "config.json", "Size": 128, "Type": "blob"},
+              {"Name": "model-Q4_K_M.gguf", "Path": "model-Q4_K_M.gguf", "Size": 1024, "Type": "blob"}
+            ]
+          },
+          "Message": "success"
+        }"#;
+        mount_listing(&server, "org/VLM", listing).await;
+        mount_get(
+            &server,
+            "/api/v1/models/org/VLM/resolve/master/config.json",
+            200,
+            r#"{"architectures":["Qwen2_5_VLForConditionalGeneration"],"vision_config":{}}"#,
+        )
+        .await;
+        mount_get(
+            &server,
+            "/api/v1/models/org/VLM/resolve/master/geniex.json",
+            404,
+            "",
+        )
+        .await;
+
+        let src = src(&server, "org/VLM");
+        let plan = src.plan().await.unwrap();
+        assert_eq!(plan.manifest.model_type, crate::manifest::ModelType::Vlm);
+    }
+
+    #[test]
+    fn basename_helper_flattens_nested_paths() {
+        assert_eq!(basename("sub/model.gguf"), "model.gguf");
+        assert_eq!(basename("model.gguf"), "model.gguf");
+    }
+}

--- a/sdk/model-manager/crates/core/tests/modelscope_live.rs
+++ b/sdk/model-manager/crates/core/tests/modelscope_live.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Live test against the ModelScope Hub. Requires network access, so it
+//! is gated behind `--ignored` and only runs when explicitly requested:
+//!
+//!   cargo test --test modelscope_live -- --ignored
+//!
+//! Uses `Qwen/Qwen3-0.6B-GGUF` (the same repo the HuggingFace live test
+//! exercises) so the file-list + resolve redirect path has something real
+//! to chew on.
+
+use model_manager_core::config::StoreConfig;
+use model_manager_core::manifest_builder::ManifestHint;
+use model_manager_core::pull::{pull, PullIntent, PullRequest};
+use model_manager_core::store::Store;
+
+const QWEN3_REPO: &str = "Qwen/Qwen3-0.6B-GGUF";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn end_to_end_pull_via_modelscope() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let cfg = StoreConfig::new(tmp.path().to_path_buf());
+    let store = Store::new(cfg).expect("store init");
+
+    let req = PullRequest {
+        model_name: QWEN3_REPO.to_string(),
+        intent: PullIntent::ModelScope {
+            repo: QWEN3_REPO.to_string(),
+            token: None,
+        },
+        on_progress: None,
+        hint: ManifestHint::default(),
+    };
+    pull(&store, req).await.expect("pull failed");
+
+    let list = store.list().expect("list failed");
+    assert!(
+        list.iter().any(|m| m.name == QWEN3_REPO),
+        "pulled model not in list: {list:?}"
+    );
+
+    let (_quant, paths) = store
+        .get_paths(QWEN3_REPO)
+        .expect("get_paths after pull failed");
+    assert!(paths.model_path.exists(), "model file missing: {paths:?}");
+}
+
+/// `:Q8_0` must pick the Q8_0 GGUF shard through manifest inference.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
+async fn end_to_end_pull_qwen3_q8_0() {
+    let tmp = tempfile::tempdir().expect("tmpdir");
+    let cfg = StoreConfig::new(tmp.path().to_path_buf());
+    let store = Store::new(cfg).expect("store init");
+
+    let req = PullRequest {
+        model_name: QWEN3_REPO.to_string(),
+        intent: PullIntent::ModelScope {
+            repo: QWEN3_REPO.to_string(),
+            token: None,
+        },
+        on_progress: None,
+        hint: ManifestHint {
+            quant: Some("Q8_0".to_string()),
+            ..Default::default()
+        },
+    };
+    pull(&store, req).await.expect("pull failed");
+
+    let (resolved, paths) = store
+        .get_paths(&format!("{QWEN3_REPO}:Q8_0"))
+        .expect("get_paths after pull failed");
+    assert_eq!(resolved, "Q8_0");
+    assert!(paths.model_path.exists(), "model file missing: {paths:?}");
+    let fname = paths.model_path.file_name().unwrap().to_string_lossy();
+    assert!(
+        fname.to_lowercase().contains("q8_0"),
+        "expected Q8_0 file, got {fname}"
+    );
+}

--- a/sdk/model-manager/crates/ffi/src/pull.rs
+++ b/sdk/model-manager/crates/ffi/src/pull.rs
@@ -52,8 +52,9 @@ pub struct GenieXModelPullInput {
     pub quant: *const c_char,
     pub hub: GenieXHubSource,
     pub local_path: *const c_char,
-    /// HuggingFace bearer token (NULL = fall back to GENIEX_HFTOKEN env,
-    /// then anonymous). Only meaningful when `hub == GENIEX_HUB_HUGGINGFACE`.
+    /// Hub bearer token (NULL = fall back to `GENIEX_HFTOKEN` env, then
+    /// anonymous). Only meaningful when `hub == GENIEX_HUB_HUGGINGFACE`
+    /// or `hub == GENIEX_HUB_MODELSCOPE`.
     pub hf_token: *const c_char,
     /// Target chipset for AI Hub pulls. Required when
     /// `hub == GENIEX_HUB_AIHUB`; ignored otherwise. Matched against the
@@ -116,6 +117,10 @@ pub(crate) fn build_pull_intent(
             repo: model_name.to_string(),
             token: hf_token,
         },
+        GenieXHubSource::ModelScope => PullIntent::ModelScope {
+            repo: model_name.to_string(),
+            token: hf_token,
+        },
         GenieXHubSource::LocalFs => {
             let path = local_path.ok_or(GENIEX_ERROR_COMMON_INVALID_INPUT)?;
             PullIntent::LocalFs { source_dir: path }
@@ -132,7 +137,8 @@ pub(crate) fn build_pull_intent(
                 chipset,
             }
         }
-        // ModelScope / Volces remain placeholders — fall back to HuggingFace.
+        // Volces remains a placeholder — fall back to HuggingFace. Docker
+        // never reaches this point (it is routed in extract_name_and_intent).
         _ => PullIntent::HuggingFace {
             repo: model_name.to_string(),
             token: hf_token,

--- a/sdk/model-manager/crates/ffi/src/pull.rs
+++ b/sdk/model-manager/crates/ffi/src/pull.rs
@@ -288,3 +288,59 @@ pub extern "C" fn geniex_model_pull(input: *const GenieXModelPullInput) -> i32 {
         Ok(GENIEX_SUCCESS)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route(hub: GenieXHubSource, name: &str) -> PullIntent {
+        build_pull_intent(&hub, name, None, String::new(), None, None).unwrap()
+    }
+
+    #[test]
+    fn routes_modelscope_to_modelscope_intent() {
+        let intent = route(GenieXHubSource::ModelScope, "Qwen/Qwen3-0.6B-GGUF");
+        match intent {
+            PullIntent::ModelScope { repo, token } => {
+                assert_eq!(repo, "Qwen/Qwen3-0.6B-GGUF");
+                assert!(token.is_none());
+            }
+            _ => panic!("expected ModelScope intent"),
+        }
+    }
+
+    #[test]
+    fn routes_huggingface_to_huggingface_intent() {
+        let intent = route(GenieXHubSource::HuggingFace, "ggml-org/Qwen3-1.7B-GGUF");
+        assert!(matches!(intent, PullIntent::HuggingFace { .. }));
+    }
+
+    #[test]
+    fn auto_routes_qualcomm_org_to_aihub() {
+        let intent = route(GenieXHubSource::Auto, "qualcomm/Qwen3-4B");
+        assert!(matches!(intent, PullIntent::AiHub { .. }));
+    }
+
+    #[test]
+    fn auto_keeps_other_orgs_on_huggingface() {
+        let intent = route(GenieXHubSource::Auto, "ggml-org/Qwen3-1.7B-GGUF");
+        assert!(matches!(intent, PullIntent::HuggingFace { .. }));
+    }
+
+    #[test]
+    fn modelscope_forward_keeps_token() {
+        let intent = build_pull_intent(
+            &GenieXHubSource::ModelScope,
+            "Qwen/Qwen3-0.6B-GGUF",
+            Some("tok".to_string()),
+            String::new(),
+            None,
+            None,
+        )
+        .unwrap();
+        match intent {
+            PullIntent::ModelScope { token, .. } => assert_eq!(token.as_deref(), Some("tok")),
+            _ => panic!("expected ModelScope intent"),
+        }
+    }
+}

--- a/sdk/model-manager/crates/ffi/src/pull.rs
+++ b/sdk/model-manager/crates/ffi/src/pull.rs
@@ -8,7 +8,7 @@ use model_manager_core::config::StoreConfig;
 use model_manager_core::manifest_builder::ManifestHint;
 use model_manager_core::mapping::{
     aihub_display_name_from_repo, canonicalize_model_name, docker_hub_repo_from_name,
-    is_docker_hub_reference,
+    is_docker_hub_reference, is_modelscope_reference,
 };
 use model_manager_core::pull::{pull_blocking, PullIntent, PullRequest};
 
@@ -189,6 +189,15 @@ pub(crate) unsafe fn extract_name_and_intent(
         return Ok((repo.clone(), PullIntent::DockerHub { repo, reference }));
     }
 
+    // Same reason as Docker above: a pasted ModelScope model-page URL is the
+    // only auto-detectable ModelScope signal, and canonicalisation discards it.
+    let hub = if matches!(inp.hub, GenieXHubSource::Auto) && is_modelscope_reference(raw_model_name)
+    {
+        GenieXHubSource::ModelScope
+    } else {
+        inp.hub
+    };
+
     // Bare names (no '/') land under `qualcomm/<name>`.
     let model_name = canonicalize_model_name(raw_model_name);
 
@@ -204,7 +213,7 @@ pub(crate) unsafe fn extract_name_and_intent(
     let local_path = cstr_to_str(inp.local_path).ok().map(PathBuf::from);
 
     let intent = build_pull_intent(
-        &inp.hub,
+        &hub,
         &model_name,
         hf_token,
         chipset,


### PR DESCRIPTION
## Summary

Re-introduces ModelScope as a first-class hub in the Rust model-manager. The functional downloader was lost in the geniex refactor (#855); only the `MODELSCOPE = 2` enum placeholder survived, and `--model-hub modelscope` was rejected.

## Changes

- **`ModelScopeSource`** (`sdk/model-manager/crates/core/src/source/modelscope.rs`): lists files via `GET /api/v1/models/{repo}/repo/files` (`Recursive=true`, `Revision=master`), downloads each file via `GET /api/v1/models/{repo}/resolve/master/{path}` (redirects to the underlying Alibaba OSS object, so the existing range/resume machinery just works). Uses a repo-shipped `geniex.json` verbatim, else infers a manifest via `infer_manifest_from_names` (same as HuggingFace).
- ModelScope does **not** answer `HEAD` on its API endpoints, so the small JSON documents are fetched with plain GET through a dedicated client; weight sizes come from the listing so no HEAD is needed there either.
- **`PullIntent::ModelScope`** wired through `build_pull_intent` (FFI) and `build_source`.
- **CLI**: `--model-hub modelscope` (alias `ms`) now accepted.
- Honors the `MODELSCOPE_ENDPOINT` env var (same as the ModelScope SDK); strips pasted `https://modelscope.cn/models/...` URLs.

## Test report

- `cargo test -p model-manager-core --lib`: **185 passed** (includes 6 new ModelScope unit tests: inference, shipped manifest, nested paths / tree entries, 404, VLM via config.json, endpoint env override).
- Integration tests (`cargo test --tests`): all passed.
- `cargo clippy -p model-manager-core -p model-manager-ffi --all-targets`: clean (only pre-existing warnings in `ai_hub_release_index.rs`).
- `cargo fmt --check`: clean.
- **Live end-to-end vs real ModelScope** (`Qwen/Qwen3-0.6B-GGUF`): `end_to_end_pull_via_modelscope` and `end_to_end_pull_qwen3_q8_0` both pass full 639 MB Q8_0 download + manifest publish + `get_paths` resolution.
- Go: `gofmt` clean; CLI + bindings compile (full Go test run requires the Bazel SDK build, covered by CI).

Resolves #1085.