### PR TITLE
refactor(qairt): resolve the runtime path in one place, reachable from every binding

### DIFF
--- a/bindings/android/app/src/main/cpp/geniex_sdk.cpp
+++ b/bindings/android/app/src/main/cpp/geniex_sdk.cpp
@@ -83,3 +83,16 @@ extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_GenieXSdk_getPluginVers
     const char* result = geniex_get_plugin_version(id.c_str());
     return env->NewStringUTF(result ? result : "");
 }
+
+// Reaching this from Kotlin needs native code: the JVM has no setenv, so the
+// GENIEX_QNN_LIB fallback the other bindings can use is not available here.
+extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_GenieXSdk_setQairtRuntimePath(
+    JNIEnv* env, jobject thiz, jstring path) {
+    std::string p = jstring2str(env, path);
+    return geniex_set_qairt_runtime_path(p.c_str());
+}
+
+extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_GenieXSdk_getQairtRuntimePath(JNIEnv* env, jobject thiz) {
+    const char* result = geniex_get_qairt_runtime_path();
+    return env->NewStringUTF(result ? result : "");
+}

--- a/bindings/android/app/src/main/java/com/geniex/sdk/GenieXSdk.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/GenieXSdk.kt
@@ -18,6 +18,20 @@ class GenieXSdk private constructor() {
 
     external fun getPluginVersion(pluginId: String): String
 
+    /**
+     * Load the QAIRT runtime from [path] instead of the one bundled in the APK, for
+     * running against another QAIRT version. [path] is either a QAIRT SDK root or a
+     * flat folder of QNN libraries, pushed somewhere the app can read; "" restores the
+     * bundled runtime. Ignored by other plugins.
+     *
+     * Process-global, because the QNN libraries load once per process. Call before
+     * creating the model that should use it; an unusable path is reported when that
+     * model is created, not here.
+     */
+    external fun setQairtRuntimePath(path: String): Int
+
+    external fun getQairtRuntimePath(): String
+
     // Idempotent across Activity recreation. Plugin registration is
     // safe to re-attempt (it logs and moves on); model-manager init is
     // not — the FFI rejects re-init — so we guard it here.

--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -88,6 +88,20 @@ func SetLog(enable bool) {
 	}
 }
 
