### PR TITLE
fix(llama_cpp): disable OpenCL backend to avoid Adreno CB.dll crash on Windows-on-Snapdragon

### DIFF
--- a/sdk/plugins/llama_cpp/CMakeLists.txt
+++ b/sdk/plugins/llama_cpp/CMakeLists.txt
@@ -3,6 +3,12 @@
 set(GGML_BLAS OFF)
 set(GGML_NATIVE OFF)
 set(GGML_BACKEND_DL OFF)
+# Qualcomm Adreno OpenCL driver (CB.dll) fail-fast crashes (0xC0000409) any
+# process that calls clGetPlatformIDs on Windows-on-Snapdragon builds (26000+).
+# llama.cpp's OpenCL backend initializes at startup regardless of --compute,
+# so linking it poisons the whole process. Hexagon (NPU) + CPU backends cover
+# the Snapdragon NPU/CPU path and do not touch the OpenCL driver; disable it.
+set(GGML_OPENCL OFF)
 
 set(LLAMA_BUILD_COMMON ON)
 set(LLAMA_CURL OFF)


### PR DESCRIPTION
## Problem

On Windows-on-Snapdragon (OS build 26000+), **every GGUF/llama_cpp model crashes the geniex serve process** with exit code `0xC0000409` (STATUS_STACK_BUFFER_OVERRUN / fail-fast) — before any inference begins. Qairt models work fine.

## Root cause

The Qualcomm **Adreno OpenCL driver (`CB.dll`, v32.0.172.0**, in the `qcdx8480` driver store) **fail-fast crashes any process that calls `clGetPlatformIDs`**.

llama.cpp's OpenCL backend (used for Adreno GPU offload) initializes at startup **regardless of `--compute cpu/npu`**, because `ggml.dll` statically imports `ggml-opencl.dll`. So merely loading a GGUF model triggers OpenCL init -> CB.dll crashes the whole process.

Isolated reproduction confirms it is not geniex or llama.cpp:
- Load `OpenCL.dll` alone -> survives
- Call `clGetPlatformIDs()` -> instant `0xC0000409`
- Windows WER fault module = `CB.dll` in `qcdx8480.inf_arm64_*`

## Why Qairt worked

The QNN/HTP runtime talks to the Hexagon NPU directly and never loads the OpenCL driver.

## Fix

Disable the OpenCL backend in the llama_cpp plugin build (`set(GGML_OPENCL OFF)`). The **Hexagon (NPU) + CPU** backends cover the Snapdragon path and do not touch the broken OpenCL driver.

## Verification

After disabling OpenCL and rebuilding, GGUF models (lfm2, gemma-4-4B, gpt-oss-20b) serve successfully on geniex. Task Manager shows **both the NPU and CPU active** during inference (hybrid offload working). A full Hermes agent session ran end-to-end against a GGUF model through geniex.

## Note

This is a workaround for a Qualcomm OpenCL driver bug. The ideal long-term fix is a corrected Adreno OpenCL driver (`CB.dll`) that does not crash on `clGetPlatformIDs`. Until then, disabling OpenCL unblocks NPU/CPU hybrid GGUF inference on Snapdragon Windows.
