### PR TITLE
fix(sdk): patch llama.cpp OpenCL add kernel for Adreno

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -144,7 +144,11 @@ enable_testing()
 # * llama-opencl-adreno-cpy-constreg.patch works around an Adreno OpenCL
 #   compiler crash: kernel_cpy_f32_f32_pack's min(ne00, get_local_size(0))
 #   emits an IMINrr with two constant-class operands, which the driver's
-#   instruction validator rejects (NumConstRegsError). See GenieX #1250.
+#   instruction validator rejects (NumConstRegsError). See GenieX #1250. The
+#   same fix is applied to kernel_add: the strength-reduced
+#   get_local_size(0) * nb0X step emits an equivalent UMULLrr, hit on a
+#   QCS9075 board (Adreno driver 1.855.3) during VLM inference. See
+#   qcom-ai-hub/geniex#1566.
 # * llama-zero-free-mem-even-split.patch keeps load_tensors from throwing when
 #   every device reports 0 free memory: the splits normalize to NaN and the
 #   device lookup runs off the end. Adreno 643 on QCS6490 hits it because the

--- a/sdk/patches/llama-opencl-adreno-cpy-constreg.patch
+++ b/sdk/patches/llama-opencl-adreno-cpy-constreg.patch
@@ -1,3 +1,24 @@
+diff --git a/ggml/src/ggml-opencl/kernels/add.cl b/ggml/src/ggml-opencl/kernels/add.cl
+index 509bf1734..3d72cb84a 100644
+--- a/ggml/src/ggml-opencl/kernels/add.cl
++++ b/ggml/src/ggml-opencl/kernels/add.cl
+@@ -55,7 +55,14 @@ kernel void kernel_add(
+     global char * src1_ptr = src1 + i13*nb13 + i12*nb12 + i11*nb11;
+     global char * dst_ptr  = dst  + i03*nb3  + i02*nb2  + i01*nb1;
+ 
+-    for (int i0 = get_local_id(0); i0 < ne0; i0 += get_local_size(0)) {
++    // Adreno's instruction validator rejects the strength-reduced step
++    // `get_local_size(0) * nb0X`: get_local_size(0) is a constant-class
++    // register, nb0X a uniform-class one, and the resulting UMULLrr still
++    // trips "# of constant registers must be < 2". Force lsz into a GPR via
++    // volatile to break the pairing, same fix as kernel_cpy_f32_f32_pack.
++    volatile int lsz_v = get_local_size(0);
++    int lsz = lsz_v;
++    for (int i0 = get_local_id(0); i0 < ne0; i0 += lsz) {
+         const int i10 = i0 % ne10;
+         *((global float *)(dst_ptr + i0*nb0)) = *((global float *)(src0_ptr + i0*nb00)) + *((global float *)(src1_ptr + i10*nb10));
+     }
+ }
 diff --git a/ggml/src/ggml-opencl/kernels/cpy.cl b/ggml/src/ggml-opencl/kernels/cpy.cl
 index adbd2e766..89aeb1cca 100644
 --- a/ggml/src/ggml-opencl/kernels/cpy.cl


### PR DESCRIPTION
## Problem
On QCS9075 (Adreno driver 1.855.3), `llama_cpp` `--device gpu` aborts for every model during OpenCL kernel compilation:

```
NumConstRegsError: # of constant registers must be < 2.
    In inst# 7:    %R1_d<def> = UMULLrr %UR0_b, %C23.x, 1
Assertion failed: false && "back-end instruction validation failed"
```

## Root cause
Same class of bug as #1250 (`kernel_cpy_f32_f32_pack`'s `IMINrr`), this time in `kernel_add` — the first OpenCL kernel file compiled. The loop `for (int i0 = get_local_id(0); i0 < ne0; i0 += get_local_size(0))` combined with the `i0*nb00` (ulong) address multiply gets strength-reduced by the compiler into `get_local_size(0) * nb00`, computed once outside the loop. `get_local_size(0)` is a constant-class register, `nb00` a uniform-class one; Adreno's instruction validator rejects the resulting `UMULLrr`.

## Fix
Merged into the existing `llama-opencl-adreno-cpy-constreg.patch`, applying the same `volatile` workaround already validated for the cpy kernel: force `get_local_size(0)` through a non-optimizable load before it's used as the loop step, breaking the constant-register pairing. Pure compiler-visibility change — no logic or numeric difference, negligible perf cost (one extra scalar load once per kernel dispatch, not in the hot loop).

## Verification
Reproduced and fixed live on a QCS9075 IQ-9075 EVK board:
- Before: `--device gpu` aborts immediately after `ggml_opencl: loading OpenCL kernels`, before the first kernel file's success marker — for both `unsloth/gemma-4-E2B-it-GGUF:Q4_0` and `unsloth/Qwen3.5-2B-GGUF:Q4_0`, with or without the OpenCL binary kernel cache cleared.
- After: both models complete VLM inference end-to-end on `gpu` (`GPUOpenCL`), e.g. `ttft=228.0ms prefill=57.4tps decode=12.8tps`.

Fixes qcom-ai-hub/geniex#1566.