+// SetQairtRuntimePath loads the QAIRT runtime from path instead of the one bundled
+// with the qairt plugin, for running against another QAIRT version without
+// rebuilding. path is either a QAIRT SDK root or a flat folder of QNN libraries;
+// "" restores the bundled runtime. Ignored by other plugins.
+//
+// Process-global rather than per-model, because the QNN libraries load once per
+// process. Call before creating the model that should use it. An unusable path is
+// reported when that model is created, not here.
+func SetQairtRuntimePath(path string) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	C.geniex_set_qairt_runtime_path(cPath)
+}
+
 // GetPluginVersion returns the version the plugin reports for itself (QAIRT
 // runtime version, llama.cpp build commit, …). Empty string if not registered.
 func GetPluginVersion(pluginID string) string {

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -178,6 +178,7 @@ interrupts the current reply. `geniex-py <cmd> --help` for all flags.
 | `GENIEX_HFTOKEN`   | HuggingFace token for gated repos.                   |
 | `GENIEX_LIB_PATH`  | Point at a pre-built `libgeniex.so` / `geniex.dll`.  |
 | `GENIEX_LOG`       | Log level: `trace`/`debug`/`info`/`warn`/`error`/`none`. Default `info`. |
+| `GENIEX_QNN_LIB`   | Run the `qairt` plugin against another QAIRT runtime: a QAIRT SDK root or a flat folder of QNN libraries. A runtime is bundled and used by default. `geniex.set_qairt_runtime_path()` does the same thing and takes precedence. |
 
 ## Logging
 

--- a/bindings/python/geniex/__init__.py
+++ b/bindings/python/geniex/__init__.py
@@ -7,9 +7,11 @@ from ._ffi._api import (
     deinit,
     get_compute_unit_list,
     get_plugin_version,
+    get_qairt_runtime_path,
     get_runtime_list,
     init,
     set_log_level,
+    set_qairt_runtime_path,
     version,
 )
 from ._version import __version__
@@ -30,6 +32,8 @@ __all__ = [
     'init',
     'deinit',
     'set_log_level',
+    'set_qairt_runtime_path',
+    'get_qairt_runtime_path',
     'version',
     'get_plugin_version',
     'get_runtime_list',

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -160,6 +160,12 @@ def _bind_all() -> None:
     lib.geniex_version.argtypes = []
     lib.geniex_version.restype = c_char_p
 
+    lib.geniex_set_qairt_runtime_path.argtypes = [c_char_p]
+    lib.geniex_set_qairt_runtime_path.restype = c_int32
+
+    lib.geniex_get_qairt_runtime_path.argtypes = []
+    lib.geniex_get_qairt_runtime_path.restype = c_char_p
+
     lib.geniex_get_plugin_version.argtypes = [c_char_p]
     lib.geniex_get_plugin_version.restype = c_char_p
 
@@ -452,6 +458,28 @@ def version() -> str:
     _ensure_bound()
     lib = load_library()
     return lib.geniex_version().decode()
+
+
+def set_qairt_runtime_path(path: str) -> None:
+    """Load the QAIRT runtime from ``path`` instead of the one bundled with the plugin.
+
+    ``path`` is either a QAIRT SDK root or a flat folder of QNN libraries; ``""``
+    restores the bundled runtime. Ignored by other plugins.
+
+    Process-global rather than per-model, because the QNN libraries load once per
+    process. Call before creating the model that should use it; an unusable path is
+    reported when that model is created, not here.
+    """
+    _ensure_bound()
+    lib = load_library()
+    lib.geniex_set_qairt_runtime_path(path.encode() if path else None)
+
+
+def get_qairt_runtime_path() -> str:
+    """Return the path set by :func:`set_qairt_runtime_path`, or ``""`` when unset."""
+    _ensure_bound()
+    lib = load_library()
+    return (lib.geniex_get_qairt_runtime_path() or b'').decode()
 
 
 def get_plugin_version(plugin_id: str) -> str:

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -82,7 +82,7 @@ var (
 		llmFlags := pflag.NewFlagSet("LLM/VLM Model", pflag.ExitOnError)
 		llmFlags.SortFlags = false
 		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, hybrid, or an explicit device list like HTP0,HTP1,HTP2,HTP3 (llama_cpp only) (default: npu)")
-		llmFlags.StringVarP(&qnnLib, "qnn-lib", "", "", "run against a different QAIRT runtime: path to a QAIRT SDK root or a folder of QNN libraries (qairt only; sets GENIEX_QNN_LIB; optional — a QAIRT runtime is bundled and used by default)")
+		llmFlags.StringVarP(&qnnLib, "qnn-lib", "", "", "run against a different QAIRT runtime: path to a QAIRT SDK root or a folder of QNN libraries (qairt only; overrides GENIEX_QNN_LIB; optional — a QAIRT runtime is bundled and used by default)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
 		llmFlags.Int32VarP(&nctx, "nctx", "", 4096, "context window size; raise to extend context (llama_cpp only)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")
@@ -143,12 +143,8 @@ func infer() *cobra.Command {
 			return err
 		}
 
-		// Exported rather than passed down so every path in this process -- LLM, VLM, any
-		// binding -- picks the override up the same way.
 		if qnnLib != "" {
-			if err := os.Setenv("GENIEX_QNN_LIB", qnnLib); err != nil {
-				return fmt.Errorf("failed to set GENIEX_QNN_LIB: %w", err)
-			}
+			geniex_sdk.SetQairtRuntimePath(qnnLib)
 		}
 
 		if err := common.InitSDK(); err != nil {

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -59,13 +58,10 @@ func serve() *cobra.Command {
 	serveCmd.Run = func(cmd *cobra.Command, args []string) {
 		checkAudioDependency()
 
-		// Exported rather than passed down, matching `infer`: every model the server
-		// loads, LLM or VLM, then picks the override up the same way.
+		// Applies to every model the server loads, LLM or VLM: the QNN libraries load
+		// once per process, so this cannot be a per-request setting.
 		if qnnLib := viper.GetString("qnnlib"); qnnLib != "" {
-			if err := os.Setenv("GENIEX_QNN_LIB", qnnLib); err != nil {
-				common.PrintError(fmt.Errorf("failed to set GENIEX_QNN_LIB: %w", err))
-				os.Exit(1)
-			}
+			geniex_sdk.SetQairtRuntimePath(qnnLib)
 		}
 
 		if err := common.InitSDK(); err != nil {

--- a/notes/run.md
+++ b/notes/run.md
@@ -115,12 +115,31 @@ A QAIRT runtime ships with GenieX and is used by default. To run against a diffe
 without reinstalling, point the plugin at it:
 
 ```bash
-# via the CLI flag (qairt models only)
+# via the CLI flag (qairt models only; also on `geniex serve`)
 geniex infer local/granite4_micro --qnn-lib /path/to/qairt/2.XX.0
 
-# or via the environment variable (picked up by any front-end: CLI, pybind, Android)
+# or via the environment variable, for any process that can set one
 GENIEX_QNN_LIB=/path/to/qairt/2.XX.0 geniex infer local/granite4_micro
 ```
+
+Embedders set it explicitly instead, which is the only route open to Android — the JVM has
+no `setenv`, so the environment variable above is unreachable from an app:
+
+```python
+geniex.set_qairt_runtime_path('/path/to/qairt/2.XX.0')   # before creating the model
+```
+
+```go
+geniex_sdk.SetQairtRuntimePath("/path/to/qairt/2.XX.0")
+```
+
+```kotlin
+GenieXSdk.getInstance().setQairtRuntimePath("/path/to/qairt/2.XX.0")
+```
+
+An explicit path wins over `GENIEX_QNN_LIB`. It is process-global in every binding, because
+the QNN libraries load once per process — two models cannot run against different QAIRT
+versions.
 
 The path accepts either layout:
 
@@ -136,11 +155,15 @@ The path accepts either layout:
 > the override resolved where you meant. Run with `--log info` (the CLI default is `none`):
 >
 > ```
-> Overriding the bundled QAIRT runtime from GENIEX_QNN_LIB: <what you passed> (host libs: <resolved dir>)
+> Loading the QAIRT runtime from <what you passed> rather than the bundled one
+> HTP runtime path: <resolved dir> (overridden via QnnRuntimeConfig::htp_dir)
+> Host libraries taken from <resolved dir> (a QAIRT SDK root was given)
 > ```
 >
-> `host libs:` is the part that matters — for an SDK root it is the `lib/<triple>` subfolder,
-> not the root you passed.
+> `HTP runtime path:` is the part that matters — for an SDK root it is the `lib/<triple>`
+> subfolder, not the root you passed, and the third line only appears in that case. Setting
+> `GENIEX_QNN_LIB` rather than an explicit path says `(overridden via GENIEX_QNN_LIB)`
+> instead, and omits the first line.
 
 <details><summary>Which runtimes are accepted, and why this is a supported override</summary>
 
@@ -158,9 +181,17 @@ which is why this is a supported override rather than a testing-only aid.
 `htp_backend_ext_config.json` itself through the public C API — so a runtime folder does not
 need to carry it.
 
-`--qnn-lib` just sets `GENIEX_QNN_LIB` for the process, so the flag wins when both are given.
-An unusable path fails model load immediately, e.g. `GENIEX_QNN_LIB does not contain
-QnnHtp.dll (looked in the folder itself and lib/aarch64-windows-msvc): <path>`.
+`--qnn-lib` passes the path down through the SDK rather than exporting it, so the flag wins
+when both it and `GENIEX_QNN_LIB` are given. Resolution belongs entirely to the plugin: this
+repo neither validates the path nor derives library names from it. An unusable path fails
+model creation immediately, naming both accepted layouts:
+
+```
+geniex: QnnHtp.dll not found in HTP runtime folder: <path>
+  (from QnnRuntimeConfig::htp_dir)
+Expected either a flat directory holding QnnHtp.dll and its arch stubs (shaped like the
+bundled htp-files/), or a QAIRT SDK root with lib/aarch64-windows-msvc/.
+```
 
 </details>
 

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -187,6 +187,40 @@ GENIEX_API int32_t geniex_deinit(void);
 GENIEX_API int32_t geniex_set_log(geniex_log_callback callback);
 
 /**
+ * @brief Load the QAIRT runtime from `path` instead of the one bundled with the plugin
+ *
+ * Optional: a QAIRT runtime ships with the qairt plugin and is used by default, so
+ * this is for running against another QAIRT version without rebuilding. Ignored by
+ * other plugins.
+ *
+ * `path` may be either a QAIRT SDK root or a flat folder of QNN libraries; the
+ * plugin tells them apart. Pass NULL or "" to go back to the bundled runtime.
+ *
+ * Process-global rather than per-model, because the QNN libraries load once per
+ * process: two models cannot run against different QAIRT versions. Set it before
+ * creating the model that should use it. Takes precedence over GENIEX_QNN_LIB.
+ *
+ * @param path[in]: Runtime directory, or NULL to unset. Copied; the caller keeps
+ *                  ownership. Not validated here — an unusable path fails model
+ *                  creation with a message naming the layouts it looked for.
+ *
+ * @return geniex_ErrorCode: GENIEX_SUCCESS on success, negative on failure.
+ *
+ * @thread_safety: Not thread-safe against concurrent model creation.
+ */
+GENIEX_API int32_t geniex_set_qairt_runtime_path(const char* path);
+
+/**
+ * @brief Read back what geniex_set_qairt_runtime_path() stored
+ *
+ * @return Null-terminated UTF-8 string, "" when unset. Owned by the library; valid
+ *         until the next geniex_set_qairt_runtime_path() call. Never NULL.
+ *
+ * @thread_safety: Not thread-safe against geniex_set_qairt_runtime_path().
+ */
+GENIEX_API const char* geniex_get_qairt_runtime_path(void);
+
+/**
  * @brief Simple wrapper around free() to free memory allocated by ML library functions
  *
  * @param ptr[in]: The pointer to free.

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -3,44 +3,14 @@
 
 #pragma once
 
-#if defined(_WIN32)
-#include <windows.h>
-#endif
-
-#include <cstdlib>
 #include <filesystem>
 #include <optional>
-#include <stdexcept>
 #include <string>
-#include <vector>
 
+#include "geniex.h"  // geniex_get_qairt_runtime_path
 #include "types.h"
 
 namespace geniex::qairt::runtime {
-
-// Reads an environment variable as a path; empty when unset. Takes both spellings of the
-// name because Windows needs the wide-char API for Unicode paths to round-trip.
-inline std::filesystem::path read_env_path(const char* name_utf8, const wchar_t* name_wide) {
-#if defined(_WIN32)
-    static_cast<void>(name_utf8);
-    size_t required_size = 0;
-    _wgetenv_s(&required_size, nullptr, 0, name_wide);
-    if (required_size > 0) {
-        std::vector<wchar_t> env_buffer(required_size);
-        _wgetenv_s(&required_size, env_buffer.data(), required_size, name_wide);
-        if (env_buffer[0] != L'\0') {
-            return std::filesystem::path(env_buffer.data());
-        }
-    }
-    return {};
-#else   // _WIN32
-    static_cast<void>(name_wide);
-    if (const char* value = std::getenv(name_utf8)) {
-        return std::filesystem::path(value);
-    }
-    return {};
-#endif  // _WIN32
-}
 
 // NOTE: no `collect_bin_files()` helper here on purpose. Context-binary shards must
 // come from genie_config.json's `ctx-bins` via the core's `modelConfigFromDirectory()`,
@@ -54,128 +24,22 @@ inline std::optional<std::string> find_optional_file(const std::filesystem::path
     return std::nullopt;
 }
 
-// QNN library names, the SDK's host-lib subfolder, and the OS PATH separator, by platform.
-#if defined(_WIN32)
-constexpr const char* kQnnBackendLib    = "QnnHtp.dll";
-constexpr const char* kQnnSystemLib     = "QnnSystem.dll";
-constexpr const char* kQnnExtensionsLib = "QnnHtpNetRunExtensions.dll";
-constexpr const char* kHostLibTriple    = "aarch64-windows-msvc";
-constexpr char        kPathSep          = ';';
-#elif defined(__ANDROID__)
-constexpr const char* kQnnBackendLib    = "libQnnHtp.so";
-constexpr const char* kQnnSystemLib     = "libQnnSystem.so";
-constexpr const char* kQnnExtensionsLib = "libQnnHtpNetRunExtensions.so";
-constexpr const char* kHostLibTriple    = "aarch64-android";
-constexpr char        kPathSep          = ':';
-#else  // __linux__
-constexpr const char* kQnnBackendLib    = "libQnnHtp.so";
-constexpr const char* kQnnSystemLib     = "libQnnSystem.so";
-constexpr const char* kQnnExtensionsLib = "libQnnHtpNetRunExtensions.so";
-constexpr const char* kHostLibTriple    = "aarch64-oe-linux-gcc11.2";
-constexpr char        kPathSep          = ':';
-#endif
-
-// Finds the directory holding the host QNN libraries under `root`, which may be either a
-// flat folder or a QAIRT SDK install. Empty when neither layout matches.
-inline std::filesystem::path locate_qnn_host_lib_dir(const std::filesystem::path& root) {
-    namespace fs = std::filesystem;
-    std::error_code ec;
-
-    // Flat folder: libs directly inside root.
-    if (fs::exists(root / kQnnBackendLib, ec)) return root;
-
-    // QAIRT SDK: canonical per-platform triple.
-    const fs::path triple_dir = root / "lib" / kHostLibTriple;
-    if (fs::exists(triple_dir / kQnnBackendLib, ec)) return triple_dir;
-
-    // Fallback for triples that vary across SDK versions (e.g. differing Linux gcc suffixes).
-    const fs::path lib_dir = root / "lib";
-    if (fs::is_directory(lib_dir, ec)) {
-        for (const auto& entry : fs::directory_iterator(lib_dir, ec)) {
-            if (entry.is_directory(ec) && fs::exists(entry.path() / kQnnBackendLib, ec)) {
-                return entry.path();
-            }
-        }
-    }
-    return {};
-}
-
-// Builds an ADSP_LIBRARY_PATH covering every Hexagon skel folder in a QAIRT SDK, so QNN's
-// loader can pick the one matching the on-device HTP arch. Empty when `root` ships no skels.
-inline std::string collect_adsp_library_path(const std::filesystem::path& root) {
-    namespace fs = std::filesystem;
-    std::error_code          ec;
-    std::vector<std::string> dirs;
-
-    const fs::path lib_dir = root / "lib";
-    if (fs::is_directory(lib_dir, ec)) {
-        for (const auto& entry : fs::directory_iterator(lib_dir, ec)) {
-            if (!entry.is_directory(ec)) continue;
-            if (entry.path().filename().string().rfind("hexagon-", 0) != 0) continue;
-            const fs::path unsigned_dir = entry.path() / "unsigned";
-            dirs.push_back(fs::is_directory(unsigned_dir, ec) ? unsigned_dir.string() : entry.path().string());
-        }
-    }
-
-    std::sort(dirs.begin(), dirs.end());
-    std::string joined;
-    for (const auto& d : dirs) {
-        if (!joined.empty()) joined.push_back(kPathSep);
-        joined += d;
-    }
-    return joined;
-}
-
-// Returns a QnnRuntimeConfig for the given model directory.
+// Returns the QnnRuntimeConfig every model in this plugin is created with.
 //
-// GENIEX_QNN_LIB (or the CLI `--qnn-lib` flag) is an optional override; unset, the config
-// stays empty and the plugin resolves its own bundled runtime. Set, we pin all three path
-// fields, which the plugin then honors as-is -- translating an SDK root is our job because
-// the plugin only understands the flat layout. Throws when set but unusable.
-inline QnnRuntimeConfig make_qnn_runtime_config(const std::filesystem::path& model_dir) {
-    namespace fs = std::filesystem;
-
+// A runtime path set through geniex_set_qairt_runtime_path() is handed down as-is:
+// the plugin owns resolution -- both accepted directory layouts, the GENIEX_QNN_LIB
+// fallback, ADSP_LIBRARY_PATH and the Windows DLL search path -- so nothing here
+// interprets or validates it. Unset leaves every field empty, which is how the plugin
+// is told to use the QAIRT runtime it bundles.
+inline QnnRuntimeConfig make_qnn_runtime_config() {
     QnnRuntimeConfig runtime_cfg{};
 
-    const fs::path qnn_lib_root = read_env_path("GENIEX_QNN_LIB", L"GENIEX_QNN_LIB");
-    if (qnn_lib_root.empty()) {
-        GENIEX_LOG_DEBUG("GENIEX_QNN_LIB unset; using the QAIRT runtime bundled with the plugin");
-        static_cast<void>(model_dir);
-        return runtime_cfg;
+    const char* path = geniex_get_qairt_runtime_path();
+    if (path != nullptr && *path != '\0') {
+        GENIEX_LOG_INFO("Loading the QAIRT runtime from {} rather than the bundled one", path);
+        runtime_cfg.htp_dir = path;
     }
 
-    std::error_code ec;
-    if (!fs::is_directory(qnn_lib_root, ec)) {
-        throw std::runtime_error("GENIEX_QNN_LIB path is not a directory: " + qnn_lib_root.string() +
-                                 "\nUnset it to use the QAIRT runtime bundled with the plugin.");
-    }
-    const fs::path host_dir = locate_qnn_host_lib_dir(qnn_lib_root);
-    if (host_dir.empty()) {
-        throw std::runtime_error("GENIEX_QNN_LIB does not contain " + std::string(kQnnBackendLib) +
-                                 " (looked in the folder itself and lib/" + kHostLibTriple +
-                                 "): " + qnn_lib_root.string() +
-                                 "\nUnset it to use the QAIRT runtime bundled with the plugin.");
-    }
-
-    // A QAIRT SDK keeps skels apart from the host libs; a flat folder has them together.
-    std::string adsp_path = collect_adsp_library_path(qnn_lib_root);
-    if (adsp_path.empty()) adsp_path = host_dir.string();
-
-    GENIEX_LOG_INFO("Overriding the bundled QAIRT runtime from GENIEX_QNN_LIB: {} (host libs: {})",
-        qnn_lib_root.string(),
-        host_dir.string());
-    GENIEX_LOG_DEBUG("Setting ADSP_LIBRARY_PATH to {}", adsp_path);
-#if defined(_WIN32)
-    _putenv_s("ADSP_LIBRARY_PATH", adsp_path.c_str());
-    SetDllDirectoryA(host_dir.string().c_str());
-#else
-    setenv("ADSP_LIBRARY_PATH", adsp_path.c_str(), 1);
-#endif
-    runtime_cfg.backend_path    = (host_dir / kQnnBackendLib).string();
-    runtime_cfg.system_lib_path = (host_dir / kQnnSystemLib).string();
-    runtime_cfg.extensions_path = (host_dir / kQnnExtensionsLib).string();
-
-    static_cast<void>(model_dir);
     return runtime_cfg;
 }
 

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -62,7 +62,7 @@ int32_t QairtLlm::create(const geniex_LlmCreateInput* input) {
 
     bundle_sampler_ = parseGenieSamplerConfig(model_dir);
 
-    QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config(model_dir);
+    QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config();
 
     // Bundle layout comes from the QAIRT core: `modelConfigFromDirectory` reads
     // genie_config.json's `dialog.engine.model.binary.ctx-bins` and takes only

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -60,7 +60,7 @@ int32_t QairtVlm::create(const geniex_VlmCreateInput* input) {
 
     bundle_sampler_ = parseGenieSamplerConfig(model_dir);
 
-    QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config(model_dir);
+    QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config();
 
     // Resolve vision encoder path first so we can exclude it from LLM shards.
     std::string resolved_vision_bin;

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 #include "build_config.h"
 #include "logging.h"
@@ -136,6 +137,19 @@ int32_t geniex_set_log(geniex_log_callback callback) {
     geniex_log = callback;
     return GENIEX_SUCCESS;
 }
+
+// QAIRT runtime override
+
+// Read by the qairt plugin while creating a model, so the documented contract is
+// set-before-create; nothing here guards against a concurrent create.
+static std::string qairt_runtime_path;
+
+int32_t geniex_set_qairt_runtime_path(const char* path) {
+    qairt_runtime_path = (path != nullptr) ? path : "";
+    return GENIEX_SUCCESS;
+}
+
+const char* geniex_get_qairt_runtime_path(void) { return qairt_runtime_path.c_str(); }
 
 void geniex_free(void* ptr) {
     if (ptr) free(ptr);


### PR DESCRIPTION
Follow-up (b) from @vinovo's review on #1389: the runtime path is now resolved in exactly one place. Stacked on `AIHW/workbench-build` (#1389) — retarget to `main` once that merges.

1. **Deletes the duplication.** `make_qnn_runtime_config` sets `htp_dir` and nothing else — 150 lines gone from this repo.
2. **Fixes a contradiction**: this layer accepted a QAIRT SDK root while the plugin errored on one, for the same env var.
3. **New C API**: `geniex_set_qairt_runtime_path()` / `geniex_get_qairt_runtime_path()` — answers "why don't we pass it down to cgo?"
4. **Reaches every binding**: Go, Python, Kotlin/JNI. Android could not set this at all before — the JVM has no `setenv`.
5. `--qnn-lib` passes the path down instead of exporting `GENIEX_QNN_LIB`; the variable stays as a fallback.
6. Submodule bumped to plugin `4dbb6a1` (needed: it carries the SDK-root support).

Not built locally — no Go toolchain or NDK on this machine. Details below.

<details><summary>Why a process-global setter rather than a geniex_ModelConfig field</summary>

A `geniex_ModelConfig` field would have matched the existing plumbing for `chat_template_path` and friends, but it would promise something we cannot deliver: the QNN libraries load once per process, so two models in one process cannot run against different QAIRT versions. A per-model field says otherwise. It also changes a struct that four bindings mirror by layout, which has to land in lockstep or corrupt memory silently; a new function is additive and each binding is a one-line wrapper.

`geniex_set_log` is the precedent for a process-global setter in this API. The getter exists so the qairt plugin layer can read the value back rather than keeping a second copy of the state.

**Precedence**, highest first: explicit path (API or `--qnn-lib`) → `GENIEX_QNN_LIB` → bundled runtime. The plugin owns all three rungs.

</details>

<details><summary>What the two layers each used to do</summary>

| | this layer, before | plugin |
|---|---|---|
| read `GENIEX_QNN_LIB` | yes | yes |
| set `ADSP_LIBRARY_PATH` | always | only when the folder holds skels |
| `SetDllDirectory` | yes | yes |
| accept a QAIRT SDK root | yes | **no — errored on it** |

The plugin used to say *"This looks like a QAIRT SDK root. Point `GENIEX_QNN_LIB` at the host library directory itself … not the SDK root"* for exactly the layout this layer translated, so a plugin-direct user and a GenieX user got opposite answers from one variable.

One subtlety for anyone tracing the old behaviour: `resolveHtpPaths` returns early when all three library paths are set, and this layer pinned all three — so on the override path the plugin never ran its resolver and never set ADSP. The SDK-side ADSP code was compensating for a short-circuit it caused. Passing `htp_dir` instead of three pinned paths is what makes deleting it safe.

</details>

<details><summary>Verification, and what is not verified</summary>

Checked locally:
- `clang-format` clean on all six changed C/C++ files. Confirmed my local clang-format agrees with the repo baseline on untouched files first, since CI pins 18 and mine is newer.
- `ruff check` clean; `ruff format` reports only a pre-existing line I did not touch, so I left it.
- Python files parse; the diff is line-for-line consistent with the `geniex_set_log` / `version` wrappers next to it.
- No line-ending churn (the two `.cpp` call sites are a one-line diff each).

**Not** verified, and worth a reviewer's attention:
- **No Go, NDK or SDK build ran.** There is no Go toolchain or Android NDK on this machine, so `build-cli`, `build-android-aar` and `build-sdk` in CI are the first compile of every line here. The JNI symbol names and the Kotlin `external fun` signatures are matched by hand.
- **No on-device run.** The SDK-root path has never actually loaded a model — neither here nor in geniex-qairt-plugin#51, which covered it with unit tests only. Before this is trusted, one run with `--qnn-lib` pointed at a real 2.48 or 2.49 SDK root, checking the generated text and not just that it loads: a mismatched runtime produces garbage at full speed rather than failing.
- `geniex_set_qairt_runtime_path` is documented as not thread-safe against concurrent model creation, matching how the rest of the global setters behave. Nothing enforces it.

</details>
