### PR TITLE
feat(sdk): load QAIRT system prompt from metadata

### DIFF
--- a/sdk/plugins/qairt/include/llm.h
+++ b/sdk/plugins/qairt/include/llm.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "llm/llm_spec_loader.h"  // ParsedSamplerConfig
 #include "pipeline/llm_pipeline.h"
@@ -16,6 +17,9 @@ class QairtLlm : public ILlm {
 
     // Bundle's `dialog.sampler` defaults; parsed once at create().
     ParsedSamplerConfig bundle_sampler_;
+
+    // Bundle's `genie.chat_template.default_system_prompt`.
+    std::string default_system_prompt_;
 
     bool is_first_turn_ = true;
 

--- a/sdk/plugins/qairt/include/metadata_utils.h
+++ b/sdk/plugins/qairt/include/metadata_utils.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Qualcomm Technologies, Inc. and/or its subsidiaries.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "utils/detail/json.hpp"
+
+namespace geniex::qairt {
+
+struct ChatTemplateMetadata {
+    std::string default_system_prompt;
+};
+
+inline ChatTemplateMetadata read_chat_template_metadata(const std::filesystem::path& model_dir) {
+    ChatTemplateMetadata result;
+    const auto           metadata_path = model_dir / "metadata.json";
+    std::ifstream        file(metadata_path);
+    if (!file) return result;
+
+    try {
+        const auto  metadata = qualla::json::parse(file);
+        const auto& prompt   = metadata.at("genie").at("chat_template").at("default_system_prompt");
+        if (prompt.is_string()) result.default_system_prompt = prompt.get<std::string>();
+    } catch (const std::exception&) {
+    }
+    return result;
+}
+
+}  // namespace geniex::qairt

--- a/sdk/plugins/qairt/include/vlm.h
+++ b/sdk/plugins/qairt/include/vlm.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "llm/llm_spec_loader.h"  // ParsedSamplerConfig
 #include "pipeline/vlm_pipeline.h"
@@ -20,6 +21,9 @@ class QairtVlm : public IVlm {
 
     // Bundle's `dialog.sampler` defaults; parsed once at create().
     ParsedSamplerConfig bundle_sampler_;
+
+    // Bundle's `genie.chat_template.default_system_prompt`.
+    std::string default_system_prompt_;
 
     // Incremental history tracking.
     // history_size_         — messages already committed to the KV cache (advanced by generate()).

--- a/sdk/plugins/qairt/src/llm.cpp
+++ b/sdk/plugins/qairt/src/llm.cpp
@@ -24,6 +24,7 @@
 #include "geniex-proc/types.h"      // ChatMessage, Role
 #include "llm/llm_spec_loader.h"    // parseGenieSamplerConfig
 #include "logging.h"
+#include "metadata_utils.h"
 #include "pipeline/llm_pipeline.h"
 #include "qnn_runtime_utils.h"
 #include "sampler_config_utils.h"
@@ -34,8 +35,6 @@ namespace fs = std::filesystem;
 namespace geniex {
 
 namespace {
-// Default system prompt used on the first turn when the caller does not supply one
-// via a `system` role chat message.
 constexpr const char* kDefaultSystemPrompt = "You are a helpful AI assistant.";
 }  // namespace
 
@@ -60,6 +59,9 @@ int32_t QairtLlm::create(const geniex_LlmCreateInput* input) {
     fs::path model_path(input->model_path);
     fs::path model_dir = model_path.parent_path();
 
+    const auto chat_template_metadata = qairt::read_chat_template_metadata(model_dir);
+    default_system_prompt_            = chat_template_metadata.default_system_prompt;
+    if (default_system_prompt_.empty()) default_system_prompt_ = kDefaultSystemPrompt;
     bundle_sampler_ = parseGenieSamplerConfig(model_dir);
 
     QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config(model_dir);
@@ -183,10 +185,10 @@ int32_t QairtLlm::apply_chat_template(
         qairt::apply_tool_fields(out, m.tool_calls, m.tool_call_count, m.tool_call_id, m.tool_name);
         messages.push_back(std::move(out));
     }
-    if (is_first_turn_ && !has_system) {
+    if (is_first_turn_ && !has_system && !default_system_prompt_.empty()) {
         ChatMessage sys;
         sys.role    = Role::System;
-        sys.content = kDefaultSystemPrompt;
+        sys.content = default_system_prompt_;
         messages.insert(messages.begin(), std::move(sys));
     }
 

--- a/sdk/plugins/qairt/src/vlm.cpp
+++ b/sdk/plugins/qairt/src/vlm.cpp
@@ -21,6 +21,7 @@
 #include "geniex-proc/types.h"      // ChatMessage, MMContent, Role::, Modality::
 #include "llm/llm_spec_loader.h"    // parseGenieSamplerConfig
 #include "logging.h"
+#include "metadata_utils.h"
 #include "path_utils.h"
 #include "pipeline/vlm_pipeline.h"
 #include "qnn_runtime_utils.h"
@@ -32,8 +33,6 @@ namespace fs = std::filesystem;
 namespace geniex {
 
 namespace {
-// Default system prompt prepended on the first turn when the caller does not include
-// a `system` role message in the chat history.
 constexpr const char* kDefaultSystemPrompt = "You are a helpful AI assistant.";
 }  // namespace
 
@@ -58,6 +57,9 @@ int32_t QairtVlm::create(const geniex_VlmCreateInput* input) {
     fs::path model_path(input->model_path);
     fs::path model_dir = model_path.parent_path();
 
+    const auto chat_template_metadata = qairt::read_chat_template_metadata(model_dir);
+    default_system_prompt_            = chat_template_metadata.default_system_prompt;
+    if (default_system_prompt_.empty()) default_system_prompt_ = kDefaultSystemPrompt;
     bundle_sampler_ = parseGenieSamplerConfig(model_dir);
 
     QnnRuntimeConfig runtime_cfg = qairt::runtime::make_qnn_runtime_config(model_dir);
@@ -227,12 +229,12 @@ int32_t QairtVlm::apply_chat_template(
 
     // On the first turn, ensure there is a system prompt at the front. If the caller did
     // not supply one, inject the default. Subsequent turns reuse the already-cached system.
-    if (history_size_ == 0) {
+    if (history_size_ == 0 && !default_system_prompt_.empty()) {
         const bool has_system = !new_messages.empty() && new_messages.front().role == Role::System;
         if (!has_system) {
             ChatMessage sys{};
             sys.role    = Role::System;
-            sys.content = kDefaultSystemPrompt;
+            sys.content = default_system_prompt_;
             new_messages.insert(new_messages.begin(), std::move(sys));
         }
     }


### PR DESCRIPTION
## Summary
- Load QAIRT default system prompts from `metadata.json` at `genie.chat_template.default_system_prompt`.
- Preserve the existing hardcoded prompt as a fallback for missing or invalid metadata.

## Test plan
- [x] Build `geniex_qairt` on qcs.
- [x] Build the CLI from the same source tree on qcs.
- [x] Compare QAIRT formatted prompts before and after changing the cached model metadata.

Closes qcom-ai-hub/geniex#1580