### PR TITLE
fix(qairt): use host workers for decode KV overlap

### DIFF
--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "llm.h"
+#include <algorithm>
+#include <thread>
 
 #include <cstdlib>
 #include <cstring>
@@ -36,6 +38,13 @@ namespace {
 // Default system prompt used on the first turn when the caller does not supply one
 // via a `system` role chat message.
 constexpr const char* kDefaultSystemPrompt = "You are a helpful AI assistant.";
+
+unsigned resolveDecodeWorkerCount(int32_t requested_threads, size_t shard_count) {
+    unsigned workers = requested_threads > 0 ? static_cast<unsigned>(requested_threads)
+                                         : std::thread::hardware_concurrency();
+    if (workers == 0) workers = 1;
+    return std::min(workers, std::max(1u, static_cast<unsigned>(shard_count)));
+}
 }  // namespace
 
 QairtLlm::~QairtLlm() = default;
@@ -75,6 +84,16 @@ int32_t QairtLlm::create(const geniex_LlmCreateInput* input) {
         GENIEX_LOG_ERROR("Failed to resolve QAIRT bundle layout in {}: {}", model_dir.string(), e.what());
         return GENIEX_ERROR_COMMON_FILE_NOT_FOUND;
     }
+
+    // Keep CPU-side KV writes parallel with HTP execution. --threads remains an
+    // explicit override; its default (0) uses the host’s available workers.
+    model_cfg.n_decode_workers =
+        resolveDecodeWorkerCount(input->config.n_threads, model_cfg.model_paths.size());
+    GENIEX_LOG_INFO(
+        "QAIRT decode workers: {} (requested threads={}, model shards={})",
+        model_cfg.n_decode_workers,
+        input->config.n_threads,
+        model_cfg.model_paths.size());
 
     GENIEX_LOG_DEBUG("Found {} model shards in {}", model_cfg.model_paths.size(), model_dir.string());
 


### PR DESCRIPTION
## Summary

This change connects the configured thread count to QAIRT CPU-side decode and KV-cache overlap workers. When no thread count is provided, it uses detected host concurrency and caps the worker count to the number of model shards. It also logs the selected worker count for runtime verification.

## Test report

- Static diff and whitespace validation passed.
- DCO passed for the latest commit.
- GitHub reports the branch is mergeable with no conflicts.
- Qualcomm CI workflows are awaiting maintainer approval.
- End-to-end throughput validation requires Snapdragon X Plus hardware and the matching QAIRT bundle.

Related to #1433.