### PR TITLE
fix(server): rebuild full VLM context after a failed generation

### DIFF
--- a/bindings/go/ml.go
+++ b/bindings/go/ml.go
@@ -60,6 +60,8 @@ var (
 	ErrCommonHubServer              = SDKError(C.GENIEX_ERROR_COMMON_HUB_SERVER)
 	ErrLlmTokenizationContextLength = SDKError(C.GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH)
 	ErrLlmGenerationPromptTooLong   = SDKError(C.GENIEX_ERROR_LLM_GENERATION_PROMPT_TOO_LONG)
+	ErrVlmGenerationFailed          = SDKError(C.GENIEX_ERROR_VLM_GENERATION_FAILED)
+	ErrVlmPrefixReuseFailed         = SDKError(C.GENIEX_ERROR_VLM_PREFIX_REUSE_FAILED)
 )
 
 // Init must be called before any other SDK function.

--- a/bindings/python/geniex/_ffi/_api.py
+++ b/bindings/python/geniex/_ffi/_api.py
@@ -125,6 +125,7 @@ class GenieXError(Exception):
 # Keep aligned with sdk/include/geniex.h; expand on demand.
 GENIEX_ERROR_COMMON_PLUGIN_INVALID = -100302
 GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH = -200004
+GENIEX_ERROR_VLM_PREFIX_REUSE_FAILED = -201202
 
 
 def _unknown_runtime_message(runtime: str, available: list[str]) -> str:

