### PR TITLE
fix(sdk): pin mtmd vision encoder to HTP for npu/hybrid

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -149,12 +149,19 @@ enable_testing()
 #   every device reports 0 free memory: the splits normalize to NaN and the
 #   device lookup runs off the end. Adreno 643 on QCS6490 hits it because the
 #   OpenCL backend subtracts a fixed 1 GiB margin from global_mem_size. See #1497.
+# * llama-opencl-adreno-xmem-gemm-off.patch defaults the Adreno xmem F16xF32
+#   GEMM path (upstream #27640) back to off. On this Adreno generation it
+#   corrupts output after repeated model loads through the same OpenCL
+#   context (quality/logits-parity tests pass individually, fail once several
+#   gpu/hybrid models have loaded in one process); upstream's own
+#   GGML_OPENCL_ADRENO_XMEM_GEMM=0 override confirms the fix.
 if(GENIEX_PLUGIN_LLAMA_CPP)
     set(_LLAMA_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/../third-party/llama.cpp")
     set(_LLAMA_PATCHES
         "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-hexagon-release-sessions.patch"
         "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-cpy-constreg.patch"
-        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-zero-free-mem-even-split.patch")
+        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-zero-free-mem-even-split.patch"
+        "${CMAKE_CURRENT_SOURCE_DIR}/patches/llama-opencl-adreno-xmem-gemm-off.patch")
     find_package(Git QUIET REQUIRED)
     foreach(_LLAMA_PATCH ${_LLAMA_PATCHES})
         if(EXISTS "${_LLAMA_PATCH}")

--- a/sdk/patches/llama-hexagon-release-sessions.patch
+++ b/sdk/patches/llama-hexagon-release-sessions.patch
@@ -1,9 +1,9 @@
 diff --git a/ggml/src/ggml-hexagon/ggml-hexagon.cpp b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
-index 54d313ade..5ed2e3de3 100644
+index 3eb84fd2a..4762835a0 100644
 --- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
 +++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
-@@ -4325,6 +4325,42 @@ ggml_hexagon_registry::ggml_hexagon_registry(ggml_backend_reg_t reg) {
-     }
+@@ -5668,6 +5668,41 @@ ggml_hexagon_registry::ggml_hexagon_registry(ggml_backend_reg_t reg) {
+ 
  }
  
 +
@@ -16,47 +16,44 @@ index 54d313ade..5ed2e3de3 100644
 +    auto hreg = static_cast<ggml_hexagon_registry *>(reg->context);
 +    if (!hreg) return;
 +    for (size_t i = 0; i < opt_ndev; i++) {
-+        auto sess = static_cast<ggml_hexagon_session *>(hreg->devices[i].context);
-+        if (sess) {
-+            delete sess;
-+            hreg->devices[i].context = nullptr;
++        auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(hreg->devices[i].context);
++        if (dev_ctx) {
++            dev_ctx->sess.reset();
 +        }
 +    }
 +}
 +
 +// geniex: recreate HTP sessions that a prior release cleared out. Must be
-+// called before any HTP device is used again. The outer ggml registry
-+// (ggml-backend-reg.cpp) caches ggml_backend_dev_t pointers at startup and
-+// never re-invokes ggml_backend_hexagon_reg_get_device, so a lazy path on
-+// device lookup is not sufficient.
++// called before any HTP device is used again. dev_ctx->session() would
++// otherwise lazily recreate it on the next use, but callers that read
++// dev_ctx->sess directly (not through session()) need it populated eagerly.
 +static void ggml_backend_hexagon_reacquire_sessions(ggml_backend_reg_t reg) {
 +    auto hreg = static_cast<ggml_hexagon_registry *>(reg->context);
 +    if (!hreg) return;
 +    for (size_t i = 0; i < opt_ndev; i++) {
-+        if (hreg->devices[i].context) continue;
++        auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(hreg->devices[i].context);
++        if (!dev_ctx || dev_ctx->sess) continue;
 +        try {
-+            hreg->devices[i].context = new ggml_hexagon_session(i, &hreg->devices[i]);
++            dev_ctx->session();
 +        } catch (const std::exception &) {
 +            GGML_LOG_ERROR("ggml-hex: failed to reacquire session %zu\n", i);
-+            hreg->devices[i].context = nullptr;
 +        }
 +    }
 +}
++
  ggml_hexagon_registry::~ggml_hexagon_registry() {
      GGML_LOG_INFO("ggml-hex: releasing registry\n");
  
-@@ -4361,6 +4397,14 @@ static void * ggml_backend_hexagon_get_proc_address(ggml_backend_reg_t reg, cons
-         return (void *) fct;
+@@ -5820,6 +5855,12 @@ static void * ggml_backend_hexagon_get_proc_address(ggml_backend_reg_t reg, cons
+     if (strcmp(name, "ggml_backend_comm_allreduce_tensor") == 0) {
+         return (void *) ggml_backend_hexagon_comm_allreduce_tensor;
      }
- 
 +    if (strcmp(name, "ggml_backend_hexagon_release_sessions") == 0) {
-+        auto fct = ggml_backend_hexagon_release_sessions;
-+        return (void *) fct;
++        return (void *) ggml_backend_hexagon_release_sessions;
 +    }
 +    if (strcmp(name, "ggml_backend_hexagon_reacquire_sessions") == 0) {
-+        auto fct = ggml_backend_hexagon_reacquire_sessions;
-+        return (void *) fct;
++        return (void *) ggml_backend_hexagon_reacquire_sessions;
 +    }
      return NULL;
-     GGML_UNUSED(reg);
  }
+ 

--- a/sdk/patches/llama-opencl-adreno-xmem-gemm-off.patch
+++ b/sdk/patches/llama-opencl-adreno-xmem-gemm-off.patch
@@ -1,0 +1,13 @@
+diff --git a/ggml/src/ggml-opencl/ggml-opencl.cpp b/ggml/src/ggml-opencl/ggml-opencl.cpp
+index 34d58f4ee..ad7d87871 100644
+--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
++++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
+@@ -6067,7 +6067,7 @@ static ggml_backend_opencl_context * ggml_cl_init(ggml_backend_dev_t dev) {
+     {
+         const char * xmem_env = getenv("GGML_OPENCL_ADRENO_XMEM_GEMM");
+         backend_ctx->adreno_xmem_gemm_enabled = backend_ctx->gpu_family == GPU_FAMILY::ADRENO &&
+-                                                (xmem_env ? atoi(xmem_env) != 0 : true);
++                                                (xmem_env ? atoi(xmem_env) != 0 : false);
+     }
+ #endif
+ 

--- a/sdk/plugins/llama_cpp/src/llm.cpp
+++ b/sdk/plugins/llama_cpp/src/llm.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <nlohmann/json.hpp>
 #include <sstream>
 #include <vector>
 
@@ -216,7 +215,7 @@ int32_t LlamaLlm::apply_chat_template(
     inputs.add_generation_prompt = input->add_generation_prompt;
 
     if (input->tools && strlen(input->tools) > 0) {
-        inputs.tools = common_chat_tools_parse_oaicompat(nlohmann::ordered_json::parse(std::string(input->tools)));
+        inputs.tools = common_chat_tools_parse_oaicompat(common_json::parse(std::string(input->tools)));
     }
 
     inputs.enable_thinking = input->enable_thinking;

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -90,14 +90,23 @@ int32_t LlamaVlm::create(const geniex_VlmCreateInput* input) {
 
     // Initialize vision context if mmproj_path provided
     if (input->mmproj_path) {
+        ggml_backend_dev_t htp_device = device == Device::NPU ? ggml_backend_dev_by_name("HTP0") : nullptr;
+
         mtmd_context_params mparams = mtmd_context_params_default();
-        mparams.use_gpu             = device == Device::GPU;
+        mparams.use_gpu             = device == Device::GPU || htp_device != nullptr;
+        mparams.device              = htp_device;
         mparams.print_timings       = false;
         mparams.n_threads           = 4;
         // Zack TODO: elegant fix this error:  no member named 'verbosity' in 'mtmd_context_params'
         // mparams.verbosity           = GGML_LOG_LEVEL_ERROR;
 
         this->ctx_vision = mtmd_init_from_file(input->mmproj_path, this->model, mparams);
+        if (!this->ctx_vision && htp_device) {
+            GENIEX_LOG_WARN("mtmd failed to initialize the vision encoder on HTP; falling back to CPU");
+            mparams.use_gpu  = false;
+            mparams.device   = nullptr;
+            this->ctx_vision = mtmd_init_from_file(input->mmproj_path, this->model, mparams);
+        }
         // Continue even if vision context fails
         if (this->ctx_vision) {
             this->supports_vision = mtmd_support_vision(this->ctx_vision);

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <nlohmann/json.hpp>
 
 #include "chat.h"
 #include "common.h"
@@ -168,7 +167,7 @@ int32_t LlamaVlm::apply_chat_template(
     tmpl_inputs.add_generation_prompt = true;
     tmpl_inputs.use_jinja             = true;
     if (input->tools && strlen(input->tools) > 0) {
-        tmpl_inputs.tools = common_chat_tools_parse_oaicompat(nlohmann::ordered_json::parse(std::string(input->tools)));
+        tmpl_inputs.tools = common_chat_tools_parse_oaicompat(common_json::parse(std::string(input->tools)));
     }
 
     if (input->enable_thinking) {
@@ -228,9 +227,9 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             GENIEX_LOG_DEBUG("processing {} image(s)", input->config->image_count);
             for (int i = 0; i < input->config->image_count; ++i) {
                 if (input->config->image_paths[i]) {
-                    mtmd_bitmap* bmp =
-                        mtmd_helper_bitmap_init_from_file(this->ctx_vision, input->config->image_paths[i], false)
-                            .bitmap;
+                    mtmd_bitmap* bmp = mtmd_helper_bitmap_init_from_file(
+                        this->ctx_vision, input->config->image_paths[i], false, mtmd_helper_init_opt_default())
+                                           .bitmap;
                     if (bmp) {
                         bitmaps.push_back(bmp);
                         n_media++;
@@ -251,9 +250,9 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
             GENIEX_LOG_DEBUG("processing {} audio file(s)", input->config->audio_count);
             for (int i = 0; i < input->config->audio_count; ++i) {
                 if (input->config->audio_paths[i]) {
-                    mtmd_bitmap* bmp =
-                        mtmd_helper_bitmap_init_from_file(this->ctx_vision, input->config->audio_paths[i], false)
-                            .bitmap;
+                    mtmd_bitmap* bmp = mtmd_helper_bitmap_init_from_file(
+                        this->ctx_vision, input->config->audio_paths[i], false, mtmd_helper_init_opt_default())
+                                           .bitmap;
                     if (bmp) {
                         bitmaps.push_back(bmp);
                         n_media++;


### PR DESCRIPTION
## Summary
- Pin the mtmd vision encoder (`clip`) to the resolved HTP device for the `npu` / `hybrid` device aliases, instead of relying on `use_gpu` + ggml's type-based backend auto-pick. ggml-hexagon registers as `GGML_BACKEND_DEVICE_TYPE_GPU`, so when OpenCL is also enabled, the auto-pick can land on OpenCL/Adreno instead of HTP, leaving clip unaccelerated for the default `npu` path.
- Fall back to CPU if HTP initialization for the vision encoder fails, so vision support degrades gracefully instead of being lost entirely.
- Bump the llama.cpp submodule to `b10731`. The previously pinned commit shares one eagerly-created HTP session between the LLM context and clip's own scheduler; on real HTP hardware this corrupts the session's async queue state across multiple VLM turns once clip actually runs on HTP (`dspqueue_read` failures). The bump picks up ggml-hexagon's "create sessions on demand" rework (upstream #27785), which this scenario needs.
- Refresh `llama-hexagon-release-sessions.patch` for the new per-device `ggml_backend_hexagon_device_context` wrapper (session is now a lazily-created `unique_ptr` instead of the raw context pointer), and adapt the two call sites the version jump broke: `mtmd_helper_bitmap_init_from_file` gained an `mtmd_helper_init_opt` parameter, and `common_chat_tools_parse_oaicompat` now takes the new opaque `common_json` type instead of `nlohmann::ordered_json`.
- Add `llama-opencl-adreno-xmem-gemm-off.patch`: the bump also picks up upstream #27640, which defaults ggml-opencl's Adreno xmem F16xF32 GEMM path on. On this Adreno generation it corrupts output after several `gpu`/`hybrid` model loads through the same OpenCL context — confirmed as a genuine bump regression by running the full `test_llama_cpp.py` suite against unpatched `main` (44 passed, 0 failed) vs. the bumped commit before this patch (35 passed, 9 failed, all `gpu`/`hybrid` quality/logits-parity checks). Defaulting it back off via upstream's own `GGML_OPENCL_ADRENO_XMEM_GEMM=0` override resolves it.

## Test plan
- [x] `--device npu`, SmolVLM-256M + mmproj + image: clip loads on `HTP0` (was `CPU`); TTFT drops from ~4.0s to ~0.6s on this host
- [x] `--device hybrid`: clip also loads on `HTP0`
- [x] `--device gpu`: unchanged — clip still loads on `OpenCL` (no regression)
- [x] Full SDK build with `GENIEX_PLUGIN_QAIRT=ON` alongside `llama_cpp` succeeds and the HTP pinning above still holds with both plugins loaded
- [x] `test_vlm_multi_turn[gemma-4-E2B-it-GGUF-npu]` — the scenario that crashed pre-bump (`dspqueue_read` on real HTP hardware) — passes locally (Windows ARM64) and on QDC android (SM8850), which now runs the full `test_llama_cpp.py` suite clean
- [x] Full `test_llama_cpp.py` suite (44 tests, cpu/gpu/npu/hybrid, MTP excluded) passes 100% locally with both patches applied, matching a clean `main` baseline run byte-for-byte in pass count