### PR TITLE
fix(sdk): keep bench output when generation exhausts the context

### DIFF
--- a/sdk/benchmark/run.c
+++ b/sdk/benchmark/run.c
@@ -171,6 +171,19 @@ static void print_gen_text(const char* text) {
         if (!nl) break;
         line = nl + 1;
     }
+    /* stdout is block-buffered when redirected to a file, so an answer already
+     * generated would still be lost if the process is later killed (harness
+     * timeout, unrelated crash). Flush per answer to bound that loss. */
+    fflush(stdout);
+}
+
+/* Context exhaustion is a stop condition, not a failure: both plugins populate
+ * full_text and profile_data (stop_reason = "length") before returning it, the
+ * same way they do for a max-tokens stop. Treating it as fatal threw away a
+ * complete answer and exited before geniex_deinit(). Everything else is a real
+ * error with nothing usable in the output. */
+static bool generate_rc_is_fatal(int32_t rc) {
+    return rc != GENIEX_SUCCESS && rc != GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH;
 }
 
 /* ----------------------------- LLM run loop ----------------------------- */
@@ -288,13 +301,20 @@ void run_llm(const options_t* o, const device_t* dev, run_result_t* out) {
             gin.user_data = (void*)o;
 
             int32_t rc = geniex_llm_generate(llm, &gin, &gout);
-            if (rc != GENIEX_SUCCESS) {
+            if (generate_rc_is_fatal(rc)) {
                 const char* msg = geniex_get_error_message((geniex_ErrorCode)rc);
                 fprintf(stderr, "ERROR: geniex_llm_generate run %d failed: %s (%d)\n", run_idx, msg ? msg : "?", rc);
                 if (templated_prompt) geniex_free(templated_prompt);
                 free(tokens);
                 geniex_llm_destroy(llm);
                 exit(1);
+            }
+            if (rc != GENIEX_SUCCESS) {
+                fprintf(stderr,
+                    "[warn] geniex_llm_generate run %d: %s (%d); keeping partial output\n",
+                    run_idx,
+                    geniex_get_error_message((geniex_ErrorCode)rc),
+                    rc);
             }
 
             if (!is_warmup) {
@@ -499,12 +519,19 @@ void run_vlm(const options_t* o, const device_t* dev, run_result_t* out) {
             gin.user_data   = (void*)o;
 
             int32_t rc = geniex_vlm_generate(vlm, &gin, &gout);
-            if (rc != GENIEX_SUCCESS) {
+            if (generate_rc_is_fatal(rc)) {
                 const char* msg = geniex_get_error_message((geniex_ErrorCode)rc);
                 fprintf(stderr, "ERROR: geniex_vlm_generate run %d failed: %s (%d)\n", run_idx, msg ? msg : "?", rc);
                 if (built_prompt) geniex_free(built_prompt);
                 geniex_vlm_destroy(vlm);
                 exit(1);
+            }
+            if (rc != GENIEX_SUCCESS) {
+                fprintf(stderr,
+                    "[warn] geniex_vlm_generate run %d: %s (%d); keeping partial output\n",
+                    run_idx,
+                    geniex_get_error_message((geniex_ErrorCode)rc),
+                    rc);
             }
 
             if (!is_warmup) {


### PR DESCRIPTION
## Summary

1. `geniex-bench` treated **every** non-success return from `geniex_{llm,vlm}_generate` as fatal.
2. Both plugins return `GENIEX_ERROR_LLM_TOKENIZATION_CONTEXT_LENGTH` *after* filling in `full_text` and `profile_data` with a complete result and `stop_reason = "length"` — same as a max-tokens stop.
3. So a generation that ran to the context wall printed no `[gen ]` text, recorded no results row, and `exit(1)`'d before `geniex_deinit()`.
4. Net effect: an answer the model fully produced was indistinguishable downstream from an empty response.
5. Fix — treat that one code as a stop condition, warn on stderr, fall through to the normal record/print path. Everything else stays fatal.
6. Also `fflush(stdout)` per answer, so a later unrelated kill can't discard answers already generated.

<details><summary>Mechanism, in order</summary>

```
qairt: ContextLengthExceededError -> stop_reason "context_length", partial text kept
llm.cpp: sets stop_reason "length", populates full_text, returns -200004
run.c:   rc != GENIEX_SUCCESS -> fprintf(stderr, "ERROR: ..."); exit(1)
         ^ print_gen_text() and record_run() never reached
exit(1): skips geniex_deinit(), so Registry::clear() never runs
```

Worth stating plainly because it is easy to misread from a log: there is **no crash** and **no missing-flush** here. Exit code 1 is `run.c`'s own `exit(1)`; the absent `Registry cleared successfully` is `geniex_deinit()` being skipped; stdout is empty because the text was never printed, not because it wasn't flushed. The `fflush` in this PR is unrelated hardening.

</details>

## Test plan

Windows ARM64 / Snapdragon X Elite, `qwen3_4b_instruct_2507` (4-shard QAIRT bundle, CL 4096), 532-token prompt run to the context wall. A/B against a control built from the same tree with only `run.c` reverted.

- [x] **Context-exhausted, patched**: exit 0, 19232 B stdout, 105 `[gen ]` lines, `[ok  ]` row present, `Registry cleared successfully` reached
- [x] **Context-exhausted, control**: exit 1, 0 B stdout, 0 `[gen ]` lines, no `[ok  ]` row, clean teardown never reached
- [x] **Normal EOS stop unchanged**: exit 0, text printed, no `[warn]` line emitted
- [x] **Genuinely fatal error still fatal**: 5.3k-token prompt → `Input prompt too long (-200103)` → exit 1
- [x] `clang -std=c11 -Wall -Wextra` clean; `clang-format` clean

<details><summary>A/B detail</summary>

Identical prompt, model, and `geniex.dll`; the two binaries differ only in `run.c`.

| | control | patched |
|---|---|---|
| exit code | 1 | 0 |
| stdout bytes | 0 | 19232 |
| `[gen ]` lines | 0 | 105 |
| `[ok  ]` results row | absent | present |
| `Registry cleared successfully` | no | yes |
| `prompt_tokens` / `generated_tokens` | 532 / 3565 | 532 / 3565 |
| `stop_reason` | length | length |

Token counts and `stop_reason` are identical across the two, confirming the change affects only the disposition of the result, not generation itself.

New stderr line on the soft path:

```
[warn] geniex_llm_generate run 0: Context length exceeded (-200004); keeping partial output
```

</details>

Closes #1450
