### PR TITLE
fix(server): trigger keepalive reset from divergent conversations, not a header

### DIFF
--- a/cli/cmd/geniex/run.go
+++ b/cli/cmd/geniex/run.go
@@ -199,8 +199,7 @@ func runCompletions(ctx context.Context, name string, modelType geniex_sdk.Model
 				option.WithJSONSet("spec_draft_model", draftModel),
 				option.WithJSONSet("spec_n_max", draftTokens),
 				option.WithJSONSet("spec_n_min", draftMin),
-				option.WithJSONSet("spec_p_min", draftPMin),
-				option.WithHeaderAdd("GenieX-KeepCache", "true"))
+				option.WithJSONSet("spec_p_min", draftPMin))
 
 			var firstToken time.Time
 			var profileData geniex_sdk.ProfileData

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/config"
 	"github.com/qualcomm/GenieX/cli/server/service"
 	"github.com/qualcomm/GenieX/cli/server/types"
+	"github.com/qualcomm/GenieX/cli/server/utils"
 )
 
 type ChatCompletionNewParams openai.ChatCompletionNewParams
@@ -129,8 +130,11 @@ func ChatCompletions(c *gin.Context) {
 		if !ok {
 			return
 		}
-		runChat(c, param, modelParam, messages, prepareLLM)
+		runChat(c, param, modelParam, messages, utils.SessionKeyOf(messages), prepareLLM)
 	case geniex_sdk.ModelTypeVLM:
+		// Hash before buildVLMMessages replaces each image/audio part with a
+		// per-request temp file path; see SessionKeyOfVLMRequest.
+		session := utils.SessionKeyOfVLMRequest(param.Messages)
 		messages, tempFiles, ok := buildVLMMessages(c, param)
 		for _, f := range tempFiles {
 			defer os.Remove(f)
@@ -138,7 +142,7 @@ func ChatCompletions(c *gin.Context) {
 		if !ok {
 			return
 		}
-		runChat(c, param, modelParam, messages, prepareVLM)
+		runChat(c, param, modelParam, messages, session, prepareVLM)
 	default:
 		slog.Error("Model type not support", "model_type", paths.ModelType)
 		c.JSON(http.StatusBadRequest, map[string]any{"error": "model type not support"})
@@ -218,8 +222,9 @@ func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param C
 	return formatted.FormattedText, gen, nil
 }
 
-// runChat is the shared flow wrapping the type-specific prepareFn.
-func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam, messages M, prepare prepareFn[T, M]) {
+// runChat is the shared flow wrapping the type-specific prepareFn. session
+// identifies the conversation for the keepalive cache's reset decision.
+func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam, messages M, session utils.SessionKey, prepare prepareFn[T, M]) {
 	// ---- prepare: parse tools, load the model, apply the chat template ----
 	parseTool, tools, err := parseTools(param)
 	if err != nil {
@@ -231,7 +236,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 	p, err := service.KeepAliveGet[T](
 		string(param.Model),
 		modelParam,
-		c.GetHeader("GenieX-KeepCache") != "true",
+		session,
 	)
 	if writeKeepAliveError(c, err) {
 		return

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -153,15 +153,23 @@ func ChatCompletions(c *gin.Context) {
 // generateFn adapts LLM/VLM Generate to one shape; fullText is set even on error.
 type generateFn func(prompt string, onToken func(string) bool) (geniex_sdk.ProfileData, string, error)
 
+type prepareInput[M any] struct {
+	Messages M
+	Param    ChatCompletionRequest
+	Tools    string
+	Sampler  *geniex_sdk.SamplerConfig
+	Fresh    bool
+}
+
 // prepareFn holds the only LLM/VLM-specific work: apply the chat template, then
 // return the formatted prompt and a generateFn.
-type prepareFn[T, M any] func(p *T, messages M, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (prompt string, gen generateFn, err error)
+type prepareFn[T, M any] func(p *T, input prepareInput[M]) (prompt string, gen generateFn, err error)
 
-func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
+func prepareLLM(p *geniex_sdk.LLM, input prepareInput[[]geniex_sdk.LlmChatMessage]) (string, generateFn, error) {
 	formatted, err := p.ApplyChatTemplate(geniex_sdk.LlmApplyChatTemplateInput{
-		Messages:            messages,
-		Tools:               tools,
-		EnableThink:         param.EnableThink,
+		Messages:            input.Messages,
+		Tools:               input.Tools,
+		EnableThink:         input.Param.EnableThink,
 		AddGenerationPrompt: true,
 	})
 	if err != nil {
@@ -172,8 +180,8 @@ func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param C
 			PromptUTF8: prompt,
 			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
-				MaxTokens:     int32(param.MaxCompletionTokens.Value),
-				SamplerConfig: sampler,
+				MaxTokens:     int32(input.Param.MaxCompletionTokens.Value),
+				SamplerConfig: input.Sampler,
 			},
 		})
 		if out == nil {
@@ -184,23 +192,28 @@ func prepareLLM(p *geniex_sdk.LLM, messages []geniex_sdk.LlmChatMessage, param C
 	return formatted.FormattedText, gen, nil
 }
 
-func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param ChatCompletionRequest, tools string, sampler *geniex_sdk.SamplerConfig) (string, generateFn, error) {
+func prepareVLM(p *geniex_sdk.VLM, input prepareInput[[]geniex_sdk.VlmChatMessage]) (string, generateFn, error) {
 	formatted, err := p.ApplyChatTemplate(geniex_sdk.VlmApplyChatTemplateInput{
-		Messages:    messages,
-		Tools:       tools,
-		EnableThink: param.EnableThink,
+		Messages:    input.Messages,
+		Tools:       input.Tools,
+		EnableThink: input.Param.EnableThink,
 	})
 	if err != nil {
 		return "", nil, err
 	}
-	images := make([]string, 0)
-	audios := make([]string, 0)
-	for _, content := range messages[len(messages)-1].Contents {
-		switch content.Type {
-		case geniex_sdk.VlmContentTypeImage:
-			images = append(images, content.Text)
-		case geniex_sdk.VlmContentTypeAudio:
-			audios = append(audios, content.Text)
+	start := len(input.Messages) - 1
+	if input.Fresh {
+		start = 0
+	}
+	var images, audios []string
+	for _, message := range input.Messages[start:] {
+		for _, content := range message.Contents {
+			switch content.Type {
+			case geniex_sdk.VlmContentTypeImage:
+				images = append(images, content.Text)
+			case geniex_sdk.VlmContentTypeAudio:
+				audios = append(audios, content.Text)
+			}
 		}
 	}
 	gen := func(prompt string, onToken func(string) bool) (geniex_sdk.ProfileData, string, error) {
@@ -208,8 +221,8 @@ func prepareVLM(p *geniex_sdk.VLM, messages []geniex_sdk.VlmChatMessage, param C
 			PromptUTF8: prompt,
 			OnToken:    onToken,
 			Config: &geniex_sdk.GenerationConfig{
-				MaxTokens:     int32(param.MaxCompletionTokens.Value),
-				SamplerConfig: sampler,
+				MaxTokens:     int32(input.Param.MaxCompletionTokens.Value),
+				SamplerConfig: input.Sampler,
 				ImagePaths:    images,
 				AudioPaths:    audios,
 			},
@@ -233,7 +246,7 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		return
 	}
 
-	p, err := service.KeepAliveGet[T](
+	acquired, err := service.KeepAliveGet[T](
 		string(param.Model),
 		modelParam,
 		session,
@@ -261,7 +274,13 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		FrequencyPenalty:  float32(param.FrequencyPenalty.Value),
 		Seed:              int32(param.Seed.Value),
 	}
-	prompt, gen, err := prepare(p, messages, param, tools, sampler)
+	prompt, gen, err := prepare(acquired.Model, prepareInput[M]{
+		Messages: messages,
+		Param:    param,
+		Tools:    tools,
+		Sampler:  sampler,
+		Fresh:    acquired.Fresh,
+	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, map[string]any{"error": err.Error(), "code": geniex_sdk.SDKErrorCode(err)})
 		return

--- a/cli/server/handler/completion.go
+++ b/cli/server/handler/completion.go
@@ -143,7 +143,7 @@ func Completions(c *gin.Context) {
 		modelParam.NCtx = int32(req.MaxTokens.Value)
 	}
 
-	p, err := service.KeepAliveGet[geniex_sdk.LLM](
+	acquired, err := service.KeepAliveGet[geniex_sdk.LLM](
 		string(req.Model),
 		modelParam,
 		utils.HashText(prompt),
@@ -151,6 +151,7 @@ func Completions(c *gin.Context) {
 	if writeKeepAliveError(c, err) {
 		return
 	}
+	p := acquired.Model
 
 	genConfig := &geniex_sdk.GenerationConfig{
 		MaxTokens: int32(req.MaxTokens.Value),

--- a/cli/server/handler/completion.go
+++ b/cli/server/handler/completion.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/config"
 	"github.com/qualcomm/GenieX/cli/server/service"
 	"github.com/qualcomm/GenieX/cli/server/types"
+	"github.com/qualcomm/GenieX/cli/server/utils"
 )
 
 type CompletionNewParams openai.CompletionNewParams
@@ -145,7 +146,7 @@ func Completions(c *gin.Context) {
 	p, err := service.KeepAliveGet[geniex_sdk.LLM](
 		string(req.Model),
 		modelParam,
-		c.GetHeader("GenieX-KeepCache") != "true",
+		utils.HashText(prompt),
 	)
 	if writeKeepAliveError(c, err) {
 		return

--- a/cli/server/handler/logits.go
+++ b/cli/server/handler/logits.go
@@ -86,7 +86,7 @@ func ForwardLogits(c *gin.Context) {
 		return
 	}
 
-	p, err := service.KeepAliveGet[geniex_sdk.LLM](
+	acquired, err := service.KeepAliveGet[geniex_sdk.LLM](
 		req.Model,
 		modelParam,
 		utils.HashTokens(req.InputIDs),
@@ -94,6 +94,7 @@ func ForwardLogits(c *gin.Context) {
 	if writeKeepAliveError(c, err) {
 		return
 	}
+	p := acquired.Model
 
 	topN := defaultLogitsTopN
 	if req.TopN != nil {

--- a/cli/server/handler/logits.go
+++ b/cli/server/handler/logits.go
@@ -13,6 +13,7 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/config"
 	"github.com/qualcomm/GenieX/cli/server/service"
 	"github.com/qualcomm/GenieX/cli/server/types"
+	"github.com/qualcomm/GenieX/cli/server/utils"
 )
 
 // ForwardLogitsRequest is the body for POST /v1/logits: one prefill-only forward
@@ -88,7 +89,7 @@ func ForwardLogits(c *gin.Context) {
 	p, err := service.KeepAliveGet[geniex_sdk.LLM](
 		req.Model,
 		modelParam,
-		c.GetHeader("GenieX-KeepCache") != "true",
+		utils.HashTokens(req.InputIDs),
 	)
 	if writeKeepAliveError(c, err) {
 		return

--- a/cli/server/middleware/cors.go
+++ b/cli/server/middleware/cors.go
@@ -13,7 +13,7 @@ func CORS(c *gin.Context) {
 	h := c.Writer.Header()
 	h.Set("Access-Control-Allow-Origin", config.Get().Origins)
 	h.Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST")
-	h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, GenieX-KeepCache")
+	h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
 	h.Set("Access-Control-Max-Age", "86400")
 
 	if c.Request.Method == "OPTIONS" {

--- a/cli/server/service/BUILD.bazel
+++ b/cli/server/service/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//cli/internal/store",
         "//cli/server/middleware",
         "//cli/server/types",
+        "//cli/server/utils",
     ],
 )
 

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -78,17 +78,23 @@ func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCo
 	return mp, nil
 }
 
+// AcquiredModel is a cached model and whether it has reusable request state.
+type AcquiredModel[T any] struct {
+	Model *T
+	Fresh bool
+}
+
 // KeepAliveGet returns the cached model of type T, loading it if needed, to
 // avoid reloading from disk on every request. session identifies the
-// conversation this request belongs to.
-func KeepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (*T, error) {
-	t, err := keepAliveGet[T](name, param, session)
+// conversation this request belongs to. Fresh is true after a load or reset.
+func KeepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (AcquiredModel[T], error) {
+	t, fresh, err := keepAliveGet[T](name, param, session)
 	if err != nil {
-		return nil, err
+		return AcquiredModel[T]{}, err
 	}
 	// Stamp the idle timer at request end (only model requests reach here).
 	middleware.RunOnRelease(func() { keepAlive.lastActivity = time.Now() })
-	return t.(*T), nil
+	return AcquiredModel[T]{Model: t.(*T), Fresh: fresh}, nil
 }
 
 var keepAlive keepAliveService
@@ -158,31 +164,32 @@ func (keepAlive *keepAliveService) destroy() {
 }
 
 // keepAliveGet reuses the cached model when name and params match, otherwise
-// loads a fresh one. Either way, it resets the model when session isn't a
-// continuation of the one last served, so a new conversation never inherits
-// another's KV cache / turn state. Runs under the request GIL, so no locking
-// here.
-func keepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (any, error) {
+// loads a fresh one. It resets a reused model when session isn't a continuation
+// of the one last served, so a new conversation never inherits another's KV
+// cache / turn state. The returned bool reports whether the model is fresh
+// after either a reset or load. Runs under the request GIL, so no locking here.
+func keepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (any, bool, error) {
 	// The SDK resolves bare names / aliases and picks the default precision
 	// when none is given; pass the request string through verbatim.
 	paths, err := geniex_sdk.ModelGetPaths(name)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	slog.Debug("KeepAliveGet", "name", name, "param", param, "model_path", paths.ModelPath)
 
 	modelfile := paths.ModelPath
 
 	if keepAlive.name == name && reflect.DeepEqual(keepAlive.param, param) {
-		if !utils.IsContinuation(keepAlive.lastSession, session) {
+		fresh := !utils.IsContinuation(keepAlive.lastSession, session)
+		if fresh {
 			if r, ok := keepAlive.model.(resettable); ok {
 				if err := r.Reset(); err != nil {
-					return nil, err
+					return nil, false, err
 				}
 			}
 		}
 		keepAlive.lastSession = session
-		return keepAlive.model, nil
+		return keepAlive.model, fresh, nil
 	}
 
 	// Drop the current model so only one stays in memory.
@@ -199,7 +206,7 @@ func keepAliveGet[T any](name string, param types.ModelParam, session utils.Sess
 		if param.Spec.Type != "" && param.Spec.DraftModel != "" {
 			p, perr := resolveDraftModelPath(param.Spec.DraftModel)
 			if perr != nil {
-				return nil, perr
+				return nil, false, perr
 			}
 			draftPath = p
 		}
@@ -229,17 +236,17 @@ func keepAliveGet[T any](name string, param types.ModelParam, session utils.Sess
 			RuntimeID: paths.RuntimeID,
 		})
 	default:
-		return nil, fmt.Errorf("unsupported model type: %s", reflect.TypeFor[T]())
+		return nil, false, fmt.Errorf("unsupported model type: %s", reflect.TypeFor[T]())
 	}
 	if e != nil {
-		return nil, e
+		return nil, false, e
 	}
 	keepAlive.name = name
 	keepAlive.model = t
 	keepAlive.param = param
 	keepAlive.lastSession = session
 
-	return t, nil
+	return t, true, nil
 }
 
 // stop ends the sweep goroutine and frees the cached model — here rather than in

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -15,6 +15,7 @@ import (
 	"github.com/qualcomm/GenieX/cli/internal/render"
 	"github.com/qualcomm/GenieX/cli/server/middleware"
 	"github.com/qualcomm/GenieX/cli/server/types"
+	"github.com/qualcomm/GenieX/cli/server/utils"
 )
 
 // resolveDraftModelPath maps a spec_draft_model value to an absolute GGUF path:
@@ -78,9 +79,10 @@ func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCo
 }
 
 // KeepAliveGet returns the cached model of type T, loading it if needed, to
-// avoid reloading from disk on every request.
-func KeepAliveGet[T any](name string, param types.ModelParam, reset bool) (*T, error) {
-	t, err := keepAliveGet[T](name, param, reset)
+// avoid reloading from disk on every request. session identifies the
+// conversation this request belongs to.
+func KeepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (*T, error) {
+	t, err := keepAliveGet[T](name, param, session)
 	if err != nil {
 		return nil, err
 	}
@@ -97,16 +99,18 @@ type keepAliveService struct {
 	name         string           // cache key of the loaded model, "" when none
 	model        keepable         // nil when none
 	param        types.ModelParam // params the cache keys on
+	lastSession  utils.SessionKey // session served by the last request
 	lastActivity time.Time        // when the last model request finished
 	stopCh       chan struct{}
 }
 
-// keepable is a model the cache can free; keepResetable can also be reset.
+// keepable is a model the cache can free; resettable can also clear its
+// KV cache / turn state without a full reload.
 type keepable interface {
 	Destroy() error
 }
 
-type keepResetable interface {
+type resettable interface {
 	keepable
 	Reset() error
 }
@@ -154,8 +158,11 @@ func (keepAlive *keepAliveService) destroy() {
 }
 
 // keepAliveGet reuses the cached model when name and params match, otherwise
-// loads a fresh one. Runs under the request GIL, so no locking here.
-func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, error) {
+// loads a fresh one. Either way, it resets the model when session isn't a
+// continuation of the one last served, so a new conversation never inherits
+// another's KV cache / turn state. Runs under the request GIL, so no locking
+// here.
+func keepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (any, error) {
 	// The SDK resolves bare names / aliases and picks the default precision
 	// when none is given; pass the request string through verbatim.
 	paths, err := geniex_sdk.ModelGetPaths(name)
@@ -167,11 +174,14 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 	modelfile := paths.ModelPath
 
 	if keepAlive.name == name && reflect.DeepEqual(keepAlive.param, param) {
-		if reset {
-			if r, ok := keepAlive.model.(keepResetable); ok {
-				r.Reset()
+		if !utils.IsContinuation(keepAlive.lastSession, session) {
+			if r, ok := keepAlive.model.(resettable); ok {
+				if err := r.Reset(); err != nil {
+					return nil, err
+				}
 			}
 		}
+		keepAlive.lastSession = session
 		return keepAlive.model, nil
 	}
 
@@ -227,6 +237,7 @@ func keepAliveGet[T any](name string, param types.ModelParam, reset bool) (any, 
 	keepAlive.name = name
 	keepAlive.model = t
 	keepAlive.param = param
+	keepAlive.lastSession = session
 
 	return t, nil
 }

--- a/cli/server/utils/BUILD.bazel
+++ b/cli/server/utils/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "utils",
     srcs = [
         "common.go",
+        "hash.go",
         "toolcall.go",
         "toolcall_gemma4.go",
         "toolcall_gptoss.go",
@@ -15,6 +16,7 @@ go_library(
     importpath = "github.com/qualcomm/GenieX/cli/server/utils",
     visibility = ["//visibility:public"],
     deps = [
+        "//bindings/go:geniex_sdk_go",
         "@com_github_bytedance_sonic//:sonic",
         "@com_github_bytedance_sonic//ast",
         "@com_github_openai_openai_go_v3//:openai-go",

--- a/cli/server/utils/BUILD.bazel
+++ b/cli/server/utils/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//scripts:cgo_test.bzl", "go_cgo_test")
 
 go_library(
     name = "utils",
@@ -24,7 +25,7 @@ go_library(
     ],
 )
 
-go_test(
+go_cgo_test(
     name = "utils_test",
     srcs = [
         "common_test.go",

--- a/cli/server/utils/hash.go
+++ b/cli/server/utils/hash.go
@@ -1,0 +1,146 @@
+// Copyright 2024-2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+package utils
+
+import (
+	"encoding/binary"
+	"hash"
+	"hash/fnv"
+
+	"github.com/openai/openai-go/v3"
+
+	geniex_sdk "github.com/qualcomm/GenieX/bindings/go"
+)
+
+// SessionKey identifies a conversation as one hash per turn (chat: one per
+// message; completions/logits: a single turn). A cached model is reset when
+// the new request's key isn't a continuation of the last one served.
+type SessionKey []uint64
+
+// IsContinuation reports whether next carries on from last: the same
+// sequence of turns, with zero or more new ones appended.
+func IsContinuation(last, next SessionKey) bool {
+	if len(last) > len(next) {
+		return false
+	}
+	for i, v := range last {
+		if next[i] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// hashFields folds a turn's fields into one SessionKey element, length-prefixed
+// so ("ab","c") and ("a","bc") can't collide.
+func hashFields(fields ...string) uint64 {
+	h := fnv.New64a()
+	var lenBuf [8]byte
+	for _, f := range fields {
+		binary.LittleEndian.PutUint64(lenBuf[:], uint64(len(f)))
+		h.Write(lenBuf[:])
+		h.Write([]byte(f))
+	}
+	return h.Sum64()
+}
+
+// HashText returns the single-turn SessionKey for a plain-text prompt (the
+// /v1/completions endpoint, which has no message history).
+func HashText(text string) SessionKey {
+	return SessionKey{hashFields(text)}
+}
+
+// HashTokens returns the single-turn SessionKey for a token-ID prompt (the
+// /v1/logits endpoint, which has no text form).
+func HashTokens(ids []int32) SessionKey {
+	h := fnv.New64a()
+	writeInt32s(h, ids)
+	return SessionKey{h.Sum64()}
+}
+
+func writeInt32s(h hash.Hash, ids []int32) {
+	var buf [4]byte
+	for _, id := range ids {
+		binary.LittleEndian.PutUint32(buf[:], uint32(id))
+		h.Write(buf[:])
+	}
+}
+
+// ToolCallFields flattens tool calls into a field list for HashMessages.
+func ToolCallFields(tcs []geniex_sdk.ToolCall) []string {
+	fields := make([]string, 0, len(tcs)*3)
+	for _, tc := range tcs {
+		fields = append(fields, tc.ID, tc.Name, tc.Arguments)
+	}
+	return fields
+}
+
+// HashMessages builds a SessionKey by hashing each message's fields, as
+// produced by fields. Hash the client-sent content, not a server-derived
+// artifact (e.g. a per-request temp file path) — that would never repeat
+// across requests and so would never be recognized as a continuation.
+func HashMessages[M any](msgs []M, fields func(M) []string) SessionKey {
+	key := make(SessionKey, len(msgs))
+	for i, m := range msgs {
+		key[i] = hashFields(fields(m)...)
+	}
+	return key
+}
+
+// SessionKeyOf hashes the model-ready LLM messages GenieX is about to feed
+// the plugin, keyed stably regardless of the request's raw JSON formatting.
+func SessionKeyOf(messages []geniex_sdk.LlmChatMessage) SessionKey {
+	return HashMessages(messages, func(m geniex_sdk.LlmChatMessage) []string {
+		return append([]string{string(m.Role), m.Content, m.ToolCallID, m.ToolName}, ToolCallFields(m.ToolCalls)...)
+	})
+}
+
+// SessionKeyOfVLMRequest hashes the raw request messages, not the
+// model-ready ones buildVLMMessages produces — those carry a per-request
+// temp file path for each image/audio part instead of its source.
+func SessionKeyOfVLMRequest(msgs []openai.ChatCompletionMessageParamUnion) SessionKey {
+	return HashMessages(msgs, func(msg openai.ChatCompletionMessageParamUnion) []string {
+		fields := []string{}
+		if role := msg.GetRole(); role != nil {
+			fields = append(fields, *role)
+		}
+		switch content := msg.GetContent().AsAny().(type) {
+		case *string:
+			fields = append(fields, "text", *content)
+		case *[]openai.ChatCompletionContentPartTextParam:
+			for _, ct := range *content {
+				fields = append(fields, "text", ct.Text)
+			}
+		case *[]openai.ChatCompletionContentPartUnionParam:
+			for _, ct := range *content {
+				switch *ct.GetType() {
+				case "text":
+					fields = append(fields, "text", *ct.GetText())
+				case "image_url":
+					fields = append(fields, "image", ct.GetImageURL().URL)
+				case "input_audio":
+					fields = append(fields, "audio", ct.GetInputAudio().Data)
+				}
+			}
+		case *[]openai.ChatCompletionAssistantMessageParamContentArrayOfContentPartUnion:
+			for _, ct := range *content {
+				if *ct.GetType() == "text" {
+					fields = append(fields, "text", *ct.GetText())
+				}
+			}
+		}
+		if toolCallID := msg.GetToolCallID(); toolCallID != nil {
+			fields = append(fields, *toolCallID)
+		}
+		for _, tc := range msg.GetToolCalls() {
+			if fn := tc.GetFunction(); fn != nil {
+				fields = append(fields, fn.Name, fn.Arguments)
+			}
+			if id := tc.GetID(); id != nil {
+				fields = append(fields, *id)
+			}
+		}
+		return fields
+	})
+}


### PR DESCRIPTION
## Summary
- Replace the `GenieX-KeepCache` client header with automatic session detection: each request's messages are hashed into a `SessionKey`, and the cached model is reset only when the new key isn't a continuation of the one last served.
- VLM requests hash the raw image/audio source instead of the per-request temp file path `buildVLMMessages` creates for it, since that path is random per request and previously caused every VLM turn with media to be misdetected as a new conversation (spurious reset).

Fixes qcom-ai-hub/geniex#1480

## Test plan
- [x] `bazelisk build --test_env=PATH --action_env=PATH //cli/server/...` and `//cli/cmd/geniex` build clean
- [x] Live server (`bazelisk run ... -- serve`), LLM: fresh load / continuation / diverging conversation all reset correctly
- [x] Live server, VLM (`unsloth/Qwen3.5-2B-GGUF`): same-image continuation turn no longer triggers `Reset called`; a genuinely new conversation (different image) still does