### PR TITLE
feat(sdk): apply chat template in geniex-bench --accuracy mode

### DIFF
--- a/sdk/benchmark/README.md
+++ b/sdk/benchmark/README.md
@@ -161,6 +161,12 @@ Run `geniex-bench --help` for the full flag list.
   `runs` array. Every other mode feeds the file verbatim as one prompt,
   because the segments differ in length and a tok/s median across them would
   mix populations.
+- with `--accuracy`, each prompt-file segment is run through the bundle's own
+  chat template (`geniex_llm_apply_chat_template`) before generation — the
+  same templating `geniex infer` uses — so pass the raw user turn, not
+  pre-templated text. `--system-prompt TEXT` adds a system message ahead of
+  it; `--think` / `--no-think` sets `enable_thinking` (default: think).
+  Without `--accuracy`, `--prompt-file` still feeds the file verbatim.
 - `--logits` runs one prefill-only forward pass (no decode loop, no timing) over
   `-p N` random ids and writes every position's top-N logits to `--output-json`
   (`--logits-top-n`, default 20; `--logits-last-only` for the last row only).

--- a/sdk/benchmark/bench.h
+++ b/sdk/benchmark/bench.h
@@ -86,6 +86,12 @@ typedef struct {
     int32_t      repeat;
     bool         reset_between_runs; /* true => geniex_llm_reset() before each run, freeing KV */
     bool         accuracy;           /* true => single run (warmup=0, repeat=1), print generated text */
+    /* --accuracy --prompt-file only: run each prompt through the bundle's own
+     * chat template (geniex_llm_apply_chat_template) before generation, so the
+     * benchmark exercises the same templating production inference uses
+     * instead of feeding the file verbatim. */
+    const char* system_prompt;   /* --system-prompt; NULL = no system message */
+    bool        enable_thinking; /* --think / --no-think; default true, matches `geniex infer` */
 
     /* Prefill-only raw-logits mode (--logits): one forward pass over the prompt,
      * no decode loop. Bypasses the timing/warmup/repeat machinery entirely. */

--- a/sdk/benchmark/options.c
+++ b/sdk/benchmark/options.c
@@ -95,6 +95,14 @@ static void usage(const char* argv0) {
         "                         speed. Overrides --warmup / --repetitions. Pair\n"
         "                         with --prompt-file for a real prompt; the default\n"
         "                         random-ids prefill produces meaningless text.\n"
+        "                         Each --prompt-file segment is run through the\n"
+        "                         bundle's own chat template before generation --\n"
+        "                         same templating `geniex infer` uses -- so pass the\n"
+        "                         raw user turn, not pre-templated text.\n"
+        "  --system-prompt TEXT   with --accuracy --prompt-file: system message added\n"
+        "                         ahead of the prompt in the chat template\n"
+        "  --think / --no-think  with --accuracy --prompt-file: enable_thinking for\n"
+        "                         the chat template (default: think)\n"
         "  --logits               prefill-only raw-logits mode: run one forward pass\n"
         "                         (geniex_llm_forward_logits, no decode loop) over N\n"
         "                         random token ids (-p N, like the timing default) and\n"
@@ -263,6 +271,8 @@ void parse_args(int argc, char** argv, options_t* o) {
     o->repeat                  = 5;
     o->reset_between_runs      = true;
     o->accuracy                = false;
+    o->system_prompt           = NULL;
+    o->enable_thinking         = true;
     o->logits_mode             = false;
     o->logits_last_only        = false;
     o->logits_top_n            = 20;
@@ -335,6 +345,12 @@ void parse_args(int argc, char** argv, options_t* o) {
             o->reset_between_runs = false;
         } else if (strcmp(a, "--accuracy") == 0) {
             o->accuracy = true;
+        } else if (strcmp(a, "--system-prompt") == 0) {
+            o->system_prompt = arg_value(argc, argv, &i, a);
+        } else if (strcmp(a, "--think") == 0) {
+            o->enable_thinking = true;
+        } else if (strcmp(a, "--no-think") == 0) {
+            o->enable_thinking = false;
         } else if (strcmp(a, "--logits") == 0) {
             o->logits_mode = true;
         } else if (strcmp(a, "--logits-last-only") == 0) {
@@ -388,6 +404,9 @@ void parse_args(int argc, char** argv, options_t* o) {
     if (o->accuracy) {
         o->warmup = 0;
         o->repeat = 1;
+    } else if (o->system_prompt) {
+        fprintf(stderr, "ERROR: --system-prompt requires --accuracy --prompt-file\n");
+        exit(2);
     }
 
     if (o->logits_mode) {

--- a/sdk/benchmark/run.c
+++ b/sdk/benchmark/run.c
@@ -175,6 +175,43 @@ static void print_gen_text(const char* text) {
 
 /* ----------------------------- LLM run loop ----------------------------- */
 
+/* --accuracy --prompt-file: run user_prompt (optionally preceded by
+ * --system-prompt) through the bundle's own chat template before
+ * generation, so the benchmark exercises the same templating `geniex infer`
+ * uses instead of feeding the file verbatim. Returns heap text the caller
+ * frees with geniex_free, or NULL on failure. */
+static char* build_llm_accuracy_prompt(geniex_LLM* llm, const options_t* o, const char* user_prompt) {
+    geniex_LlmChatMessage messages[2];
+    int32_t               nm = 0;
+    if (o->system_prompt) {
+        messages[nm].role    = "system";
+        messages[nm].content = o->system_prompt;
+        nm++;
+    }
+    messages[nm].role    = "user";
+    messages[nm].content = user_prompt;
+    nm++;
+
+    geniex_LlmApplyChatTemplateInput  tin;
+    geniex_LlmApplyChatTemplateOutput tout;
+    memset(&tin, 0, sizeof(tin));
+    memset(&tout, 0, sizeof(tout));
+    tin.messages              = messages;
+    tin.message_count         = nm;
+    tin.enable_thinking       = o->enable_thinking;
+    tin.add_generation_prompt = true;
+
+    int32_t rc = geniex_llm_apply_chat_template(llm, &tin, &tout);
+    if (rc != GENIEX_SUCCESS) {
+        fprintf(stderr,
+            "ERROR: geniex_llm_apply_chat_template: %s (%d)\n",
+            geniex_get_error_message((geniex_ErrorCode)rc),
+            rc);
+        return NULL;
+    }
+    return tout.formatted_text;
+}
+
 void run_llm(const options_t* o, const device_t* dev, run_result_t* out) {
     geniex_LlmCreateInput cin;
     memset(&cin, 0, sizeof(cin));
@@ -226,8 +263,19 @@ void run_llm(const options_t* o, const device_t* dev, run_result_t* out) {
             geniex_LlmGenerateOutput gout;
             memset(&gin, 0, sizeof(gin));
             memset(&gout, 0, sizeof(gout));
+            char* templated_prompt = NULL;
             if (cur_prompt) {
-                gin.prompt_utf8 = cur_prompt;
+                if (o->accuracy) {
+                    templated_prompt = build_llm_accuracy_prompt(llm, o, cur_prompt);
+                    if (!templated_prompt) {
+                        free(tokens);
+                        geniex_llm_destroy(llm);
+                        exit(1);
+                    }
+                    gin.prompt_utf8 = templated_prompt;
+                } else {
+                    gin.prompt_utf8 = cur_prompt;
+                }
             } else {
                 gin.input_ids       = tokens;
                 gin.input_ids_count = o->n_prompt;
@@ -240,6 +288,7 @@ void run_llm(const options_t* o, const device_t* dev, run_result_t* out) {
             if (rc != GENIEX_SUCCESS) {
                 const char* msg = geniex_get_error_message((geniex_ErrorCode)rc);
                 fprintf(stderr, "ERROR: geniex_llm_generate run %d failed: %s (%d)\n", run_idx, msg ? msg : "?", rc);
+                if (templated_prompt) geniex_free(templated_prompt);
                 free(tokens);
                 geniex_llm_destroy(llm);
                 exit(1);
@@ -262,6 +311,9 @@ void run_llm(const options_t* o, const device_t* dev, run_result_t* out) {
             }
             if (gout.full_text) {
                 geniex_free(gout.full_text);
+            }
+            if (templated_prompt) {
+                geniex_free(templated_prompt);
             }
         }
     }

--- a/sdk/benchmark/run.c
+++ b/sdk/benchmark/run.c
@@ -181,8 +181,11 @@ static void print_gen_text(const char* text) {
  * uses instead of feeding the file verbatim. Returns heap text the caller
  * frees with geniex_free, or NULL on failure. */
 static char* build_llm_accuracy_prompt(geniex_LLM* llm, const options_t* o, const char* user_prompt) {
+    /* Zero first: the plugins dereference the optional tool-calling fields
+     * whenever they're non-NULL, so stack garbage there is an access violation. */
     geniex_LlmChatMessage messages[2];
-    int32_t               nm = 0;
+    memset(messages, 0, sizeof(messages));
+    int32_t nm = 0;
     if (o->system_prompt) {
         messages[nm].role    = "system";
         messages[nm].content = o->system_prompt;


### PR DESCRIPTION
## Summary

`--accuracy --prompt-file` fed the prompt file to `prompt_utf8` verbatim, so accuracy runs never exercised chat templating — callers had to pre-template the prompt host-side, which for `llama_cpp` meant a separate HF tokenizer lookup with no local fallback.

This routes the raw user turn through the bundle's own `geniex_llm_apply_chat_template` before generation under `--accuracy` — the same call `geniex infer` uses — so the benchmark's accuracy path now matches production templating for both `llama_cpp` and `qairt`. Adds `--system-prompt` and `--think`/`--no-think` (default: think, matching `geniex infer`) to control it. The non-`--accuracy` `--prompt-file` perf path is untouched (still verbatim).

## Test plan

- [x] `geniex-bench --plugin llama_cpp --device cpu -m <Qwen3-0.6B-Q4_0.gguf> --accuracy --prompt-file prompt.txt --system-prompt "You are a pirate..." --no-think` — templated output confirmed via trace log (`<|im_start|>system...<|im_end|>...`), and the model's reply actually adopted the system prompt's persona.
- [x] Default `--think` (no flag) — trace log shows `enable_thinking: true` and the model emits a populated `<think>...</think>` block.
- [x] `--prompt-file` without `--accuracy` still feeds the file verbatim (no `apply_chat_template` call in the trace log).
- [x] `--system-prompt` without `--accuracy` is rejected (`ERROR: --system-prompt requires --accuracy --prompt-file`, exit 2).
- [x] Uninitialized-`messages` crash (fixed in dc90e7f6): reproduced on a Snapdragon X Elite against the `v0.6.0-alpha.1` bundle's own `geniex.dll`/plugin (`GENIEX_PLUGIN_PATH` set as the release layout expects). Every `--system-prompt` run died at `apply_chat_template` with `0xC0000005`; without it, runs passed. cdb backtrace landed inside the llama_cpp plugin, and the fault was independent of model (granite-4.0-h-micro, Qwen3-0.6B) and device (npu, cpu). After zeroing the array, the same invocation exits 0 and the trace shows the system turn correctly templated (`<|start_of_role|>system<|end_of_role|>...`); `--think` and the no-`--system-prompt` path both still pass.