### PR TITLE
feat(sdk): expose the QAIRT runtime path on the C API

### DIFF
--- a/bindings/android/app/src/main/cpp/geniex_sdk.cpp
+++ b/bindings/android/app/src/main/cpp/geniex_sdk.cpp
@@ -83,3 +83,16 @@ extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_GenieXSdk_getPluginVers
     const char* result = geniex_get_plugin_version(id.c_str());
     return env->NewStringUTF(result ? result : "");
 }
+
+// Reaching this from Kotlin needs native code: the JVM has no setenv, so the
+// GENIEX_QAIRT_LIB fallback the other bindings can use is not available here.
+extern "C" JNIEXPORT jint JNICALL Java_com_geniex_sdk_GenieXSdk_setQairtRuntimePath(
+    JNIEnv* env, jobject thiz, jstring path) {
+    std::string p = jstring2str(env, path);
+    return geniex_set_qairt_runtime_path(p.c_str());
+}
+
+extern "C" JNIEXPORT jstring JNICALL Java_com_geniex_sdk_GenieXSdk_getQairtRuntimePath(JNIEnv* env, jobject thiz) {
+    const char* result = geniex_get_qairt_runtime_path();
+    return env->NewStringUTF(result ? result : "");
+}

--- a/bindings/android/app/src/main/java/com/geniex/sdk/GenieXSdk.kt
+++ b/bindings/android/app/src/main/java/com/geniex/sdk/GenieXSdk.kt
@@ -18,6 +18,20 @@ class GenieXSdk private constructor() {
 
     external fun getPluginVersion(pluginId: String): String
 
+    /**
+     * Load the QAIRT runtime from [path] instead of the one bundled in the APK, for
+     * running against another QAIRT version. [path] is either a QAIRT SDK root or a
+     * flat folder of QNN libraries, pushed somewhere the app can read; "" restores the
+     * bundled runtime. Ignored by other plugins.
+     *
+     * Call before [init]: the QNN libraries load once per process and are never
+     * unloaded, so this fails afterwards. An unusable path is reported when the model
+     * is created, not here.
+     */
+    external fun setQairtRuntimePath(path: String): Int
+
+    external fun getQairtRuntimePath(): String
+
     // Idempotent across Activity recreation. Plugin registration is
     // safe to re-attempt (it logs and moves on); model-manager init is
     // not — the FFI rejects re-init — so we guard it here.

--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -88,6 +88,28 @@ func SetLog(enable bool) {
 	}
 }
 
