### PR TITLE
fix(sdk): use resolved device for VLM encoder

### DIFF
--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -89,18 +89,19 @@ int32_t LlamaVlm::create(const geniex_VlmCreateInput* input) {
 
     // Initialize vision context if mmproj_path provided
     if (input->mmproj_path) {
-        ggml_backend_dev_t htp_device = device == Device::NPU ? ggml_backend_dev_by_name("HTP0") : nullptr;
-
         mtmd_context_params mparams = mtmd_context_params_default();
-        mparams.use_gpu             = device == Device::GPU || htp_device != nullptr;
-        mparams.device              = htp_device;
-        mparams.print_timings       = false;
-        mparams.n_threads           = 4;
+        mparams.use_gpu             = false;
+        if (!selection->empty()) {
+            mparams.use_gpu = true;
+            mparams.device  = selection->data()[0];
+        }
+        mparams.print_timings = false;
+        mparams.n_threads     = 4;
         // Zack TODO: elegant fix this error:  no member named 'verbosity' in 'mtmd_context_params'
         // mparams.verbosity           = GGML_LOG_LEVEL_ERROR;
 
         this->ctx_vision = mtmd_init_from_file(input->mmproj_path, this->model, mparams);
-        if (!this->ctx_vision && htp_device) {
+        if (!this->ctx_vision && !selection->empty()) {
             GENIEX_LOG_WARN("mtmd failed to initialize the vision encoder on HTP; falling back to CPU");
             mparams.use_gpu  = false;
             mparams.device   = nullptr;


### PR DESCRIPTION
## Summary
- Use the resolved llama.cpp device selection when initializing the VLM vision encoder.
- Disable mtmd GPU selection by default so CPU and hybrid paths remain on CPU.
- Preserve CPU fallback when the selected accelerator cannot initialize.

## Test plan
- [x] `clang-format-18` on `sdk/plugins/llama_cpp/src/vlm.cpp`
- [x] QCS Windows ARM64: `cpu` → CPU CLIP; `gpu` → OpenCL CLIP; `npu` → HTP0 CLIP; `hybrid` → CPU CLIP; all VLM generations passed.
- [x] QCS9075M Linux: cross-compiled SDK successfully; `cpu` and `hybrid -ngl 0` VLM cells passed, with logs confirming CPU CLIP.
- [ ] QCS9075M Linux `gpu`: resolved `GPUOpenCL` and CLIP selected OpenCL, but the platform Adreno driver aborts with `back-end instruction validation failed` during kernel compilation.
- [x] QCS9075M Linux `npu`: CLIP selected `HTP0`, but only work with small model.
- [x] `git diff --check`

Tracks qcom-ai-hub/geniex#1562