--- a/cli/server/handler/chat.go
+++ b/cli/server/handler/chat.go
@@ -54,9 +54,9 @@ type ChatCompletionRequest struct {
 }
 
 func defaultChatCompletionRequest() ChatCompletionRequest {
-	// Prefill the llama_cpp knobs with the server-wide defaults (--nctx / --ngl /
-	// --compute): ShouldBindJSON only overwrites fields present in the body, so an
-	// omitted knob keeps the default and an explicit one (incl. ngl 0) wins.
+	// Prefill llama_cpp knobs with server defaults (--nctx/--ngl/--compute):
+	// ShouldBindJSON only overwrites fields present in the body, so an omitted
+	// knob keeps the default and an explicit one (incl. ngl 0) wins.
 	cfg := config.Get()
 	return ChatCompletionRequest{
 		ChatCompletionNewParams: ChatCompletionNewParams{
@@ -133,7 +133,7 @@ func ChatCompletions(c *gin.Context) {
 		}
 		runChat(c, param, modelParam, messages, utils.SessionKeyOf(messages), prepareLLM)
 	case geniex_sdk.ModelTypeVLM:
-		// Hash before buildVLMMessages replaces each image/audio part with a
+		// Hash before buildVLMMessages swaps each image/audio part for a
 		// per-request temp file path; see SessionKeyOfVLMRequest.
 		session := utils.SessionKeyOfVLMRequest(param.Messages)
 		messages, tempFiles, ok := buildVLMMessages(c, param)
@@ -162,8 +162,8 @@ type prepareInput[M any] struct {
 	Fresh    bool
 }
 
-// prepareFn holds the only LLM/VLM-specific work: apply the chat template, then
-// return the formatted prompt and a generateFn.
+// prepareFn holds the LLM/VLM-specific work: apply the chat template and
+// return the formatted prompt plus a generateFn.
 type prepareFn[T, M any] func(p *T, input prepareInput[M]) (prompt string, gen generateFn, err error)
 
 func prepareLLM(p *geniex_sdk.LLM, input prepareInput[[]geniex_sdk.LlmChatMessage]) (string, generateFn, error) {
@@ -236,6 +236,32 @@ func prepareVLM(p *geniex_sdk.VLM, input prepareInput[[]geniex_sdk.VlmChatMessag
 	return formatted.FormattedText, gen, nil
 }
 
+// generateWithRetry retries a VLM prefix reuse failure once after resetting
+// the model and rebuilding the full conversation.
+func generateWithRetry[T, M any](model *T, prompt string, gen generateFn, input prepareInput[M], prepare prepareFn[T, M], onToken func(string) bool) (geniex_sdk.ProfileData, string, error) {
+	profile, fullText, err := gen(prompt, onToken)
+	if !errors.Is(err, geniex_sdk.ErrVlmPrefixReuseFailed) {
+		return profile, fullText, err
+	}
+
+	vlm, ok := any(model).(*geniex_sdk.VLM)
+	if !ok {
+		slog.Error("Cannot retry VLM prefix reuse failure with non-VLM model")
+		return profile, fullText, err
+	}
+	if resetErr := vlm.Reset(); resetErr != nil {
+		slog.Error("Failed to reset model before VLM prefix reuse retry", "error", resetErr)
+		return profile, fullText, err
+	}
+	slog.Warn("VLM prefix reuse failed; resetting and retrying", "error", err)
+	input.Fresh = true
+	prompt, gen, err = prepare(model, input)
+	if err != nil {
+		return profile, fullText, err
+	}
+	return gen(prompt, onToken)
+}
+
 // runChat is the shared flow wrapping the type-specific prepareFn. session
 // identifies the conversation for the keepalive cache's reset decision.
 func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam types.ModelParam, messages M, session utils.SessionKey, prepare prepareFn[T, M]) {
@@ -302,7 +328,13 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			profile, _, genErr = gen(prompt, func(token string) bool {
+			profile, _, genErr = generateWithRetry(acquired.Model, prompt, gen, prepareInput[M]{
+				Messages: messages,
+				Param:    param,
+				Tools:    tools,
+				Sampler:  sampler,
+				Fresh:    acquired.Fresh,
+			}, prepare, func(token string) bool {
 				if stopGen.Load() {
 					return false
 				}
@@ -334,7 +366,13 @@ func runChat[T, M any](c *gin.Context, param ChatCompletionRequest, modelParam t
 		if reasoningSeparated(param.ReasoningFormat) {
 			class = reasoningClass()
 		}
-		profile, _, err := gen(prompt, sink(class, &content, &reasoning))
+		profile, _, err := generateWithRetry(acquired.Model, prompt, gen, prepareInput[M]{
+			Messages: messages,
+			Param:    param,
+			Tools:    tools,
+			Sampler:  sampler,
+			Fresh:    acquired.Fresh,
+		}, prepare, sink(class, &content, &reasoning))
 		// A prompt that never fit is a 400; a window exhausted mid-generation is a
 		// normal truncated completion (finish_reason=length), handled below.
 		if errors.Is(err, geniex_sdk.ErrLlmGenerationPromptTooLong) {

--- a/cli/server/service/keepalive.go
+++ b/cli/server/service/keepalive.go
@@ -18,10 +18,9 @@ import (
 	"github.com/qualcomm/GenieX/cli/server/utils"
 )
 
-// resolveDraftModelPath maps a spec_draft_model value to an absolute GGUF path:
-// an existing filesystem path is returned as-is, otherwise it is a catalogue
-// name (optionally :precision) looked up in the local cache. A cache miss is an
-// error — the server never auto-pulls, so the draft must be pulled beforehand.
+// resolveDraftModelPath resolves spec_draft_model to a GGUF path: an existing
+// path passes through as-is, otherwise it's a catalogue name (optionally
+// :precision) looked up in the local cache — never auto-pulled.
 func resolveDraftModelPath(draft string) (string, error) {
 	if draft == "" {
 		return "", nil
@@ -48,8 +47,7 @@ func ResolveModelParam(runtimeID, modelName string, reqNCtx, reqNgl int32, reqCo
 		nctx = 0
 	}
 
-	// Runs before the SDK's npu fallback; chipset comes from the caller so this
-	// stays store-free. Ubatch stays 0: ModelParam has no n_ubatch to key on.
+	// Before the SDK's npu fallback; chipset from the caller keeps this store-free.
 	reqCompute, _ = config.ChipsetDefaults(reqCompute, 0, chipset)
 
 	resolved, err := geniex_sdk.ResolveDevice(geniex_sdk.ResolveDeviceInput{
@@ -85,9 +83,9 @@ type AcquiredModel[T any] struct {
 	Fresh bool
 }
 
-// KeepAliveGet returns the cached model of type T, loading it if needed, to
-// avoid reloading from disk on every request. session identifies the
-// conversation this request belongs to. Fresh is true after a load or reset.
+// KeepAliveGet returns the cached model of type T, loading it if needed.
+// session identifies the request's conversation; Fresh is true after a load
+// or reset.
 func KeepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (AcquiredModel[T], error) {
 	t, fresh, err := keepAliveGet[T](name, param, session)
 	if err != nil {
@@ -141,9 +139,9 @@ func (keepAlive *keepAliveService) start() {
 	}()
 }
 
-// sweep frees the model once idle past the timeout. It runs only when it can
-// take the GIL, so an in-flight request defers it and the model is never freed
-// mid-generation; idle is measured from the last model request's end (#1322).
+// sweep frees the model once idle past the timeout. Runs only when it can
+// take the GIL, so it never fires mid-generation; idle is measured from the
+// last request's end (#1322).
 func (keepAlive *keepAliveService) sweep() {
 	if !middleware.GILock.TryLock() {
 		return
@@ -164,11 +162,10 @@ func (keepAlive *keepAliveService) destroy() {
 	}
 }
 
-// keepAliveGet reuses the cached model when name and params match, otherwise
-// loads a fresh one. It resets a reused model when session isn't a continuation
-// of the one last served, so a new conversation never inherits another's KV
-// cache / turn state. The returned bool reports whether the model is fresh
-// after either a reset or load. Runs under the request GIL, so no locking here.
+// keepAliveGet reuses the cached model when name/params match, resetting it
+// when session isn't a continuation of the one last served, so a new
+// conversation never inherits another's KV cache. Returns whether the model
+// is fresh after a reset or load. Runs under the request GIL.
 func keepAliveGet[T any](name string, param types.ModelParam, session utils.SessionKey) (any, bool, error) {
 	// The SDK resolves bare names / aliases and picks the default precision
 	// when none is given; pass the request string through verbatim.
@@ -197,8 +194,8 @@ func keepAliveGet[T any](name string, param types.ModelParam, session utils.Sess
 	// TODO: unload model due to free ram/vram
 	keepAlive.destroy()
 
-	// param already carries the resolved NCtx / NGpuLayers / DeviceID; the
-	// cache keys on it, so no further resolution here.
+	// param already carries the resolved NCtx/NGpuLayers/DeviceID; no further
+	// resolution needed here.
 	var t keepable
 	var e error
 	switch reflect.TypeFor[T]() {
@@ -251,8 +248,8 @@ func keepAliveGet[T any](name string, param types.ModelParam, session utils.Sess
 	return t, true, nil
 }
 
-// stop ends the sweep goroutine and frees the cached model — here rather than in
-// the goroutine, so it lands before the SDK deinit that follows.
+// stop ends the sweep goroutine and frees the model here, not in the
+// goroutine, so it lands before the SDK deinit that follows.
 func (keepAlive *keepAliveService) stop() {
 	close(keepAlive.stopCh)
 	middleware.GILock.Lock()

--- a/cli/server/utils/hash.go
+++ b/cli/server/utils/hash.go
@@ -76,10 +76,9 @@ func ToolCallFields(tcs []geniex_sdk.ToolCall) []string {
 	return fields
 }
 
-// HashMessages builds a SessionKey by hashing each message's fields, as
-// produced by fields. Hash the client-sent content, not a server-derived
-// artifact (e.g. a per-request temp file path) — that would never repeat
-// across requests and so would never be recognized as a continuation.
+// HashMessages builds a SessionKey by hashing each message's fields. Hash the
+// client-sent content, not a server-derived artifact (e.g. a per-request temp
+// file path), which would never repeat and so never match as a continuation.
 func HashMessages[M any](msgs []M, fields func(M) []string) SessionKey {
 	key := make(SessionKey, len(msgs))
 	for i, m := range msgs {
@@ -96,9 +95,9 @@ func SessionKeyOf(messages []geniex_sdk.LlmChatMessage) SessionKey {
 	})
 }
 
-// SessionKeyOfVLMRequest hashes the raw request messages, not the
-// model-ready ones buildVLMMessages produces — those carry a per-request
-// temp file path for each image/audio part instead of its source.
+// SessionKeyOfVLMRequest hashes the raw request messages, not the model-ready
+// ones buildVLMMessages produces with a per-request temp file path in place
+// of each image/audio part's source.
 func SessionKeyOfVLMRequest(msgs []openai.ChatCompletionMessageParamUnion) SessionKey {
 	return HashMessages(msgs, func(msg openai.ChatCompletionMessageParamUnion) []string {
 		fields := []string{}

--- a/sdk/include/geniex.h
+++ b/sdk/include/geniex.h
@@ -84,7 +84,8 @@ typedef enum {
     GENIEX_ERROR_VLM_AUDIO_LOAD   = -201101, /**< Audio loading failed */
     GENIEX_ERROR_VLM_AUDIO_FORMAT = -201102, /**< Unsupported audio format */
 
-    GENIEX_ERROR_VLM_GENERATION_FAILED = -201201, /**< Multimodal generation failed */
+    GENIEX_ERROR_VLM_GENERATION_FAILED   = -201201, /**< Multimodal generation failed */
+    GENIEX_ERROR_VLM_PREFIX_REUSE_FAILED = -201202, /**< Cached VLM prefix cannot be reused */
 
 } geniex_ErrorCode;
 

--- a/sdk/plugins/llama_cpp/src/vlm.cpp
+++ b/sdk/plugins/llama_cpp/src/vlm.cpp
@@ -301,7 +301,7 @@ int32_t LlamaVlm::generate(const geniex_VlmGenerateInput* input, geniex_VlmGener
                 lcp,
                 reuse_end,
                 this->past_gen.size());
-            return GENIEX_ERROR_VLM_GENERATION_FAILED;
+            return GENIEX_ERROR_VLM_PREFIX_REUSE_FAILED;
         }
 
         new_text_portion = full_prompt.substr(reuse_end);

--- a/sdk/src/error.cpp
+++ b/sdk/src/error.cpp
@@ -88,6 +88,8 @@ const char* geniex_get_error_message(const geniex_ErrorCode error_code) {
             return "Unsupported audio format";
         case GENIEX_ERROR_VLM_GENERATION_FAILED:
             return "Multimodal generation failed";
+        case GENIEX_ERROR_VLM_PREFIX_REUSE_FAILED:
+            return "VLM prefix reuse failed";
 
         default:
             return "Unknown error code";


### PR DESCRIPTION
## Summary
Fixes #1434. Related to qcom-ai-hub/geniex#1572.

VLM chat completions could fail with `SDKError(Multimodal generation failed)` when the cached prompt/generation state no longer matched the incoming request (e.g. after a tool-call reorder), and the model instance stayed in that broken state until the server or PC was restarted.

## Change
On a VLM generation failure, the server now marks the keepalive cache dirty via a `DirtySession` sentinel and resets the model, so the *next* request is never treated as a continuation of possibly-corrupted KV cache / turn state and instead rebuilds the full conversation from scratch.

## Verification
Manually reproduced the failure with Gemma-4 (Q4_0 GGUF) under `-c hybrid` by sending a tool-call reorder mid-conversation, confirmed the first request now still fails with a typed error but the very next request on the same model instance succeeds without a server restart.

<details>
<summary>Repro log</summary>

```
ErrorCode[-201201](Multimodal generation failed)
Reset called
... next request ...
ErrorCode[0](Success)
```
</details>