+// SetQairtRuntimePath loads the QAIRT runtime from path instead of the one bundled
+// with the qairt plugin, for running against another QAIRT version without
+// rebuilding. path is either a QAIRT SDK root or a flat folder of QNN libraries;
+// "" restores the bundled runtime. Ignored by other plugins.
+//
+// Call before Init: the QNN libraries load once per process and are never unloaded, so
+// this fails once initialized. An unusable path is reported when the model is created,
+// not here.
+func SetQairtRuntimePath(path string) error {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	if res := C.geniex_set_qairt_runtime_path(cPath); res < 0 {
+		return SDKError(res)
+	}
+	return nil
+}
+
+// GetQairtRuntimePath returns the path set by SetQairtRuntimePath, "" when unset.
+func GetQairtRuntimePath() string {
+	return C.GoString(C.geniex_get_qairt_runtime_path())
+}
+
 // GetPluginVersion returns the version the plugin reports for itself (QAIRT
 // runtime version, llama.cpp build commit, …). Empty string if not registered.
 func GetPluginVersion(pluginID string) string {

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -178,6 +178,7 @@ interrupts the current reply. `geniex-py <cmd> --help` for all flags.
 | `GENIEX_HFTOKEN`   | HuggingFace token for gated repos.                   |
 | `GENIEX_LIB_PATH`  | Point at a pre-built `libgeniex.so` / `geniex.dll`.  |
 | `GENIEX_LOG`       | Log level: `trace`/`debug`/`info`/`warn`/`error`/`none`. Default `info`. |
+| `GENIEX_QAIRT_LIB` | Run the `qairt` plugin against another QAIRT runtime: a QAIRT SDK root or a flat folder of QNN libraries. A runtime is bundled and used by default. `geniex.set_qairt_runtime_path()` does the same thing and takes precedence. |
 
 ## Logging
 

--- a/bindings/python/geniex/__init__.py
+++ b/bindings/python/geniex/__init__.py
@@ -7,9 +7,11 @@ from ._ffi._api import (
     deinit,
     get_compute_unit_list,
     get_plugin_version,
+    get_qairt_runtime_path,
     get_runtime_list,
     init,
     set_log_level,
+    set_qairt_runtime_path,
     version,
 )
 from ._version import __version__
@@ -30,6 +32,8 @@ __all__ = [
     'init',
     'deinit',
     'set_log_level',
+    'set_qairt_runtime_path',
+    'get_qairt_runtime_path',
     'version',
     'get_plugin_version',
     'get_runtime_list',

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -160,6 +160,12 @@ def _bind_all() -> None:
     lib.geniex_version.argtypes = []
     lib.geniex_version.restype = c_char_p
 
+    lib.geniex_set_qairt_runtime_path.argtypes = [c_char_p]
+    lib.geniex_set_qairt_runtime_path.restype = c_int32
+
+    lib.geniex_get_qairt_runtime_path.argtypes = []
+    lib.geniex_get_qairt_runtime_path.restype = c_char_p
+
     lib.geniex_get_plugin_version.argtypes = [c_char_p]
     lib.geniex_get_plugin_version.restype = c_char_p
 
@@ -452,6 +458,28 @@ def version() -> str:
     _ensure_bound()
     lib = load_library()
     return lib.geniex_version().decode()
+
+
+def set_qairt_runtime_path(path: str) -> None:
+    """Load the QAIRT runtime from ``path`` instead of the one bundled with the plugin.
+
+    ``path`` is either a QAIRT SDK root or a flat folder of QNN libraries; ``""``
+    restores the bundled runtime. Ignored by other plugins.
+
+    Call before :func:`init`: the QNN libraries load once per process and are never
+    unloaded, so this raises afterwards. An unusable path is reported when the model is
+    created, not here.
+    """
+    _ensure_bound()
+    lib = load_library()
+    _check(lib.geniex_set_qairt_runtime_path(path.encode() if path else None))
+
+
+def get_qairt_runtime_path() -> str:
+    """Return the path set by :func:`set_qairt_runtime_path`, or ``""`` when unset."""
+    _ensure_bound()
+    lib = load_library()
+    return (lib.geniex_get_qairt_runtime_path() or b'').decode()
 
 
 def get_plugin_version(plugin_id: str) -> str:

--- a/cli/cmd/geniex/infer.go
+++ b/cli/cmd/geniex/infer.go
@@ -143,11 +143,12 @@ func infer() *cobra.Command {
 			return err
 		}
 
-		// Exported rather than passed down so every path in this process -- LLM, VLM, any
-		// binding -- picks the override up the same way.
+		// Handed to the SDK rather than exported: os.Setenv is not reliably visible to a
+		// separately-CRT-linked plugin DLL on Windows. GENIEX_QAIRT_LIB still works as the
+		// SDK's own fallback, so an inherited environment keeps behaving as before.
 		if qairtLib != "" {
-			if err := os.Setenv("GENIEX_QAIRT_LIB", qairtLib); err != nil {
-				return fmt.Errorf("failed to set GENIEX_QAIRT_LIB: %w", err)
+			if err := geniex_sdk.SetQairtRuntimePath(qairtLib); err != nil {
+				return err
 			}
 		}
 

--- a/cli/cmd/geniex/serve.go
+++ b/cli/cmd/geniex/serve.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -59,11 +58,11 @@ func serve() *cobra.Command {
 	serveCmd.Run = func(cmd *cobra.Command, args []string) {
 		checkAudioDependency()
 
-		// Exported rather than passed down, matching `infer`: every model the server
-		// loads, LLM or VLM, then picks the override up the same way.
+		// Handed to the SDK rather than exported, matching `infer`; every model the server
+		// loads, LLM or VLM, then goes through the same SDK-side resolution.
 		if qairtLib := viper.GetString("qairtlib"); qairtLib != "" {
-			if err := os.Setenv("GENIEX_QAIRT_LIB", qairtLib); err != nil {
-				common.PrintError(fmt.Errorf("failed to set GENIEX_QAIRT_LIB: %w", err))
+			if err := geniex_sdk.SetQairtRuntimePath(qairtLib); err != nil {
+				common.PrintError(err)
 				os.Exit(1)
 			}
 		}

--- a/examples/sdk/qairt-lib.md
+++ b/examples/sdk/qairt-lib.md
@@ -1,0 +1,92 @@
+# Running against another QAIRT runtime
+
+A QAIRT runtime ships with the `qairt` plugin. `geniex_set_qairt_runtime_path` points the
+plugin at a different one. Call it **before `geniex_init`**.
+
+```c
+#include <stdio.h>
+#include <string.h>
+
+#include "geniex.h"
+
+/* argv[1] = QAIRT runtime dir, argv[2] = <bundle>/genie_config.json */
+int main(int argc, char** argv) {
+    if (argc < 3) return 2;
+
+    if (geniex_set_qairt_runtime_path(argv[1]) != GENIEX_SUCCESS) return 1;
+    if (geniex_init() != GENIEX_SUCCESS) return 1;
+
+    geniex_LlmCreateInput in;
+    memset(&in, 0, sizeof(in));
+    in.model_path = argv[2];
+    in.plugin_id  = "qairt";
+    in.device_id  = "NPU";
+
+    geniex_LLM* llm = NULL;
+    int32_t     rc  = geniex_llm_create(&in, &llm);
+    if (rc != GENIEX_SUCCESS) {
+        fprintf(stderr, "create: %s\n", geniex_get_error_message(rc));
+        return 1;
+    }
+
+    geniex_GenerationConfig cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.max_tokens = 32;
+
+    geniex_LlmGenerateInput gin;
+    memset(&gin, 0, sizeof(gin));
+    gin.prompt_utf8 = "Name three primary colors.";
+    gin.config      = &cfg;
+
+    geniex_LlmGenerateOutput out;
+    memset(&out, 0, sizeof(out));
+    rc = geniex_llm_generate(llm, &gin, &out);
+    if (rc == GENIEX_SUCCESS) {
+        printf("%s\n", out.full_text);
+        geniex_free(out.full_text);
+    }
+
+    geniex_llm_destroy(llm);
+    geniex_deinit();
+    return rc == GENIEX_SUCCESS ? 0 : 1;
+}
+```
+
+Build. `pkg-geniex/lib` ships only the DLL, so Windows links the import library from the
+build tree:
+
+```pwsh
+clang --target=arm64-pc-windows-msvc -std=c11 -DGENIEX_SHARED `
+  -I sdk/pkg-geniex/include qairt-lib.c sdk/build/src/geniex.lib -o qairt-lib.exe
+```
+
+```bash
+clang -std=c11 -DGENIEX_SHARED -I sdk/pkg-geniex/include qairt-lib.c \
+  -L sdk/pkg-geniex/lib -lgeniex -o qairt-lib
+```
+
+Run with the SDK on the library path, and `GENIEX_LOG=info` to see which runtime was used:
+
+```pwsh
+$env:PATH = "sdk/pkg-geniex/lib;$env:PATH"
+$env:GENIEX_LOG = "info"
+./qairt-lib.exe C:\qairt\2.48.0 C:\models\Qwen3-4B\genie_config.json
+```
+
+```
+Overriding the bundled QAIRT runtime from geniex_set_qairt_runtime_path: <path> (host libs: <dir>)
+```
+
+`host libs:` is the part that matters — for an SDK root it is the `lib/<triple>` subfolder,
+not the root you passed.
+
+| | |
+|---|---|
+| Accepted paths | a QAIRT SDK root, or a flat folder holding `QnnHtp.dll` / `libQnnHtp.so` |
+| Precedence | this call → `GENIEX_QAIRT_LIB` → the bundled runtime |
+| After `geniex_init` | `GENIEX_ERROR_COMMON_ALREADY_INITIALIZED`. One runtime per process; `geniex_deinit` does not reset it |
+
+A bundle built for one QAIRT version may not load on another — that surfaces as a QNN context
+error from `geniex_llm_create`, not from the setter.
+
+CLI and binding equivalents: [notes/run.md](../../notes/run.md#using-a-custom-qnn-library).

--- a/notes/run.md
+++ b/notes/run.md
@@ -122,6 +122,25 @@ geniex infer local/granite4_micro --qairt-lib /path/to/qairt/2.XX.0
 GENIEX_QAIRT_LIB=/path/to/qairt/2.XX.0 geniex infer local/granite4_micro
 ```
 
+SDK embedders call it **before `geniex_init`** instead of touching their own environment —
+the only route on Android, where the JVM cannot `setenv`:
+
+```c
+geniex_set_qairt_runtime_path("/path/to/qairt/2.XX.0");  /* "" restores the bundled runtime */
+geniex_init();
+```
+
+```python
+geniex.set_qairt_runtime_path('/path/to/qairt/2.XX.0')
+```
+
+```kotlin
+GenieXSdk.getInstance().setQairtRuntimePath("/path/to/qairt/2.XX.0")
+```
+
+Precedence is `geniex_set_qairt_runtime_path` → `GENIEX_QAIRT_LIB` → the bundled runtime.
+`--qairt-lib` calls the API, so the flag wins over an inherited environment variable.
+
 The path accepts either layout:
 
 - **A QAIRT SDK root** (as installed from the Qualcomm Software Center). The host libraries
@@ -136,11 +155,12 @@ The path accepts either layout:
 > the override resolved where you meant. Run with `--log info` (the CLI default is `none`):
 >
 > ```
-> Overriding the bundled QAIRT runtime from GENIEX_QAIRT_LIB: <what you passed> (host libs: <resolved dir>)
+> Overriding the bundled QAIRT runtime from <source>: <what you passed> (host libs: <resolved dir>)
 > ```
 >
 > `host libs:` is the part that matters — for an SDK root it is the `lib/<triple>` subfolder,
-> not the root you passed.
+> not the root you passed. `<source>` is `geniex_set_qairt_runtime_path` or
+> `GENIEX_QAIRT_LIB`, so the line also tells you which knob won.
 
 <details><summary>Which runtimes are accepted, and why this is a supported override</summary>
 
@@ -158,9 +178,16 @@ which is why this is a supported override rather than a testing-only aid.
 `htp_backend_ext_config.json` itself through the public C API — so a runtime folder does not
 need to carry it.
 
-`--qairt-lib` just sets `GENIEX_QAIRT_LIB` for the process, so the flag wins when both are given.
-An unusable path fails model load immediately, e.g. `GENIEX_QAIRT_LIB does not contain
-QnnHtp.dll (looked in the folder itself and lib/aarch64-windows-msvc): <path>`.
+An unusable path fails model load immediately, naming the source it came from, e.g.
+`geniex_set_qairt_runtime_path does not contain QnnHtp.dll (looked in the folder itself and
+lib/aarch64-windows-msvc): <path>`.
+
+**One runtime per process.** `QnnHtp` is loaded once and stays resident for the life of the
+process — the plugin never unloads it, and `ADSP_LIBRARY_PATH` / `SetDllDirectory` are
+process-wide. So the path is locked at `geniex_init`, and setting it afterwards returns
+`GENIEX_ERROR_COMMON_ALREADY_INITIALIZED` rather than appearing to work. `geniex_deinit` does
+not unlock it: the QNN libraries outlive the cycle. Comparing versions means one process per
+version.
 
 </details>
 

--- a/sdk/benchmark/bench.h
+++ b/sdk/benchmark/bench.h
@@ -109,6 +109,10 @@ typedef struct {
     int32_t     draft_min;    /* min draft tokens per step (0 = llama.cpp default) */
     float       draft_p_min;  /* min greedy draft probability (0 = llama.cpp default) */
 
+    /* QAIRT runtime override (qairt); NULL = GENIEX_QAIRT_LIB, then the bundled runtime.
+     * Run-wide, not per cell: the QNN libraries load once per process. */
+    const char* qairt_lib;
+
     const char* output_json;
     const char* output_md;
     const char* cell_id;

--- a/sdk/benchmark/benchmark.c
+++ b/sdk/benchmark/benchmark.c
@@ -237,6 +237,10 @@ int main(int argc, char** argv) {
     options_t o;
     parse_args(argc, argv, &o);
 
+    /* Before init, and run-wide rather than per cell: the QNN libraries load once per
+     * process, so matrix mode cannot switch runtimes between cells. */
+    if (o.qairt_lib) check(geniex_set_qairt_runtime_path(o.qairt_lib), "geniex_set_qairt_runtime_path");
+
     check(geniex_init(), "geniex_init");
 
     int rc;

--- a/sdk/benchmark/options.c
+++ b/sdk/benchmark/options.c
@@ -57,6 +57,9 @@ static void usage(const char* argv0) {
         "  -t, --threads N        generation threads (0 = SDK default)\n"
         "  -ngl, --n-gpu-layers N llama_cpp layers to offload; overrides the\n"
         "                         device alias default (-1 = all layers)\n"
+        "  --qairt-lib DIR        run against another QAIRT runtime (qairt): a QAIRT SDK\n"
+        "                         root or a flat folder of QNN libraries. Applies to the\n"
+        "                         whole run -- the QNN libraries load once per process.\n"
         "  --spec-type TYPES      speculative type(s), comma-separated: draft-mtp,\n"
         "                         draft-eagle3,draft-simple,ngram-simple,ngram-map-k,\n"
         "                         ngram-map-k4v,ngram-mod,ngram-cache (llama_cpp)\n"
@@ -285,6 +288,7 @@ void parse_args(int argc, char** argv, options_t* o) {
     o->draft_tokens            = 0;
     o->draft_min               = 0;
     o->draft_p_min             = 0.0f;
+    o->qairt_lib               = NULL;
     o->output_json             = NULL;
     o->output_md               = NULL;
     o->cell_id                 = NULL;
@@ -364,6 +368,8 @@ void parse_args(int argc, char** argv, options_t* o) {
             o->n_threads = atoi(arg_value(argc, argv, &i, a));
         } else if (strcmp(a, "-ngl") == 0 || strcmp(a, "--n-gpu-layers") == 0) {
             o->ngl_override = atoi(arg_value(argc, argv, &i, a));
+        } else if (strcmp(a, "--qairt-lib") == 0) {
+            o->qairt_lib = arg_value(argc, argv, &i, a);
         } else if (strcmp(a, "--spec-type") == 0) {
             o->spec_type = arg_value(argc, argv, &i, a);
         } else if (strcmp(a, "--draft-model") == 0) {

--- a/sdk/benchmark/report.c
+++ b/sdk/benchmark/report.c
@@ -128,6 +128,11 @@ int write_cell_json(const options_t* o, const device_t* dev, int64_t model_size_
         }
         fprintf(f, ",\n      \"draft_tokens\": %d", o->draft_tokens);
     }
+    /* Which QAIRT runtime produced these numbers -- the reason the override exists. */
+    if (o->qairt_lib) {
+        fprintf(f, ",\n      \"qairt_lib\": ");
+        json_write_quoted(f, o->qairt_lib);
+    }
     fprintf(f, "\n    },\n");
     fprintf(f, "    \"runs\": [\n");
     for (int32_t i = 0; i < n_runs; ++i) {

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -187,6 +187,43 @@ GENIEX_API int32_t geniex_deinit(void);
 GENIEX_API int32_t geniex_set_log(geniex_log_callback callback);
 
 /**
+ * @brief Load the QAIRT runtime from `path` instead of the one bundled with the plugin
+ *
+ * Optional: a QAIRT runtime ships with the qairt plugin and is used by default, so
+ * this is for running against another QAIRT version without rebuilding. Ignored by
+ * other plugins.
+ *
+ * `path` may be either a QAIRT SDK root or a flat folder of QNN libraries; the
+ * plugin tells them apart. Pass NULL or "" to go back to the bundled runtime.
+ *
+ * Call before geniex_init. The QNN libraries load once per process and are never
+ * unloaded, so the runtime cannot be changed afterwards -- not even across a
+ * geniex_deinit / geniex_init cycle, which leaves them resident. Once initialized
+ * this returns GENIEX_ERROR_COMMON_ALREADY_INITIALIZED; run another QAIRT runtime
+ * in a fresh process. Takes precedence over GENIEX_QAIRT_LIB.
+ *
+ * @param path[in]: Runtime directory, or NULL to unset. Copied; the caller keeps
+ *                  ownership. Not validated here -- an unusable path fails model
+ *                  creation with a message naming the layouts it looked for.
+ *
+ * @return geniex_ErrorCode: GENIEX_SUCCESS, or
+ *         GENIEX_ERROR_COMMON_ALREADY_INITIALIZED when called after geniex_init.
+ *
+ * @thread_safety: Not thread-safe against geniex_init.
+ */
+GENIEX_API int32_t geniex_set_qairt_runtime_path(const char* path);
+
+/**
+ * @brief Read back what geniex_set_qairt_runtime_path() stored
+ *
+ * @return Null-terminated UTF-8 string, "" when unset. Owned by the library; valid
+ *         until the next geniex_set_qairt_runtime_path() call. Never NULL.
+ *
+ * @thread_safety: Not thread-safe against geniex_set_qairt_runtime_path().
+ */
+GENIEX_API const char* geniex_get_qairt_runtime_path(void);
+
+/**
  * @brief Simple wrapper around free() to free memory allocated by ML library functions
  *
  * @param ptr[in]: The pointer to free.

--- a/sdk/plugins/qairt/include/qnn_runtime_utils.h
+++ b/sdk/plugins/qairt/include/qnn_runtime_utils.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "geniex.h"  // geniex_get_qairt_runtime_path
 #include "types.h"
 
 namespace geniex::qairt::runtime {
@@ -40,6 +41,26 @@ inline std::filesystem::path read_env_path(const char* name_utf8, const wchar_t*
     }
     return {};
 #endif  // _WIN32
+}
+
+// The C API hands us UTF-8, so decode it through the wide encoding on Windows: path's narrow
+// constructor would read those bytes in the active ANSI code page and silently resolve a
+// different directory. This matches what read_env_path already does, so both sources behave
+// the same. A non-ASCII path still fails further down, where SetDllDirectoryA / _putenv_s and
+// the plugin's narrow path fields convert back to ANSI -- pre-existing, and identical for the
+// environment variable.
+inline std::filesystem::path path_from_utf8(const char* utf8) {
+    if (!utf8 || utf8[0] == '\0') return {};
+#if defined(_WIN32)
+    const int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, nullptr, 0);
+    if (wlen <= 0) return std::filesystem::path(utf8);
+    std::wstring wide(static_cast<size_t>(wlen), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, utf8, -1, wide.data(), wlen);
+    wide.resize(static_cast<size_t>(wlen) - 1);  // drop the terminating NUL from the count
+    return std::filesystem::path(wide);
+#else
+    return std::filesystem::path(utf8);
+#endif
 }
 
 // NOTE: no `collect_bin_files()` helper here on purpose. Context-binary shards must
@@ -128,40 +149,48 @@ inline std::string collect_adsp_library_path(const std::filesystem::path& root) 
 
 // Returns a QnnRuntimeConfig for the given model directory.
 //
-// GENIEX_QAIRT_LIB (or the CLI `--qairt-lib` flag) is an optional override; unset, the config
-// stays empty and the plugin resolves its own bundled runtime. Set, we pin all three path
-// fields, which the plugin then honors as-is -- translating an SDK root is our job because
-// the plugin only understands the flat layout. Throws when set but unusable.
+// geniex_set_qairt_runtime_path() is the override, with GENIEX_QAIRT_LIB (which the CLI's
+// `--qairt-lib` flag feeds) as its fallback; with neither set the config stays empty and the
+// plugin resolves its own bundled runtime. Set, we pin all three path fields, which the plugin
+// then honors as-is -- translating an SDK root is our job because the plugin only understands
+// the flat layout. Throws when set but unusable, naming the source the path came from.
 inline QnnRuntimeConfig make_qnn_runtime_config(const std::filesystem::path& model_dir) {
     namespace fs = std::filesystem;
 
     QnnRuntimeConfig runtime_cfg{};
 
-    const fs::path qnn_lib_root = read_env_path("GENIEX_QAIRT_LIB", L"GENIEX_QAIRT_LIB");
+    const char* source       = "geniex_set_qairt_runtime_path";
+    fs::path    qnn_lib_root = path_from_utf8(geniex_get_qairt_runtime_path());
     if (qnn_lib_root.empty()) {
-        GENIEX_LOG_DEBUG("GENIEX_QAIRT_LIB unset; using the QAIRT runtime bundled with the plugin");
+        source       = "GENIEX_QAIRT_LIB";
+        qnn_lib_root = read_env_path("GENIEX_QAIRT_LIB", L"GENIEX_QAIRT_LIB");
+    }
+    if (qnn_lib_root.empty()) {
+        GENIEX_LOG_DEBUG("No QAIRT runtime override set; using the QAIRT runtime bundled with the plugin");
         static_cast<void>(model_dir);
         return runtime_cfg;
     }
 
+    const std::string recovery =
+        "\nClear " + std::string(source) + " to use the QAIRT runtime bundled with the plugin.";
+
     std::error_code ec;
     if (!fs::is_directory(qnn_lib_root, ec)) {
-        throw std::runtime_error("GENIEX_QAIRT_LIB path is not a directory: " + qnn_lib_root.string() +
-                                 "\nUnset it to use the QAIRT runtime bundled with the plugin.");
+        throw std::runtime_error(std::string(source) + " path is not a directory: " + qnn_lib_root.string() + recovery);
     }
     const fs::path host_dir = locate_qnn_host_lib_dir(qnn_lib_root);
     if (host_dir.empty()) {
-        throw std::runtime_error("GENIEX_QAIRT_LIB does not contain " + std::string(kQnnBackendLib) +
+        throw std::runtime_error(std::string(source) + " does not contain " + std::string(kQnnBackendLib) +
                                  " (looked in the folder itself and lib/" + kHostLibTriple +
-                                 "): " + qnn_lib_root.string() +
-                                 "\nUnset it to use the QAIRT runtime bundled with the plugin.");
+                                 "): " + qnn_lib_root.string() + recovery);
     }
 
     // A QAIRT SDK keeps skels apart from the host libs; a flat folder has them together.
     std::string adsp_path = collect_adsp_library_path(qnn_lib_root);
     if (adsp_path.empty()) adsp_path = host_dir.string();
 
-    GENIEX_LOG_INFO("Overriding the bundled QAIRT runtime from GENIEX_QAIRT_LIB: {} (host libs: {})",
+    GENIEX_LOG_INFO("Overriding the bundled QAIRT runtime from {}: {} (host libs: {})",
+        source,
         qnn_lib_root.string(),
         host_dir.string());
     GENIEX_LOG_DEBUG("Setting ADSP_LIBRARY_PATH to {}", adsp_path);

--- a/sdk/src/ml.cpp
+++ b/sdk/src/ml.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 
 #include "build_config.h"
 #include "logging.h"
@@ -72,6 +73,8 @@ static void default_log_handler(geniex_LogLevel level, const char* msg) {
     std::cerr << colorCode << prefix << msg << "\033[0m" << std::endl;
 }
 
+static void lock_qairt_runtime_path();
+
 int32_t geniex_init(void) {
 #ifdef _WIN32
     // set console output to UTF-8 code page for Windows
@@ -91,6 +94,7 @@ int32_t geniex_init(void) {
 
     try {
         Registry::instance().scan_plugins();
+        lock_qairt_runtime_path();
         return GENIEX_SUCCESS;
     } catch (const std::exception& e) {
         GENIEX_LOG_ERROR("failed to initialize ml: {}", e.what());
@@ -136,6 +140,30 @@ int32_t geniex_set_log(geniex_log_callback callback) {
     geniex_log = callback;
     return GENIEX_SUCCESS;
 }
+
+// QAIRT runtime override
+
+static std::string qairt_runtime_path;
+
+// Latched by the first geniex_init and never cleared: QnnHtp is loaded once and the
+// plugin never unloads it, so a later path cannot take effect -- not even after a
+// geniex_deinit / geniex_init cycle, which leaves the QNN libraries resident.
+static bool qairt_runtime_path_locked = false;
+
+static void lock_qairt_runtime_path() { qairt_runtime_path_locked = true; }
+
+int32_t geniex_set_qairt_runtime_path(const char* path) {
+    if (qairt_runtime_path_locked) {
+        GENIEX_LOG_ERROR(
+            "geniex_set_qairt_runtime_path must be called before geniex_init; QnnHtp is already "
+            "loaded and stays resident, so run another QAIRT runtime in a fresh process");
+        return GENIEX_ERROR_COMMON_ALREADY_INITIALIZED;
+    }
+    qairt_runtime_path = (path != nullptr) ? path : "";
+    return GENIEX_SUCCESS;
+}
+
+const char* geniex_get_qairt_runtime_path(void) { return qairt_runtime_path.c_str(); }
 
 void geniex_free(void* ptr) {
     if (ptr) free(ptr);

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import geniex
+import pytest
 
 
 def test_version_nonempty(geniex_session):
@@ -70,6 +71,8 @@ def test_public_surface_exports():
         'init',
         'deinit',
         'set_log_level',
+        'set_qairt_runtime_path',
+        'get_qairt_runtime_path',
         'version',
         'get_plugin_version',
         'get_runtime_list',
@@ -80,6 +83,16 @@ def test_public_surface_exports():
     assert expected.issubset(set(geniex.__all__))
     for name in expected:
         assert hasattr(geniex, name), f'{name} missing from geniex module'
+
+
+# QAIRT runtime override — set before init, process-global, and locked once
+# initialized; see notes/run.md § Using a custom QNN library.
+
+
+def test_qairt_runtime_path_is_locked_after_init(geniex_session):
+    with pytest.raises(geniex.GenieXError):
+        geniex.set_qairt_runtime_path('/nonexistent/qairt/2.XX.0')
+    assert geniex.get_qairt_runtime_path() == ''
 
 
 # resolve_device_map — source of truth lives in sdk/src/device.cpp. Any change


### PR DESCRIPTION
## Summary

Adds the QAIRT runtime override to the C API. The only route until now was the process-wide
`GENIEX_QAIRT_LIB`, which Android cannot set (no `setenv` from the JVM) and embedders should not
have to.

```c
GENIEX_API int32_t     geniex_set_qairt_runtime_path(const char* path);
GENIEX_API const char* geniex_get_qairt_runtime_path(void);
```

Call before `geniex_init`, matching `geniex_set_log`'s existing contract. Precedence:
setter → `GENIEX_QAIRT_LIB` → bundled, so callers that set neither are unaffected.
Go / Python / Kotlin get a setter and getter, `geniex-bench` gets `--qairt-lib`, and the CLI calls
the SDK instead of `os.Setenv`. Errors and the INFO line name their source, so a bad path points
at the knob the caller actually used.

### Re-land

`49df1fb3`…`426c4fb2` added this; `e23632bb` reverted it to keep the knob env-var-only. The AIHub
Workbench team consumes the C API and needs a programmatic route. The plugin-submodule half
(`1e97168d`, `828a2116`) is **not** re-landed — resolution stays in `qnn_runtime_utils.h`.

### Process-global, latched at init

`QnnHtp` loads once per process and is never released, and on Windows `LoadLibrary` keys resident
modules by base name — so a second runtime silently hands back the first while the log reports the
new path. A `geniex_ModelConfig` field would imply per-model switching works.

So the path is latched at `geniex_init` and setting it afterwards returns
`GENIEX_ERROR_COMMON_ALREADY_INITIALIZED`. `geniex_deinit` does **not** clear the latch — the QNN
libraries outlive the cycle. This keeps the constraint out of the model-creation path entirely.

## Test plan

Snapdragon X Elite / Windows ARM64. QAIRT 2.48 extracted from geniex-qairt `5f1f30e`, vs bundled 2.45.

- [x] Cross-version: `Gemma-4-E4B-it` generates on 2.45 (13.9 tok/s) and 2.48 (13.8 tok/s)
- [x] Both layouts: flat folder, and SDK root resolving to `lib/aarch64-windows-msvc`
- [x] Precedence: API beats `GENIEX_QAIRT_LIB`; env var alone still works
- [x] Bad path names the API, not the env var; no fallback when the env var is valid
- [x] Latch: set before init stored; after init → `-100008` with the path unchanged; still refused after `deinit` + `init`
- [x] `geniex infer`, `geniex serve`, VLM, `geniex-bench --qairt-lib`
- [x] `pytest tests -m api` → 16 passed

`Qwen3-4B` fails on 2.48 (`err 5000`, context 3), identically through the untouched env-var route —
a bundle/runtime incompatibility, not this PR.

Non-ASCII runtime paths still fail at `SetDllDirectoryA` / `_putenv_s`, identically for the env
var. `path_from_utf8` buys parity and a clear error, not Unicode support.
