### PR TITLE
rename(cli): --qnn-lib -> --qairt-lib

### DIFF
--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -40,7 +40,7 @@ var (
 	input         string
 	systemPrompt  string
 	computeUnit   string
-	qnnLib        string
+	qairtLib      string
 	slidingWindow bool
 	specType      string
 	draftModel    string
@@ -82,7 +82,7 @@ var (
 		llmFlags := pflag.NewFlagSet("LLM/VLM Model", pflag.ExitOnError)
 		llmFlags.SortFlags = false
 		llmFlags.StringVarP(&computeUnit, "compute", "c", "", "compute unit to run on: cpu, gpu, npu, hybrid, or an explicit device list like HTP0,HTP1,HTP2,HTP3 (llama_cpp only) (default: npu)")
-		llmFlags.StringVarP(&qnnLib, "qnn-lib", "", "", "run against a different QAIRT runtime: path to a QAIRT SDK root or a folder of QNN libraries (qairt only; sets GENIEX_QAIRT_LIB; optional — a QAIRT runtime is bundled and used by default)")
+		llmFlags.StringVarP(&qairtLib, "qairt-lib", "", "", "run against a different QAIRT runtime: path to a QAIRT SDK root or a folder of QNN libraries (qairt only; sets GENIEX_QAIRT_LIB; optional — a QAIRT runtime is bundled and used by default)")
 		llmFlags.Int32VarP(&ngl, "ngl", "n", -1, "number of layers to offload to gpu/npu, -1 = all (llama_cpp only)")
 		llmFlags.Int32VarP(&nctx, "nctx", "", 4096, "context window size; raise to extend context (llama_cpp only)")
 		llmFlags.Int32VarP(&maxTokens, "max-tokens", "", 2048, "max tokens")
@@ -145,8 +145,8 @@ func infer() *cobra.Command {
 
 		// Exported rather than passed down so every path in this process -- LLM, VLM, any
 		// binding -- picks the override up the same way.
-		if qnnLib != "" {
-			if err := os.Setenv("GENIEX_QAIRT_LIB", qnnLib); err != nil {
+		if qairtLib != "" {
+			if err := os.Setenv("GENIEX_QAIRT_LIB", qairtLib); err != nil {
 				return fmt.Errorf("failed to set GENIEX_QAIRT_LIB: %w", err)
 			}
 		}

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -36,7 +36,7 @@ func serve() *cobra.Command {
 	serveCmd.Flags().Int32("nctx", 4096, "Default context window size, llama_cpp only (env: GENIEX_NCTX)")
 	serveCmd.Flags().Int32P("ngl", "n", -1, "Default layers to offload to gpu/npu, -1 = all, llama_cpp only (env: GENIEX_NGL)")
 	serveCmd.Flags().StringP("compute", "c", "", "Default compute unit: cpu, gpu, npu, or hybrid (env: GENIEX_COMPUTE)")
-	serveCmd.Flags().String("qnn-lib", "", "Run against a different QAIRT runtime: path to a QAIRT SDK root or a folder of QNN libraries, qairt only (env: GENIEX_QAIRT_LIB)")
+	serveCmd.Flags().String("qairt-lib", "", "Run against a different QAIRT runtime: path to a QAIRT SDK root or a folder of QNN libraries, qairt only (env: GENIEX_QAIRT_LIB)")
 	// HTTPS / TLS flags
 	serveCmd.Flags().Bool("https", false, "Enable HTTPS/TLS (env: GENIEX_HTTPS)")
 	serveCmd.Flags().String("certfile", "cert.pem", "TLS certificate file path (env: GENIEX_CERTFILE)")
@@ -48,10 +48,10 @@ func serve() *cobra.Command {
 	viper.BindPFlag("nctx", serveCmd.Flags().Lookup("nctx"))
 	viper.BindPFlag("ngl", serveCmd.Flags().Lookup("ngl"))
 	viper.BindPFlag("compute", serveCmd.Flags().Lookup("compute"))
-	viper.BindPFlag("qnnlib", serveCmd.Flags().Lookup("qnn-lib"))
+	viper.BindPFlag("qairtlib", serveCmd.Flags().Lookup("qairt-lib"))
 	// Bound explicitly so the plugin's own spelling is the only one that works;
-	// AutomaticEnv would otherwise make GENIEX_QNNLIB a silent second alias.
-	viper.BindEnv("qnnlib", "GENIEX_QAIRT_LIB")
+	// AutomaticEnv would otherwise make GENIEX_QAIRTLIB a silent second alias.
+	viper.BindEnv("qairtlib", "GENIEX_QAIRT_LIB")
 	viper.BindPFlag("enablehttps", serveCmd.Flags().Lookup("https"))
 	viper.BindPFlag("certfile", serveCmd.Flags().Lookup("certfile"))
 	viper.BindPFlag("keyfile", serveCmd.Flags().Lookup("keyfile"))
@@ -61,8 +61,8 @@ func serve() *cobra.Command {
 
 		// Exported rather than passed down, matching `infer`: every model the server
 		// loads, LLM or VLM, then picks the override up the same way.
-		if qnnLib := viper.GetString("qnnlib"); qnnLib != "" {
-			if err := os.Setenv("GENIEX_QAIRT_LIB", qnnLib); err != nil {
+		if qairtLib := viper.GetString("qairtlib"); qairtLib != "" {
+			if err := os.Setenv("GENIEX_QAIRT_LIB", qairtLib); err != nil {
 				common.PrintError(fmt.Errorf("failed to set GENIEX_QAIRT_LIB: %w", err))
 				os.Exit(1)
 			}

--- a/notes/run.md
+++ b/notes/run.md
@@ -116,7 +116,7 @@ without reinstalling, point the plugin at it:
 
 ```bash
 # via the CLI flag (qairt models only)
-geniex infer local/granite4_micro --qnn-lib /path/to/qairt/2.XX.0
+geniex infer local/granite4_micro --qairt-lib /path/to/qairt/2.XX.0
 
 # or via the environment variable (picked up by any front-end: CLI, pybind, Android)
 GENIEX_QAIRT_LIB=/path/to/qairt/2.XX.0 geniex infer local/granite4_micro
@@ -158,7 +158,7 @@ which is why this is a supported override rather than a testing-only aid.
 `htp_backend_ext_config.json` itself through the public C API — so a runtime folder does not
 need to carry it.
 
-`--qnn-lib` just sets `GENIEX_QAIRT_LIB` for the process, so the flag wins when both are given.
+`--qairt-lib` just sets `GENIEX_QAIRT_LIB` for the process, so the flag wins when both are given.
 An unusable path fails model load immediately, e.g. `GENIEX_QAIRT_LIB does not contain
 QnnHtp.dll (looked in the folder itself and lib/aarch64-windows-msvc): <path>`.
 

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -128,7 +128,7 @@ inline std::string collect_adsp_library_path(const std::filesystem::path& root) 
 
 // Returns a QnnRuntimeConfig for the given model directory.
 //
-// GENIEX_QAIRT_LIB (or the CLI `--qnn-lib` flag) is an optional override; unset, the config
+// GENIEX_QAIRT_LIB (or the CLI `--qairt-lib` flag) is an optional override; unset, the config
 // stays empty and the plugin resolves its own bundled runtime. Set, we pin all three path
 // fields, which the plugin then honors as-is -- translating an SDK root is our job because
 // the plugin only understands the flat layout. Throws when set but unusable.


### PR DESCRIPTION
## Summary

Renames the geniex infer / geniex serve CLI flag from --qnn-lib to --qairt-lib, to match GENIEX_QAIRT_LIB (the env var it sets), renamed from GENIEX_QNN_LIB per review on #1389.

The flag itself was left unrenamed at the time — this closes that gap.
